### PR TITLE
Do Not Merge: Slack vitess r12.0.5 vtctld patch

### DIFF
--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -294,7 +294,7 @@ func (s *Server) GetWorkflows(ctx context.Context, req *vtctldatapb.GetWorkflows
 			time_updated,
 			transaction_timestamp,
 			message,
-			NULL
+			''
 		FROM
 			_vt.vreplication
 		%s`,

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -270,6 +270,9 @@ func (s *Server) GetCellsWithTableReadsSwitched(
 // It has the same signature as the vtctlservicepb.VtctldServer's GetWorkflows
 // rpc, and grpcvtctldserver delegates to this function.
 func (s *Server) GetWorkflows(ctx context.Context, req *vtctldatapb.GetWorkflowsRequest) (*vtctldatapb.GetWorkflowsResponse, error) {
+	// temporary block the GetWorkflows requests
+	return nil
+
 	span, ctx := trace.NewSpan(ctx, "workflow.Server.GetWorkflows")
 	defer span.Finish()
 

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -270,9 +270,6 @@ func (s *Server) GetCellsWithTableReadsSwitched(
 // It has the same signature as the vtctlservicepb.VtctldServer's GetWorkflows
 // rpc, and grpcvtctldserver delegates to this function.
 func (s *Server) GetWorkflows(ctx context.Context, req *vtctldatapb.GetWorkflowsRequest) (*vtctldatapb.GetWorkflowsResponse, error) {
-	// temporary block the GetWorkflows requests
-	return nil
-
 	span, ctx := trace.NewSpan(ctx, "workflow.Server.GetWorkflows")
 	defer span.Finish()
 
@@ -297,7 +294,7 @@ func (s *Server) GetWorkflows(ctx context.Context, req *vtctldatapb.GetWorkflows
 			time_updated,
 			transaction_timestamp,
 			message,
-			tags
+			NULL
 		FROM
 			_vt.vreplication
 		%s`,

--- a/go/vt/wrangler/vexec.go
+++ b/go/vt/wrangler/vexec.go
@@ -472,7 +472,8 @@ func (wr *Wrangler) getStreams(ctx context.Context, workflow, keyspace string) (
 	rsr.ShardStatuses = make(map[string]*ShardReplicationStatus)
 	rsr.Workflow = workflow
 	var results map[*topo.TabletInfo]*querypb.QueryResult
-	query := "select id, source, pos, stop_pos, max_replication_lag, state, db_name, time_updated, transaction_timestamp, message, tags from _vt.vreplication"
+	//query := "select id, source, pos, stop_pos, max_replication_lag, state, db_name, time_updated, transaction_timestamp, message, tags from _vt.vreplication"
+	query := "select id, source, pos, stop_pos, max_replication_lag, state, db_name, time_updated, transaction_timestamp, message, NULL from _vt.vreplication"
 	results, err := wr.runVexec(ctx, workflow, keyspace, query, false)
 	if err != nil {
 		return nil, err

--- a/go/vt/wrangler/vexec.go
+++ b/go/vt/wrangler/vexec.go
@@ -473,7 +473,7 @@ func (wr *Wrangler) getStreams(ctx context.Context, workflow, keyspace string) (
 	rsr.Workflow = workflow
 	var results map[*topo.TabletInfo]*querypb.QueryResult
 	//query := "select id, source, pos, stop_pos, max_replication_lag, state, db_name, time_updated, transaction_timestamp, message, tags from _vt.vreplication"
-	query := "select id, source, pos, stop_pos, max_replication_lag, state, db_name, time_updated, transaction_timestamp, message, NULL from _vt.vreplication"
+	query := "select id, source, pos, stop_pos, max_replication_lag, state, db_name, time_updated, transaction_timestamp, message, '' from _vt.vreplication"
 	results, err := wr.runVexec(ctx, workflow, keyspace, query, false)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
error in vttablet log:
```
I1109 13:44:19.274626   23999 rpc_server.go:84] TabletManager.VReplicationExec(query:"select id, workflow, source, pos, stop_pos, max_replication_lag, state, db_name, time_updated, transaction_timestamp, message, tags from _vt.vreplication where db_name = 'vt_pool1'")(on us_east_1e-0303247250 from ): (*tabletmanagerdata.VReplicationExecResponse)(nil)
I1109 13:45:37.684980   23999 withddl.go:73] Updating schema for Unknown column 'tags' in 'field list' (errno 1054) (sqlstate 42S22) during query: select id, workflow, source, pos, stop_pos, max_replication_lag, state, db_name, time_updated, transaction_timestamp, message, tags from _vt.vreplication where db_name = 'vt_pool1' and retrying: Unknown column 'tags' in 'field list' (errno 1054) (sqlstate 42S22) during query: select id, workflow, source, pos, stop_pos, max_replication_lag, state, db_name, time_updated, transaction_timestamp, message, tags from _vt.vreplication where db_name = 'vt_pool1'
```
this workflow lookup query:
>select id, workflow, source, pos, stop_pos, max_replication_lag, state, db_name, time_updated, transaction_timestamp, message, tags from _vt.vreplication where db_name = '<db_name>'

was executed in WithDDL which 
>// WithDDL allows you to execute statements against
// tables whose schema may not be up-to-date. If the tables
// don't exist or result in a schema error, it can apply a series
// of idempotent DDLs that will create or bring the tables
// to the desired state and retry.

In the current upgrade situation where tablets are in v11, there is no `tags` column in the table `_vt.vreplication`, which causes a retry and a bunch of DDL execution.

And more seriously, the vtadmin UI is not able to get the workflow streams due to the query error and keeps refreshing, which results in some internal transactions (the ddls) sneaking in when PlannedReparentShard is in progress.

context:
the new column tags was introduced in v12 by https://github.com/vitessio/vitess/pull/8388/files

notes and testings:
https://gist.slack-github.com/tanjin-xu/93d6b544304bbe44153c2e43facd07a9
https://gist.slack-github.com/tanjin-xu/45ee36ffde3a7a25e4221d79fe619c83

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
