### PR TITLE
Slack vitess r12.0.5 vtctld cherrypicks

### DIFF
--- a/go/cmd/vtctldclient/command/backups.go
+++ b/go/cmd/vtctldclient/command/backups.go
@@ -36,8 +36,6 @@ var GetBackups = &cobra.Command{
 }
 
 var getBackupsOptions = struct {
-	Limit      uint32
-	OutputJSON bool
 	Limit         uint32
 	Detailed      bool
 	DetailedLimit uint32
@@ -53,9 +51,6 @@ func commandGetBackups(cmd *cobra.Command, args []string) error {
 	cli.FinishedParsing(cmd)
 
 	resp, err := client.GetBackups(commandCtx, &vtctldatapb.GetBackupsRequest{
-		Keyspace: keyspace,
-		Shard:    shard,
-		Limit:    getBackupsOptions.Limit,
 		Keyspace:      keyspace,
 		Shard:         shard,
 		Limit:         getBackupsOptions.Limit,
@@ -66,7 +61,7 @@ func commandGetBackups(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if getBackupsOptions.OutputJSON || || getBackupsOptions.Detailed {
+	if getBackupsOptions.OutputJSON || getBackupsOptions.Detailed {
 		data, err := cli.MarshalJSON(resp)
 		if err != nil {
 			return err

--- a/go/cmd/vtctldclient/command/backups.go
+++ b/go/cmd/vtctldclient/command/backups.go
@@ -38,6 +38,10 @@ var GetBackups = &cobra.Command{
 var getBackupsOptions = struct {
 	Limit      uint32
 	OutputJSON bool
+	Limit         uint32
+	Detailed      bool
+	DetailedLimit uint32
+	OutputJSON    bool
 }{}
 
 func commandGetBackups(cmd *cobra.Command, args []string) error {
@@ -52,12 +56,17 @@ func commandGetBackups(cmd *cobra.Command, args []string) error {
 		Keyspace: keyspace,
 		Shard:    shard,
 		Limit:    getBackupsOptions.Limit,
+		Keyspace:      keyspace,
+		Shard:         shard,
+		Limit:         getBackupsOptions.Limit,
+		Detailed:      getBackupsOptions.Detailed,
+		DetailedLimit: getBackupsOptions.DetailedLimit,
 	})
 	if err != nil {
 		return err
 	}
 
-	if getBackupsOptions.OutputJSON {
+	if getBackupsOptions.OutputJSON || || getBackupsOptions.Detailed {
 		data, err := cli.MarshalJSON(resp)
 		if err != nil {
 			return err
@@ -80,5 +89,7 @@ func commandGetBackups(cmd *cobra.Command, args []string) error {
 func init() {
 	GetBackups.Flags().Uint32VarP(&getBackupsOptions.Limit, "limit", "l", 0, "Retrieve only the most recent N backups")
 	GetBackups.Flags().BoolVarP(&getBackupsOptions.OutputJSON, "json", "j", false, "Output backup info in JSON format rather than a list of backups")
+	GetBackups.Flags().BoolVar(&getBackupsOptions.Detailed, "detailed", false, "Get detailed backup info, such as the engine used for each backup, and its status. Implies --json.")
+	GetBackups.Flags().Uint32Var(&getBackupsOptions.DetailedLimit, "detailed-limit", 0, "Get detailed backup info for only the most recent N backups. Ignored if --detailed is not passed.")
 	Root.AddCommand(GetBackups)
 }

--- a/go/vt/mysqlctl/azblobbackupstorage/azblob.go
+++ b/go/vt/mysqlctl/azblobbackupstorage/azblob.go
@@ -261,6 +261,11 @@ func (bh *AZBlobBackupHandle) ReadFile(ctx context.Context, filename string) (io
 	}), nil
 }
 
+// CheckFile is part of the BackupHandle interface. It is currently unimplemented.
+func (bh *AZBlobBackupHandle) CheckFile(ctx context.Context, filename string) (bool, error) {
+	return false, nil
+}
+
 // AZBlobBackupStorage structs implements the BackupStorage interface for AZBlob
 type AZBlobBackupStorage struct {
 }

--- a/go/vt/mysqlctl/backupengine.go
+++ b/go/vt/mysqlctl/backupengine.go
@@ -33,6 +33,8 @@ import (
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/vterrors"
+
+	mysqlctlpb "vitess.io/vitess/go/vt/proto/mysqlctl"
 )
 
 var (
@@ -43,6 +45,10 @@ var (
 // BackupEngine is the interface to take a backup with a given engine.
 type BackupEngine interface {
 	ExecuteBackup(ctx context.Context, params BackupParams, bh backupstorage.BackupHandle) (bool, error)
+	// GetBackupStatus returns the status of a given backup, according to the
+	// specifics of the particular backupengine implementation. See the comments
+	// on the various implementations for more information.
+	GetBackupStatus(ctx context.Context, bh backupstorage.BackupHandle, mfestBytes []byte) (mysqlctlpb.BackupInfo_Status, error)
 	ShouldDrainForBackup() bool
 }
 
@@ -118,6 +124,10 @@ var BackupRestoreEngineMap = make(map[string]BackupRestoreEngine)
 // This must only be called after flags have been parsed.
 func GetBackupEngine() (BackupEngine, error) {
 	name := *backupEngineImplementation
+	return getBackupEngine(name)
+}
+
+func getBackupEngine(name string) (BackupEngine, error) {
 	be, ok := BackupRestoreEngineMap[name]
 	if !ok {
 		return nil, vterrors.Errorf(vtrpc.Code_NOT_FOUND, "unknown BackupEngine implementation %q", name)

--- a/go/vt/mysqlctl/backupstorage/interface.go
+++ b/go/vt/mysqlctl/backupstorage/interface.go
@@ -77,6 +77,12 @@ type BackupHandle interface {
 	// ReadCloser is closed.
 	ReadFile(ctx context.Context, filename string) (io.ReadCloser, error)
 
+	// CheckFile checks if a file is included in a backup. Only works for
+	// read-only backups (created by ListBackups). Returns a boolean to indicate
+	// if the file exists, and an error. Variants of "file not found" errors do
+	// result in an error, but instead result in (false, nil).
+	CheckFile(ctx context.Context, filename string) (bool, error)
+
 	// concurrency.ErrorRecorder is embedded here to coordinate reporting and
 	// handling of errors among all the components involved in taking a backup.
 	concurrency.ErrorRecorder

--- a/go/vt/mysqlctl/builtinbackupengine.go
+++ b/go/vt/mysqlctl/builtinbackupengine.go
@@ -41,6 +41,8 @@ import (
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vttablet/tmclient"
+
+	mysqlctlpb "vitess.io/vitess/go/vt/proto/mysqlctl"
 )
 
 const (
@@ -454,6 +456,14 @@ func (be *BuiltinBackupEngine) backupFile(ctx context.Context, params BackupPara
 	// Save the hash.
 	fe.Hash = hasher.HashString()
 	return nil
+}
+
+// GetBackupStatus is part of the BackupEngine interface.
+//
+// This is currently not implemented for builtinbackupengine, so we always
+// return UNKNOWN.
+func (be *BuiltinBackupEngine) GetBackupStatus(ctx context.Context, bh backupstorage.BackupHandle, mfestBytes []byte) (mysqlctlpb.BackupInfo_Status, error) {
+	return mysqlctlpb.BackupInfo_UNKNOWN, nil
 }
 
 // ExecuteRestore restores from a backup. If the restore is successful

--- a/go/vt/mysqlctl/cephbackupstorage/ceph.go
+++ b/go/vt/mysqlctl/cephbackupstorage/ceph.go
@@ -146,6 +146,12 @@ func (bh *CephBackupHandle) ReadFile(ctx context.Context, filename string) (io.R
 	return bh.client.GetObjectWithContext(ctx, bucket, object, minio.GetObjectOptions{})
 }
 
+// CheckFile is part of the BackupHandle interface. It is currently unimplemented.
+func (bh *CephBackupHandle) CheckFile(ctx context.Context, filename string) (bool, error) {
+	// (TODO) when we implement this, use bh.client.StatObject
+	return false, nil
+}
+
 // CephBackupStorage implements BackupStorage for Ceph Cloud Storage.
 type CephBackupStorage struct {
 	// client is the instance of the Ceph Cloud Storage Go client.

--- a/go/vt/mysqlctl/filebackupstorage/file.go
+++ b/go/vt/mysqlctl/filebackupstorage/file.go
@@ -105,6 +105,25 @@ func (fbh *FileBackupHandle) ReadFile(ctx context.Context, filename string) (io.
 	return os.Open(p)
 }
 
+// CheckFile is part of the BackupHandle interface.
+func (fbh *FileBackupHandle) CheckFile(ctx context.Context, filename string) (bool, error) {
+	if !fbh.readOnly {
+		return false, fmt.Errorf("CheckFile cannot be called on read-write backup")
+	}
+
+	p := path.Join(*FileBackupStorageRoot, fbh.dir, fbh.name, filename)
+	_, err := os.Stat(p)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return true, nil
+}
+
 // FileBackupStorage implements BackupStorage for local file system.
 type FileBackupStorage struct{}
 

--- a/go/vt/mysqlctl/gcsbackupstorage/gcs.go
+++ b/go/vt/mysqlctl/gcsbackupstorage/gcs.go
@@ -115,6 +115,11 @@ func (bh *GCSBackupHandle) ReadFile(ctx context.Context, filename string) (io.Re
 	return bh.client.Bucket(*bucket).Object(object).NewReader(ctx)
 }
 
+// CheckFile is part of the BackupHandle interface. It is currently unimplemented.
+func (bh *GCSBackupHandle) CheckFile(ctx context.Context, filename string) (bool, error) {
+	return false, nil
+}
+
 // GCSBackupStorage implements BackupStorage for Google Cloud Storage.
 type GCSBackupStorage struct {
 	// client is the instance of the Google Cloud Storage Go client.

--- a/go/vt/mysqlctl/xtrabackupengine.go
+++ b/go/vt/mysqlctl/xtrabackupengine.go
@@ -38,6 +38,8 @@ import (
 	"vitess.io/vitess/go/vt/mysqlctl/backupstorage"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
+
+	mysqlctlpb "vitess.io/vitess/go/vt/proto/mysqlctl"
 )
 
 // XtrabackupEngine encapsulates the logic of the xtrabackup engine
@@ -371,6 +373,31 @@ func (be *XtrabackupEngine) backupFiles(ctx context.Context, params BackupParams
 	}
 
 	return replicationPosition, nil
+}
+
+// GetBackupStatus is part of the BackupEngine interface.
+//
+// For xtrabackup, we currently (we may want to expand this later) define a
+// backup status as:
+// - manifest can be read but contains invalid json => INVALID
+// - the FileName in the manifest does not exist => INVALID
+// - the FileName in the manifest exists => VALID
+func (be *XtrabackupEngine) GetBackupStatus(ctx context.Context, bh backupstorage.BackupHandle, mfestBytes []byte) (mysqlctlpb.BackupInfo_Status, error) {
+	var manifest xtraBackupManifest
+	if err := json.Unmarshal(mfestBytes, &manifest); err != nil {
+		return mysqlctlpb.BackupInfo_INVALID, err
+	}
+
+	exists, err := bh.CheckFile(ctx, manifest.FileName)
+	if err != nil {
+		return mysqlctlpb.BackupInfo_INVALID, err
+	}
+
+	if !exists {
+		return mysqlctlpb.BackupInfo_INVALID, nil
+	}
+
+	return mysqlctlpb.BackupInfo_VALID, nil
 }
 
 // ExecuteRestore restores from a backup. Any error is returned.

--- a/go/vt/vtctl/grpcvtctldserver/server.go
+++ b/go/vt/vtctl/grpcvtctldserver/server.go
@@ -37,6 +37,7 @@ import (
 	"vitess.io/vitess/go/vt/concurrency"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
+	"vitess.io/vitess/go/vt/mysqlctl"
 	"vitess.io/vitess/go/vt/mysqlctl/backupstorage"
 	"vitess.io/vitess/go/vt/mysqlctl/mysqlctlproto"
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -713,9 +714,14 @@ func (s *VtctldServer) GetBackups(ctx context.Context, req *vtctldatapb.GetBacku
 		bi.Shard = req.Shard
 
 		if req.Detailed {
-			if i >= backupsToSkipDetails { // nolint:staticcheck
-				// (TODO:@ajm188) Update backupengine/backupstorage implementations
-				// to get Status info for backups.
+			if i >= backupsToSkipDetails {
+				engine, status, err := mysqlctl.GetBackupInfo(ctx, bh)
+				if err != nil {
+					log.Warningf("error getting detailed backup info for %s/%s %s/%s: %s", bi.Keyspace, bi.Shard, bi.Directory, bi.Name, err)
+				}
+
+				bi.Engine = engine
+				bi.Status = status
 			}
 		}
 

--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -1610,6 +1610,14 @@ func (ts *trafficSwitcher) deleteRoutingRules(ctx context.Context) error {
 	return nil
 }
 
+func (wr *Wrangler) getRoutingRules(ctx context.Context) (map[string][]string, error) {
+	return topotools.GetRoutingRules(ctx, wr.ts)
+}
+
+func (wr *Wrangler) saveRoutingRules(ctx context.Context, rules map[string][]string) error {
+	return topotools.SaveRoutingRules(ctx, wr.ts, rules)
+}
+
 // addParticipatingTablesToKeyspace updates the vschema with the new tables that were created as part of the
 // Migrate flow. It is called when the Migrate flow is Completed
 func (ts *trafficSwitcher) addParticipatingTablesToKeyspace(ctx context.Context, keyspace, tableSpecs string) error {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
These are cherrypicks needed in vtctld for vtadmin UI to work, similarly as what we did in v11 upgrade through PR 
https://github.com/tinyspeck/vitess/pull/247.

However, the majority changes in https://github.com/tinyspeck/vitess/pull/247 are already in v12, so in this PR, just backport those are not in v12.

The branch `slack-vitess-r12.0.5-vtctld` is based on the v12 release branch `slack-vitess-r12.0.5`, and `slack-vitess-r12.0.5-vtctld` will be used for deployment.

For reference:
```
This will serve as the base branch for 11.x vtctld branches, and should not be merged into master.

I compiled a list of cherry picks you see below from the following PRs:

https://github.com/tinyspeck/vitess/pull/231
https://github.com/tinyspeck/vitess/pull/232
https://github.com/tinyspeck/vitess/pull/233
as PER: https://paper.dropbox.com/doc/Deploys--BiBeEroaHSASXm33RaJsy5GMAg-4DTMhk7UnGtetj5tqzJ75#:h2=But-where-do-the-cherry-picks-

and started to apply them to this branch using:

git cherry-pick -m1 {pr-merge-sha}
all cherry picks with [x] are done, the rest still need to be applied manually. It's a very tedious process due to many (and I mean MANY conflicts that need to be resolved manually). There are also a number of proto conflicts on generated files which I attempted to fix as follows:

make install_protoc-gen-go
make proto
From https://github.com/tinyspeck/vitess/pull/231:
 https://github.com/tinyspeck/vitess/commit/4932904f84725c10703a519c9e7ae249cbd60668 https://github.com/vitessio/vitess/pull/7965
 https://github.com/tinyspeck/vitess/commit/8e0531f5983f1c8f4151fdacf2c71132a232f725 https://github.com/vitessio/vitess/pull/7992
 https://github.com/tinyspeck/vitess/commit/0a5e76bec8ac0836d139561d06e2ccfe11c0b776 https://github.com/vitessio/vitess/pull/8052
 https://github.com/tinyspeck/vitess/commit/c85a5c266f6b79204c40153f17e2c1a21015797f https://github.com/vitessio/vitess/pull/8084
 https://github.com/tinyspeck/vitess/commit/69b9833c5ef03c68b4582becb661e9c5f5fcbf27 https://github.com/vitessio/vitess/pull/8221
 https://github.com/tinyspeck/vitess/commit/4c33b2b5a90dc200e6cc649681cbace2520725bd https://github.com/vitessio/vitess/pull/8197
 https://github.com/tinyspeck/vitess/commit/82c9752e0d85e913dbc49f578cb6d89a5a406e7b https://github.com/vitessio/vitess/pull/8199
 https://github.com/tinyspeck/vitess/commit/2a92daecbff8524fd1e202696594c752a33f98f0 https://github.com/vitessio/vitess/pull/8219
 https://github.com/tinyspeck/vitess/commit/5374002ec7f627d6e14647d78eb74788e089ac74 https://github.com/vitessio/vitess/pull/8232
 https://github.com/tinyspeck/vitess/commit/f97942a03d34548984ccf456506fd0bb8dbd966e https://github.com/vitessio/vitess/pull/8261
 https://github.com/tinyspeck/vitess/commit/405b4ba280c40511c32e1aadf001feb7ca69fe1c https://github.com/vitessio/vitess/pull/8266
 https://github.com/tinyspeck/vitess/commit/a3c34a3b1afd5d73edabc2c7b273089e870c36c9 https://github.com/vitessio/vitess/pull/8272
 https://github.com/tinyspeck/vitess/commit/ba8f8079fd94debddbf57b78bd8aba987fab4320 https://github.com/vitessio/vitess/pull/8284
 https://github.com/tinyspeck/vitess/commit/7dfbc60e9ccff7f4c53584729ca7c23abd7d6dfd https://github.com/vitessio/vitess/pull/8113
 https://github.com/tinyspeck/vitess/commit/3c0a253aa10602458d3b2fb0f1b379b6dafec498 https://github.com/vitessio/vitess/pull/8285
 https://github.com/tinyspeck/vitess/commit/0ff5ccca97e7c016534a17d45a84a59a75167945 https://github.com/vitessio/vitess/pull/8289
 https://github.com/tinyspeck/vitess/commit/d9fa9f2cd585b82ccfb000f0db6b16d3dde21fd6 https://github.com/vitessio/vitess/pull/8291
 https://github.com/tinyspeck/vitess/commit/46406453b490c2a21351db3b7f0a336cb453481e https://github.com/vitessio/vitess/pull/8320
 https://github.com/tinyspeck/vitess/commit/83dfb9aa59ce47a313ecb7bc12804298e76d350c https://github.com/vitessio/vitess/pull/8321
 https://github.com/tinyspeck/vitess/commit/a59c8a0a8d0014e8a1f564d9c97b3d1cf6255fad https://github.com/vitessio/vitess/pull/8402
 https://github.com/tinyspeck/vitess/commit/ee646092d636e5823891dc11224348607050f74b https://github.com/tinyspeck/vitess/pull/218 ( applied manually git cherry-pick -m1 ee64609 )
From https://github.com/tinyspeck/vitess/pull/232
 https://github.com/tinyspeck/vitess/commit/a8679df220721ca2bfc50b3c3b8d85321c4fcfc3 https://github.com/vitessio/vitess/pull/8368 ( applied manually git cherry-pick -m1 a8679df )
From https://github.com/tinyspeck/vitess/pull/233
 https://github.com/tinyspeck/vitess/commit/36657df49c6c4584a6442d5f10d0c8b117f5a4ab https://github.com/vitessio/vitess/pull/8296
 https://github.com/tinyspeck/vitess/commit/48f22aa56e800a98030962550642272b1c3cccb9 https://github.com/vitessio/vitess/pull/8134
 https://github.com/tinyspeck/vitess/commit/b9664922be1a119a833616a07d114eefbe9949dd Fix for padding in OrderAndCheckPartitions  vitessio/vitess#8873 ( applied manually git cherry-pick -m1 b966492 )
From TBD...
This is the section that still needs to be compiled as per:

any new vtctld changes since the last deploy
REF: https://paper.dropbox.com/doc/Deploys--BiBeEroaHSASXm33RaJsy5GMAg-4DTMhk7UnGtetj5tqzJ75#:h2=But-where-do-the-cherry-picks-
```
## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
