### PR TITLE
add rdonly patch to tabletgateway for v13

### DIFF
--- a/go/vt/vtgate/gateway.go
+++ b/go/vt/vtgate/gateway.go
@@ -43,7 +43,8 @@ var (
 	initialTabletTimeout         = flag.Duration("gateway_initial_tablet_timeout", 30*time.Second, "At startup, the gateway will wait up to that duration to get one tablet per keyspace/shard/tablettype")
 	// RetryCount is the number of times a query will be retried on error
 	// Make this unexported after DiscoveryGateway is deprecated
-	RetryCount = flag.Int("retry-count", 2, "retry count")
+	RetryCount           = flag.Int("retry-count", 2, "retry count")
+	routeReplicaToRdonly = flag.Bool("gateway_route_replica_to_rdonly", false, "route REPLICA queries to RDONLY tablets as well as REPLICA tablets")
 )
 
 // A Gateway is the query processing module for each shard,

--- a/go/vt/vtgate/tabletgateway.go
+++ b/go/vt/vtgate/tabletgateway.go
@@ -36,7 +36,6 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/buffer"
 	"vitess.io/vitess/go/vt/vttablet/queryservice"
 
-	"vitess.io/vitess/go/vt/proto/query"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
@@ -276,7 +275,7 @@ func (gw *TabletGateway) withRetry(ctx context.Context, target *querypb.Target, 
 		// discoverygateway patch - https://github.com/slackhq/vitess/commit/47adb7c8fc720cb4cb7a090530b3e88d310ff6d3
 		if *routeReplicaToRdonly && target.TabletType == topodatapb.TabletType_REPLICA {
 			// Create a new target for the same original keyspace/shard, but RDONLY tablet type.
-			rdonlyTarget := &query.Target{
+			rdonlyTarget := &querypb.Target{
 				Keyspace:   target.Keyspace,
 				Shard:      target.Shard,
 				TabletType: topodatapb.TabletType_RDONLY,


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

Applying the RDONLY patch to the tabletgateway that routes REPLICA queries to these tablets to our v13 branch 

## Related Issue(s)

https://github.com/slackhq/vitess/pull/17


