### PR TITLE
update tabletgateway to pass in target of selected tablet for rdonly patch

### DIFF
--- a/go/vt/vtgate/tabletgateway.go
+++ b/go/vt/vtgate/tabletgateway.go
@@ -300,7 +300,7 @@ func (gw *TabletGateway) withRetry(ctx context.Context, target *querypb.Target, 
 		for _, t := range tablets {
 			if _, ok := invalidTablets[topoproto.TabletAliasString(t.Tablet.Alias)]; !ok {
 				th = t
-				if *routeReplicaToRdonly && target.TabletType == topodatapb.TabletType_REPLICA {
+				if *routeReplicaToRdonly && (target.TabletType == topodatapb.TabletType_REPLICA || target.TabletType == topodatapb.TabletType_RDONLY) {
 					target = th.Target
 				}
 				break

--- a/go/vt/vtgate/tabletgateway.go
+++ b/go/vt/vtgate/tabletgateway.go
@@ -300,6 +300,9 @@ func (gw *TabletGateway) withRetry(ctx context.Context, target *querypb.Target, 
 		for _, t := range tablets {
 			if _, ok := invalidTablets[topoproto.TabletAliasString(t.Tablet.Alias)]; !ok {
 				th = t
+				if *routeReplicaToRdonly && target.TabletType == topodatapb.TabletType_REPLICA {
+					target = th.Target
+				}
 				break
 			}
 		}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

Fixes a nuance with the `tabletgateway` code and our RDONLY patch where if the tablet selected is a RDONLY, tabletgateway passes in the original target request as REPLICA instead of RDONLY. 
This PR updates the target to whatever the selected tablet's target is similar to what `discoverygatweay` does.

More context: https://slack-pde.slack.com/archives/C01CVUUUREF/p1670437058252249

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
