### PR TITLE
Allow BUILD_GIT_BRANCH and BUILD_GIT_REV override in docker build

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -32,6 +32,12 @@ ARG CGO_ENABLED=0
 # Allows docker builds to set the BUILD_NUMBER
 ARG BUILD_NUMBER
 
+# Allows docker builds to set the BUILD_GIT_BRANCH
+ARG BUILD_GIT_BRANCH
+
+# Allows docker builds to set the BUILD_GIT_REV
+ARG BUILD_GIT_REV
+
 # Re-copy sources from working tree
 USER root
 COPY . /vt/src/vitess.io/vitess

--- a/docker/base/Dockerfile.mariadb
+++ b/docker/base/Dockerfile.mariadb
@@ -9,6 +9,12 @@ ARG CGO_ENABLED=0
 # Allows docker builds to set the BUILD_NUMBER
 ARG BUILD_NUMBER
 
+# Allows docker builds to set the BUILD_GIT_BRANCH
+ARG BUILD_GIT_BRANCH
+
+# Allows docker builds to set the BUILD_GIT_REV
+ARG BUILD_GIT_REV
+
 # Re-copy sources from working tree
 USER root
 COPY . /vt/src/vitess.io/vitess

--- a/docker/base/Dockerfile.mariadb103
+++ b/docker/base/Dockerfile.mariadb103
@@ -9,6 +9,12 @@ ARG CGO_ENABLED=0
 # Allows docker builds to set the BUILD_NUMBER
 ARG BUILD_NUMBER
 
+# Allows docker builds to set the BUILD_GIT_BRANCH
+ARG BUILD_GIT_BRANCH
+
+# Allows docker builds to set the BUILD_GIT_REV
+ARG BUILD_GIT_REV
+
 # Re-copy sources from working tree
 USER root
 COPY . /vt/src/vitess.io/vitess

--- a/docker/base/Dockerfile.mysql56
+++ b/docker/base/Dockerfile.mysql56
@@ -9,6 +9,12 @@ ARG CGO_ENABLED=0
 # Allows docker builds to set the BUILD_NUMBER
 ARG BUILD_NUMBER
 
+# Allows docker builds to set the BUILD_GIT_BRANCH
+ARG BUILD_GIT_BRANCH
+
+# Allows docker builds to set the BUILD_GIT_REV
+ARG BUILD_GIT_REV
+
 # Re-copy sources from working tree
 USER root
 COPY . /vt/src/vitess.io/vitess

--- a/docker/base/Dockerfile.mysql80
+++ b/docker/base/Dockerfile.mysql80
@@ -9,6 +9,12 @@ ARG CGO_ENABLED=0
 # Allows docker builds to set the BUILD_NUMBER
 ARG BUILD_NUMBER
 
+# Allows docker builds to set the BUILD_GIT_BRANCH
+ARG BUILD_GIT_BRANCH
+
+# Allows docker builds to set the BUILD_GIT_REV
+ARG BUILD_GIT_REV
+
 # Re-copy sources from working tree
 USER root
 COPY . /vt/src/vitess.io/vitess

--- a/docker/base/Dockerfile.percona
+++ b/docker/base/Dockerfile.percona
@@ -9,6 +9,12 @@ ARG CGO_ENABLED=0
 # Allows docker builds to set the BUILD_NUMBER
 ARG BUILD_NUMBER
 
+# Allows docker builds to set the BUILD_GIT_BRANCH
+ARG BUILD_GIT_BRANCH
+
+# Allows docker builds to set the BUILD_GIT_REV
+ARG BUILD_GIT_REV
+
 # Re-copy sources from working tree
 USER root
 COPY . /vt/src/vitess.io/vitess

--- a/docker/base/Dockerfile.percona57
+++ b/docker/base/Dockerfile.percona57
@@ -9,6 +9,12 @@ ARG CGO_ENABLED=0
 # Allows docker builds to set the BUILD_NUMBER
 ARG BUILD_NUMBER
 
+# Allows docker builds to set the BUILD_GIT_BRANCH
+ARG BUILD_GIT_BRANCH
+
+# Allows docker builds to set the BUILD_GIT_REV
+ARG BUILD_GIT_REV
+
 # Re-copy sources from working tree
 USER root
 COPY . /vt/src/vitess.io/vitess

--- a/docker/base/Dockerfile.percona80
+++ b/docker/base/Dockerfile.percona80
@@ -9,6 +9,12 @@ ARG CGO_ENABLED=0
 # Allows docker builds to set the BUILD_NUMBER
 ARG BUILD_NUMBER
 
+# Allows docker builds to set the BUILD_GIT_BRANCH
+ARG BUILD_GIT_BRANCH
+
+# Allows docker builds to set the BUILD_GIT_REV
+ARG BUILD_GIT_REV
+
 # Re-copy sources from working tree
 USER root
 COPY . /vt/src/vitess.io/vitess


### PR DESCRIPTION
## Description

This PR allows `BUILD_GIT_BRANCH` and `BUILD_GIT_REV` to be passed-into docker-based builds _(via `Dockerfile`s in [`docker/base`](https://github.com/vitessio/vitess/tree/main/docker/base))_ of Vitess, so that the `BuildGitBranch` and `BuildGitRev` stats return correct information

I plan to submit this to the upstream project after successful testing

Currently we are passing these 2 x env vars to our builds like so:
```bash
	docker build \
    	--build-arg BUILD_GIT_REV="$(git rev-parse --short HEAD)" \
    	--build-arg BUILD_GIT_BRANCH="$GIT_BRANCH" \
    	--build-arg BUILD_NUMBER="$BUILD_NUMBER" \
    	-t "${IMAGE_TAG}" \
    	-f "${WORKDIR}/docker/base/Dockerfile.${FLAVOR}" "${WORKDIR}"
```
However `docker build` returns this warning that indicates they were ignored:
```bash
[Warning] One or more build-args [BUILD_GIT_BRANCH BUILD_GIT_REV] were not consumed
```

At least in our situation, this causes default values for branch/rev to be used instead which results in `HEAD` as `BuildGitBranch`, which isn't very useful:
```bash
$ curl -s localhost:15000/debug/vars|jq .BuildGitBranch
"HEAD"
```

Following the PR, the overrides passed to `docker build` should be respected and the `BuildGitBranch` and `BuildGitRev` stats should have the expected values

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
