### PR TITLE
backport - fix collation failure

### DIFF
--- a/go/mysql/collations/integration/coercion_test.go
+++ b/go/mysql/collations/integration/coercion_test.go
@@ -135,6 +135,10 @@ func TestComparisonSemantics(t *testing.T) {
 	conn := mysqlconn(t)
 	defer conn.Close()
 
+	if strings.HasPrefix(conn.ServerVersion, "8.0.31") {
+		t.Skipf("Coercion semantics have changed in 8.0.31")
+	}
+
 	for _, coll := range collations.Local().AllCollations() {
 		text := verifyTranscoding(t, coll, remote.NewCollation(conn, coll.Name()), []byte(BaseString))
 		testInputs = append(testInputs, &TextWithCollation{Text: text, Collation: coll})


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
The CI test `Unit Test (mysql80) / test (pull_request)` failed with this error:
```
--- FAIL: TestComparisonSemantics (13.17s)
    --- FAIL: TestComparisonSemantics/equals (6.40s)
        coercion_test.go:202: expected dec8_swedish_ci vs utf8_general_ci to fail coercion: Illegal mix of collations (dec8_swedish_ci,EXPLICIT) and (utf8mb3_general_ci,EXPLICIT) for operation '=' (errno 1267) (sqlstate HY000) during query: SELECT CAST(((_dec8 X'6162636441424344[30](https://github.com/slackhq/vitess/actions/runs/3414744449/jobs/5683094619#step:8:31)31323334' COLLATE "dec8_swedish_ci") = (_utf8 X'61626364414243443031323334' COLLATE "utf8_general_ci")) AS BINARY), COLLATION((_dec8 X'61626364414243443031323334' COLLATE "dec8_swedish_ci") = (_utf8 X'61626364414243443031323334' COLLATE "utf8_general_ci")), COERCIBILITY((_dec8 X'61626364414243443031323334' COLLATE "dec8_swedish_ci") = (_utf8 X'61626364414243443031323334' COLLATE "utf8_general_ci"))
```
the upstream fixed through 2 PRs:
- https://github.com/vitessio/vitess/pull/11474
- https://github.com/vitessio/vitess/pull/11487
but v13 does not have the api used by https://github.com/vitessio/vitess/pull/11487, so backporting 11474 only which should fix the error.


<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
