### PR TITLE
patch upstream pr 4660 (Fix panic in vtgate when MakeRowTrusted gets bad result)

### DIFF
--- a/go/sqltypes/result.go
+++ b/go/sqltypes/result.go
@@ -245,13 +245,14 @@ func hashCodeForRow(val []Value) string {
 // Every place this function is called, a comment is needed that explains
 // why it's justified.
 func MakeRowTrusted(fields []*querypb.Field, row *querypb.Row) []Value {
-	sqlRow := make([]Value, len(row.Lengths))
+	sqlRow := make([]Value, len(fields))
 	var offset int64
-	for i, length := range row.Lengths {
+	for i, fld := range fields {
+		length := row.Lengths[i]
 		if length < 0 {
 			continue
 		}
-		sqlRow[i] = MakeTrusted(fields[i].Type, row.Values[offset:offset+length])
+		sqlRow[i] = MakeTrusted(fld.Type, row.Values[offset:offset+length])
 		offset += length
 	}
 	return sqlRow

--- a/go/sqltypes/result_test.go
+++ b/go/sqltypes/result_test.go
@@ -25,6 +25,61 @@ import (
 	querypb "vitess.io/vitess/go/vt/proto/query"
 )
 
+func TestMakeRowTrusted(t *testing.T) {
+	fields := MakeTestFields(
+		"some_int|some_text|another_int",
+		"int8|varchar|int8",
+	)
+
+	values := []byte{}
+	hw := []byte("hello, world")
+	values = append(values, hw...)
+	values = append(values, byte(42))
+
+	row := &querypb.Row{
+		Lengths: []int64{-1, int64(len(hw)), 1},
+		Values:  values,
+	}
+
+	want := []Value{
+		MakeTrusted(querypb.Type_NULL_TYPE, nil),
+		MakeTrusted(querypb.Type_VARCHAR, []byte("hello, world")),
+		MakeTrusted(querypb.Type_INT8, []byte{byte(42)}),
+	}
+
+	result := MakeRowTrusted(fields, row)
+	if !reflect.DeepEqual(result, want) {
+		t.Errorf("MakeRowTrusted:\ngot: %#v\nwant: %#v", result, want)
+	}
+}
+
+func TestMakeRowTrustedDoesNotPanicOnNewColumns(t *testing.T) {
+	fields := MakeTestFields(
+		"some_int|some_text",
+		"int8|varchar",
+	)
+
+	values := []byte{byte(123)}
+	hw := []byte("hello, world")
+	values = append(values, hw...)
+	values = append(values, byte(42))
+
+	row := &querypb.Row{
+		Lengths: []int64{1, int64(len(hw)), 1},
+		Values:  values,
+	}
+
+	want := []Value{
+		MakeTrusted(querypb.Type_INT8, []byte{byte(123)}),
+		MakeTrusted(querypb.Type_VARCHAR, []byte("hello, world")),
+	}
+
+	result := MakeRowTrusted(fields, row)
+	if !reflect.DeepEqual(result, want) {
+		t.Errorf("MakeRowTrusted:\ngot: %#v\nwant: %#v", result, want)
+	}
+}
+
 func TestRepair(t *testing.T) {
 	fields := []*querypb.Field{{
 		Type: Int64,


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

similarly as [what we did for v12 ](https://github.com/slackhq/vitess/pull/1), we need to patch the upstream PR 4660 (Fix panic in vtgate when MakeRowTrusted gets bad result).. We still consider to work with upstream on a real fix in the near future.

context: https://github.com/vitessio/vitess/pull/4660

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
