### PR TITLE
Revert backup compressor from pargzip to pgzip

### DIFF
--- a/.github/workflows/cluster_endtoend_11.yml
+++ b/.github/workflows/cluster_endtoend_11.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (11)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (11)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_12.yml
+++ b/.github/workflows/cluster_endtoend_12.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (12)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (12)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (13)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (13)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_14.yml
+++ b/.github/workflows/cluster_endtoend_14.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (14)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (14)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (15)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (15)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_16.yml
+++ b/.github/workflows/cluster_endtoend_16.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (16)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (16)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_17.yml
+++ b/.github/workflows/cluster_endtoend_17.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (17)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (17)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_18.yml
+++ b/.github/workflows/cluster_endtoend_18.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (18)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (18)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Installing zookeeper and consul
       run: |

--- a/.github/workflows/cluster_endtoend_19.yml
+++ b/.github/workflows/cluster_endtoend_19.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (19)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (19)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_20.yml
+++ b/.github/workflows/cluster_endtoend_20.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (20)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (20)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (21)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (21)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (22)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (22)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_23.yml
+++ b/.github/workflows/cluster_endtoend_23.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (23)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (23)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_24.yml
+++ b/.github/workflows/cluster_endtoend_24.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (24)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (24)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Installing zookeeper and consul
       run: |

--- a/.github/workflows/cluster_endtoend_26.yml
+++ b/.github/workflows/cluster_endtoend_26.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (26)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (26)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_mysql80.yml
+++ b/.github/workflows/cluster_endtoend_mysql80.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (mysql80)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (mysql80)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (onlineddl_declarative)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (onlineddl_declarative)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (onlineddl_ghost)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (onlineddl_ghost)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (onlineddl_revert)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (onlineddl_revert)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (onlineddl_singleton)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (onlineddl_singleton)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (onlineddl_vrepl)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (onlineddl_vrepl)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (onlineddl_vrepl_stress)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (onlineddl_vrepl_stress)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (onlineddl_vrepl_stress_suite)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (onlineddl_vrepl_stress_suite)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (onlineddl_vrepl_suite)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (onlineddl_vrepl_suite)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_resharding.yml
+++ b/.github/workflows/cluster_endtoend_resharding.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (resharding)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (resharding)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_resharding_bytes.yml
+++ b/.github/workflows/cluster_endtoend_resharding_bytes.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (resharding_bytes)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (resharding_bytes)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (tabletmanager_consul)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (tabletmanager_consul)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Installing zookeeper and consul
       run: |

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (tabletmanager_tablegc)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (tabletmanager_tablegc)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (tabletmanager_throttler)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (tabletmanager_throttler)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (tabletmanager_throttler_custom_config)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (tabletmanager_throttler_custom_config)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vreplication_basic)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vreplication_basic)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vreplication_cellalias)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vreplication_cellalias)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_vreplication_migrate.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vreplication_migrate)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vreplication_migrate)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vreplication_multicell)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vreplication_multicell)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vreplication_v2)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vreplication_v2)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_vstream_failover.yml
+++ b/.github/workflows/cluster_endtoend_vstream_failover.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vstream_failover)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vstream_failover)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vstream_stoponreshard_false)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vstream_stoponreshard_false)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vstream_stoponreshard_true)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vstream_stoponreshard_true)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
+++ b/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vstream_with_keyspaces_to_watch)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vstream_with_keyspaces_to_watch)')
   cancel-in-progress: true
@@ -15,7 +24,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.17.12
 
     - name: Tune the OS
       run: |
@@ -40,14 +49,24 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
-      timeout-minutes: 30
-      run: |
-        source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard vstream_with_keyspaces_to_watch
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        retry_on: error
+        command: |
+          source build.env
+          eatmydata -- go run test.go -docker=false -print-log -follow -shard vstream_with_keyspaces_to_watch

