### PR TITLE
DRE_8137 Add a query log murron formatter

### DIFF
--- a/go/vt/vtgate/murron.go
+++ b/go/vt/vtgate/murron.go
@@ -1,0 +1,57 @@
+package vtgate
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"time"
+
+	"vitess.io/vitess/go/streamlog"
+)
+
+var standardFormatter streamlog.LogFormatter
+var hostname string
+
+// NewMurronLogFormatter returns a formatter for the query log that can be used to write to the rsyslog murron socket
+func NewMurronLogFormatter(formatter streamlog.LogFormatter) streamlog.LogFormatter {
+	standardFormatter = formatter
+
+	// The compiler does not like directly assigning to hostname below, so we use a temporary theHostname variable here ¯\_(ツ)_/¯
+	theHostname, err := os.Hostname()
+	if err != nil {
+		theHostname = "unknown-bedrock-vtgate"
+	}
+
+	hostname = theHostname
+
+	return queryLogMurronFormatter
+}
+
+type murronMockIOWriter struct {
+	data []byte
+}
+
+func (m murronMockIOWriter) Write(msg []byte) (int, error) {
+	m.data = msg
+
+	return len(msg), nil
+}
+
+func queryLogMurronFormatter(out io.Writer, params url.Values, message interface{}) error {
+	fakeWriter := murronMockIOWriter{}
+
+	err := standardFormatter(fakeWriter, params, message)
+	if err != nil {
+		return err
+	}
+
+	murronMessage := []byte(fmt.Sprintf("%s vtgate_query_log %s %s", time.Now().Format(time.RFC3339), hostname, string(fakeWriter.data)))
+
+	_, err = out.Write(murronMessage)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/go/vt/vtgate/murron.go
+++ b/go/vt/vtgate/murron.go
@@ -32,21 +32,21 @@ type murronMockIOWriter struct {
 	data []byte
 }
 
-func (m murronMockIOWriter) Write(msg []byte) (int, error) {
+func (m *murronMockIOWriter) Write(msg []byte) (int, error) {
 	m.data = msg
 
 	return len(msg), nil
 }
 
 func queryLogMurronFormatter(out io.Writer, params url.Values, message interface{}) error {
-	fakeWriter := murronMockIOWriter{}
+	fakeWriter := &murronMockIOWriter{}
 
 	err := standardFormatter(fakeWriter, params, message)
 	if err != nil {
 		return err
 	}
 
-	murronMessage := []byte(fmt.Sprintf("%s vtgate_query_log %s %s", time.Now().Format(time.RFC3339), hostname, string(fakeWriter.data)))
+	murronMessage := []byte(fmt.Sprintf("%s vtgate_query_log %s %s\n", time.Now().Format(time.RFC3339), hostname, string(fakeWriter.data)))
 
 	_, err = out.Write(murronMessage)
 	if err != nil {

--- a/go/vt/vtgate/murron.go
+++ b/go/vt/vtgate/murron.go
@@ -46,6 +46,12 @@ func queryLogMurronFormatter(out io.Writer, params url.Values, message interface
 		return err
 	}
 
+	// Skip sending anything to the log if there is nothing to send. It can happen if VTgate determines
+	// that the query does not need to be logged.
+	if fakeWriter.data == nil || len(fakeWriter.data) == 0 {
+		return nil
+	}
+
 	murronMessage := []byte(fmt.Sprintf("%s vtgate_query_log %s %s\n", time.Now().Format(time.RFC3339), hostname, string(fakeWriter.data)))
 
 	_, err = out.Write(murronMessage)

--- a/go/vt/vtgate/murron.go
+++ b/go/vt/vtgate/murron.go
@@ -20,7 +20,7 @@ func NewMurronLogFormatter(formatter streamlog.LogFormatter) streamlog.LogFormat
 	// The compiler does not like directly assigning to hostname below, so we use a temporary theHostname variable here ¯\_(ツ)_/¯
 	theHostname, err := os.Hostname()
 	if err != nil {
-		theHostname = "unknown-bedrock-vtgate"
+		theHostname = "unknown-vtgate"
 	}
 
 	hostname = theHostname

--- a/go/vt/vtgate/querylog.go
+++ b/go/vt/vtgate/querylog.go
@@ -38,6 +38,9 @@ var (
 
 	// queryLogToFile controls whether query logs are sent to a file
 	queryLogToFile = flag.String("log_queries_to_file", "", "Enable query logging to the specified file")
+
+	// queryLogMurronFormat controls whether to use the standard or the murron format for vtgate query logs
+	queryLogMurronFormat = flag.Bool("log_queries_murron_format", false, "If specified, write the query log file in murron's plain/rsyslog format")
 )
 
 func initQueryLogger(vtg *VTGate) error {
@@ -54,7 +57,13 @@ func initQueryLogger(vtg *VTGate) error {
 	})
 
 	if *queryLogToFile != "" {
-		_, err := QueryLogger.LogToFile(*queryLogToFile, streamlog.GetFormatter(QueryLogger))
+		formatter := streamlog.GetFormatter(QueryLogger)
+
+		if *queryLogMurronFormat {
+			formatter = NewMurronLogFormatter(formatter)
+		}
+
+		_, err := QueryLogger.LogToFile(*queryLogToFile, formatter)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Description
This PR adds the ability to log queries in a format that can be directly written by the vtgate to the murron rsyslog socket.

This is necessary so that we can continue to log queries from the vtgates nad end up in the datawarehous, without having to modify the pipeline that gets them there.

Notice that this patch is Slack-specific (as is Murron).

The screenshot below shows the message as received by murron, as per `murron-tail` output

![image](https://user-images.githubusercontent.com/5791035/207155160-f1755d80-7d6b-40d1-a12c-644ef63a8498.png)

And this one shows the query in dw:
<img width="1773" alt="image" src="https://user-images.githubusercontent.com/5791035/207348133-49c7424c-3769-4b08-a5e3-f21a1244b025.png">
