### PR TITLE
Stop syncing release-* branches

### DIFF
--- a/.github/workflows/slackhq_upstream_sync.yml
+++ b/.github/workflows/slackhq_upstream_sync.yml
@@ -11,9 +11,7 @@ jobs:
       matrix:
         branch:
           - main
-          - release-12.0
-          - release-13.0
-          - release-14.0
+
     steps:
     - name: Checkout target
       uses: actions/checkout@v2


### PR DESCRIPTION
## Description

This PR stops auto-syncing `release-*` branches (for now) because they are failing and cause `main` to fail as well

I'll add release branch syncing at a later date