--- a/.github/workflows/cluster_endtoend_vtgate_buffer.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_buffer.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vtgate_buffer)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vtgate_buffer)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vtgate_concurrentdml)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vtgate_concurrentdml)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vtgate_gen4)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vtgate_gen4)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_vtgate_queries.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_queries.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vtgate_queries)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vtgate_queries)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vtgate_readafterwrite)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vtgate_readafterwrite)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vtgate_reservedconn)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vtgate_reservedconn)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vtgate_schema)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vtgate_schema)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vtgate_schema_tracker)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vtgate_schema_tracker)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vtgate_topo)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vtgate_topo)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vtgate_topo_consul)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vtgate_topo_consul)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Installing zookeeper and consul
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vtgate_topo_etcd)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vtgate_topo_etcd)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vtgate_transaction)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vtgate_transaction)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vtgate_unsharded)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vtgate_unsharded)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_vtgate_v3.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_v3.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vtgate_v3)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vtgate_v3)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_vtgate_vindex.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vtgate_vindex)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vtgate_vindex)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vtgate_vschema)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vtgate_vschema)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vtorc)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vtorc)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (xb_recovery)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (xb_recovery)')
   cancel-in-progress: true
@@ -40,11 +49,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       uses: nick-fields/retry@v2

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,6 @@ require (
 	github.com/philhofer/fwd v1.0.0 // indirect
 	github.com/pires/go-proxyproto v0.6.1
 	github.com/pkg/errors v0.9.1
-	github.com/planetscale/pargzip v0.0.0-20201116224723-90c7fc03ea8a
 	github.com/planetscale/tengo v0.10.1-ps.v4
 	github.com/planetscale/vtprotobuf v0.2.0
 	github.com/prometheus/client_golang v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -613,8 +613,6 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
-github.com/planetscale/pargzip v0.0.0-20201116224723-90c7fc03ea8a h1:y0OpQ4+5tKxeh9+H+2cVgASl9yMZYV9CILinKOiKafA=
-github.com/planetscale/pargzip v0.0.0-20201116224723-90c7fc03ea8a/go.mod h1:GJFUzQuXIoB2Kjn1ZfDhJr/42D5nWOqRcIQVgCxTuIE=
 github.com/planetscale/tengo v0.10.1-ps.v4 h1:mGJxWVsLGg+dDAboz+xiBs4IjvCtRm+QORsLRJocC7Q=
 github.com/planetscale/tengo v0.10.1-ps.v4/go.mod h1:zR3C7CjRqDa7ag5FbIznrvCdAZGgpdd2alIEWkuF0vk=
 github.com/planetscale/vtprotobuf v0.2.0 h1:65H8opMdnSwIUvrRZ51o6rFxA01t9XG91qi997v9FoA=

--- a/go/vt/mysqlctl/builtinbackupengine.go
+++ b/go/vt/mysqlctl/builtinbackupengine.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	"github.com/klauspost/pgzip"
-	"github.com/planetscale/pargzip"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sync2"
@@ -409,12 +408,13 @@ func (be *BuiltinBackupEngine) backupFile(ctx context.Context, params BackupPara
 	}
 
 	// Create the gzip compression pipe, if necessary.
-	var gzip *pargzip.Writer
+	var gzip *pgzip.Writer
 	if *backupStorageCompress {
-		gzip = pargzip.NewWriter(writer)
-		gzip.ChunkSize = *backupCompressBlockSize
-		gzip.Parallel = *backupCompressBlocks
-		gzip.CompressionLevel = pargzip.BestSpeed
+		gzip, err = pgzip.NewWriterLevel(writer, pgzip.BestSpeed)
+		if err != nil {
+			return vterrors.Wrap(err, "cannot create gziper")
+		}
+		gzip.SetConcurrency(*backupCompressBlockSize, *backupCompressBlocks)
 		writer = gzip
 	}
 

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -1,5 +1,15 @@
 name: {{.Name}}
 on: [push, pull_request]
+
+env:
+{{if .InstallXtraBackup}}
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+{{end}}
+
 concurrency:
   group: format('{0}-{1}', ${{"{{"}} github.ref {{"}}"}}, '{{.Name}}')
   cancel-in-progress: true
@@ -40,11 +50,17 @@ jobs:
 
         {{if .InstallXtraBackup}}
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
         {{end}}
 


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

During v11 deployment/upgrade, we identified the backup compressor/decompressor `pargzip` performs worse than `pgzip`, and we reverted it through PR https://github.com/tinyspeck/vitess/pull/245, (the upstream https://github.com/vitessio/vitess/pull/8174/). 

And in upstream main branch, we do have a new feature to support external backup compressor as a new backup argument https://github.com/vitessio/vitess/pull/10558, we can consider it in next release upgrade, but for now, we just revert to `pgzip`. 

details in [thread](https://slack-pde.slack.com/archives/CQGR39RA5/p1663986906809979)


## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
