### PR TITLE
Use stats.Gauge w/o mutex for VStreamerCount stat

### DIFF
--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -144,7 +144,11 @@ func (vs *vstreamer) Cancel() {
 func (vs *vstreamer) Stream() error {
 	//defer vs.cancel()
 	ctx := context.Background()
-	defer ctx.Done()
+	vs.vse.vstreamerCount.Add(1)
+	defer func() {
+		ctx.Done()
+		vs.vse.vstreamerCount.Add(-1)
+	}()
 	vs.vse.vstreamersCreated.Add(1)
 	log.Infof("Starting Stream() with startPos %s", vs.startPos)
 	pos, err := mysql.DecodePosition(vs.startPos)


### PR DESCRIPTION
## Description

This PR updates the new `VStreamerCount` stat to match the approach PlanetScale suggested in the upstream PR https://github.com/vitessio/vitess/pull/11978 (merged)

Currently our fork implements the same new stat but it uses a mutex. The PR accepted by upstream does not use a mutex, which is smarter

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
