### PR TITLE
[vtgate planner error -outer join] backport partial fix from upstream 11763

### DIFF
--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -4,7 +4,7 @@ jobs:
 
   build:
     name: End-to-End Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/unit_race.yml
+++ b/.github/workflows/unit_race.yml
@@ -8,7 +8,7 @@ jobs:
 
   build:
     name: Unit Test (Race)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/unit_test_mariadb103.yml
+++ b/.github/workflows/unit_test_mariadb103.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/unit_test_mysql57.yml
+++ b/.github/workflows/unit_test_mysql57.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/unit_test_mysql80.yml
+++ b/.github/workflows/unit_test_mysql80.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/go/test/endtoend/vtgate/gen4/main_test.go
+++ b/go/test/endtoend/vtgate/gen4/main_test.go
@@ -54,14 +54,6 @@ create table t3(
 	primary key(id)
 ) Engine=InnoDB;
 
-create table oj_tbl(
-	c1 bigint,
-	c2 bigint,
-	c3 bigint,
-	c4 bigint,
-	primary key(c1)
-) Engine=InnoDB;
-
 create table user_region(
 	id bigint,
 	cola bigint,
@@ -156,14 +148,6 @@ create table u_b(
         }
       ]
     },
-	"oj_tbl": {
-	  "column_vindexes": [
-		{
-		  "column": "c1",
-		  "name:": "oj_vdx"
-		}
-	  ]
-	},
     "user_region": {
 	  "column_vindexes": [
 	    {

--- a/go/test/endtoend/vtgate/gen4/main_test.go
+++ b/go/test/endtoend/vtgate/gen4/main_test.go
@@ -156,7 +156,7 @@ create table u_b(
         }
       ]
     },
-	"obj_tbl": {
+	"oj_tbl": {
 	  "column_vindexes": [
 		{
 		  "column": "c1",

--- a/go/test/endtoend/vtgate/gen4/main_test.go
+++ b/go/test/endtoend/vtgate/gen4/main_test.go
@@ -54,6 +54,14 @@ create table t3(
 	primary key(id)
 ) Engine=InnoDB;
 
+create table oj_tbl(
+	c1 int,
+	c2 int,
+	c3 int,
+	c4 int,
+	primary key(c1)
+) Engine=InnoDB;
+
 create table user_region(
 	id bigint,
 	cola bigint,
@@ -148,6 +156,14 @@ create table u_b(
         }
       ]
     },
+	"obj_tbl": {
+	  "column_vindexes": [
+		{
+		  "column": "c1",
+		  "name:": "xxhash"
+		}
+	  ]
+	},
     "user_region": {
 	  "column_vindexes": [
 	    {

--- a/go/test/endtoend/vtgate/gen4/main_test.go
+++ b/go/test/endtoend/vtgate/gen4/main_test.go
@@ -55,10 +55,10 @@ create table t3(
 ) Engine=InnoDB;
 
 create table oj_tbl(
-	c1 int,
-	c2 int,
-	c3 int,
-	c4 int,
+	c1 bigint,
+	c2 bigint,
+	c3 bigint,
+	c4 bigint,
 	primary key(c1)
 ) Engine=InnoDB;
 
@@ -160,7 +160,7 @@ create table u_b(
 	  "column_vindexes": [
 		{
 		  "column": "c1",
-		  "name:": "xxhash"
+		  "name:": "oj_vdx"
 		}
 	  ]
 	},

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -3927,3 +3927,21 @@ Gen4 plan same as above
   }
 }
 Gen4 plan same as above
+
+"select distinct t1.c1, t1.c2, t1.c3, t1.c4 from obj_tbl t1 inner join obj_tbl t2 on (t1.c2= t2.c2 and t1.c3 = t2.c3 and t2.c4 >= 10) left join obj_tbl t3 on (t1.c2 = t3.c2 and t1.c3 = t3.c3 and t3.c4 < 10 and t1.c1 < t3.c1) where t1.c2 = 10 order by t1.c4 desc, t1.c1 desc limit 10"
+{
+  "QueryType": "SELECT",
+  "Original": "select distinct t1.c1, t1.c2, t1.c3, t1.c4 from obj_tbl t1 inner join obj_tbl t2 on (t1.c2= t2.c2 and t1.c3 = t2.c3 and t2.c4 >= 10) left join obj_tbl t3 on (t1.c2 = t3.c2 and t1.c3 = t3.c3 and t3.c4 < 10 and t1.c1 < t3.c1) where t1.c2 = 10 order by t1.c4 desc, t1.c1 desc limit 10",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "Scatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select `user`.col from user_extra left join `user` on user_extra.user_id = `user`.id where 1 != 1",
+    "Query": "select `user`.col from user_extra left join `user` on user_extra.user_id = `user`.id where `user`.id is null",
+    "Table": "obj_tbl"
+  }
+}
+Gen4 plan same as above

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -3915,29 +3915,15 @@ Gen4 plan same as above
   "QueryType": "SELECT",
   "Original": "select user.col from user_extra left outer join user on user_extra.user_id = user.id WHERE user.id IS NULL",
   "Instructions": {
-    "OperatorType": "SimpleProjection",
-    "Columns": [
-      1
-    ],
-    "Inputs": [
-      {
-        "OperatorType": "Filter",
-        "Predicate": "`user`.id is null",
-        "Inputs": [
-          {
-            "OperatorType": "Route",
-            "Variant": "Scatter",
-            "Keyspace": {
-              "Name": "user",
-              "Sharded": true
-            },
-            "FieldQuery": "select `user`.id, `user`.col from user_extra left join `user` on user_extra.user_id = `user`.id where 1 != 1",
-            "Query": "select `user`.id, `user`.col from user_extra left join `user` on user_extra.user_id = `user`.id",
-            "Table": "`user`, user_extra"
-          }
-        ]
-      }
-    ]
+    "OperatorType": "Route",
+    "Variant": "Scatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select `user`.id, `user`.col from user_extra left join `user` on user_extra.user_id = `user`.id where 1 != 1",
+    "Query": "select `user`.id, `user`.col from user_extra left join `user` on user_extra.user_id = `user`.id",
+    "Table": "`user`, user_extra"
   }
 }
 Gen4 plan same as above

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -3928,10 +3928,10 @@ Gen4 plan same as above
 }
 Gen4 plan same as above
 
-"select distinct t1.c1, t1.c2, t1.c3, t1.c4 from obj_tbl t1 inner join obj_tbl t2 on (t1.c2= t2.c2 and t1.c3 = t2.c3 and t2.c4 >= 10) left join obj_tbl t3 on (t1.c2 = t3.c2 and t1.c3 = t3.c3 and t3.c4 < 10 and t1.c1 < t3.c1) where t1.c2 = 10 order by t1.c4 desc, t1.c1 desc limit 10"
+"select distinct t1.c1, t1.c2, t1.c3, t1.c4 from oj_tbl t1 inner join oj_tbl t2 on (t1.c2= t2.c2 and t1.c3 = t2.c3 and t2.c4 >= 10) left join oj_tbl t3 on (t1.c2 = t3.c2 and t1.c3 = t3.c3 and t3.c4 < 10 and t1.c1 < t3.c1) where t1.c2 = 10 order by t1.c4 desc, t1.c1 desc limit 10"
 {
   "QueryType": "SELECT",
-  "Original": "select distinct t1.c1, t1.c2, t1.c3, t1.c4 from obj_tbl t1 inner join obj_tbl t2 on (t1.c2= t2.c2 and t1.c3 = t2.c3 and t2.c4 >= 10) left join obj_tbl t3 on (t1.c2 = t3.c2 and t1.c3 = t3.c3 and t3.c4 < 10 and t1.c1 < t3.c1) where t1.c2 = 10 order by t1.c4 desc, t1.c1 desc limit 10",
+  "Original": "select distinct t1.c1, t1.c2, t1.c3, t1.c4 from oj_tbl t1 inner join oj_tbl t2 on (t1.c2= t2.c2 and t1.c3 = t2.c3 and t2.c4 >= 10) left join oj_tbl t3 on (t1.c2 = t3.c2 and t1.c3 = t3.c3 and t3.c4 < 10 and t1.c1 < t3.c1) where t1.c2 = 10 order by t1.c4 desc, t1.c1 desc limit 10",
   "Instructions": {
     "OperatorType": "Route",
     "Variant": "Scatter",

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -3941,7 +3941,7 @@ Gen4 plan same as above
     },
     "FieldQuery": "select `user`.col from user_extra left join `user` on user_extra.user_id = `user`.id where 1 != 1",
     "Query": "select `user`.col from user_extra left join `user` on user_extra.user_id = `user`.id where `user`.id is null",
-    "Table": "obj_tbl"
+    "Table": "oj_tbl"
   }
 }
 Gen4 plan same as above

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -3928,11 +3928,10 @@ Gen4 plan same as above
 }
 Gen4 plan same as above
 
-"select distinct t1.c1, t1.c2, t1.c3, t1.c4 from oj_tbl t1 inner join oj_tbl t2 on (t1.c2= t2.c2 and t1.c3 = t2.c3 and t2.c4 >= 10) left join oj_tbl t3 on (t1.c2 = t3.c2 and t1.c3 = t3.c3 and t3.c4 < 10 and t1.c1 < t3.c1) where t1.c2 = 10 order by t1.c4 desc, t1.c1 desc limit 10"
+"select distinct t1.c1 from oj_tbl t1 left join oj_tbl t3 on t1.c2 = t3.c2 where t3.c1 is NULL"
 {
   "QueryType": "SELECT",
-  "Original": "select distinct t1.c1, t1.c2, t1.c3, t1.c4 from oj_tbl t1 inner join oj_tbl t2 on (t1.c2= t2.c2 and t1.c3 = t2.c3 and t2.c4 >= 10) left join oj_tbl t3 on (t1.c2 = t3.c2 and t1.c3 = t3.c3 and t3.c4 < 10 and t1.c1 < t3.c1) where t1.c2 = 10 order by t1.c4 desc, t1.c1 desc limit 10",
-  "Instructions": {
+  "Original": "select distinct t1.c1 from oj_tbl t1 left join oj_tbl t3 on t1.c2 = t3.c2 where t3.c1 is NULL"
     "OperatorType": "Route",
     "Variant": "Scatter",
     "Keyspace": {

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -3921,8 +3921,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select `user`.id, `user`.col from user_extra left join `user` on user_extra.user_id = `user`.id where 1 != 1",
-    "Query": "select `user`.id, `user`.col from user_extra left join `user` on user_extra.user_id = `user`.id",
+    "FieldQuery": "select `user`.col from user_extra left join `user` on user_extra.user_id = `user`.id where 1 != 1",
+    "Query": "select `user`.col from user_extra left join `user` on user_extra.user_id = `user`.id where `user`.id is null",
     "Table": "`user`, user_extra"
   }
 }

--- a/go/vt/vtgate/planbuilder/testdata/schema_test.json
+++ b/go/vt/vtgate/planbuilder/testdata/schema_test.json
@@ -322,7 +322,7 @@
             }
           ]
         },
-        "obj_tbl":{
+        "oj_tbl":{
           "column_vindexes": [
             {
               "column": "c1",

--- a/go/vt/vtgate/planbuilder/testdata/schema_test.json
+++ b/go/vt/vtgate/planbuilder/testdata/schema_test.json
@@ -89,7 +89,8 @@
           "type": "multiCol_test"
         },
         "ojvidx": {
-          "type": "ojvidx"
+          "type": "hash_test",
+          "owner": "user"
         },
         "colc_map": {
           "type": "lookup_test",

--- a/go/vt/vtgate/planbuilder/testdata/schema_test.json
+++ b/go/vt/vtgate/planbuilder/testdata/schema_test.json
@@ -88,6 +88,9 @@
         "multicolIdx": {
           "type": "multiCol_test"
         },
+        "ojvidx": {
+          "type": "ojvidx"
+        },
         "colc_map": {
           "type": "lookup_test",
           "owner": "multicol_tbl"
@@ -316,6 +319,32 @@
             {
               "column": "name",
               "name": "name_muticoltbl_map"
+            }
+          ]
+        },
+        "obj_tbl":{
+          "column_vindexes": [
+            {
+              "column": "c1",
+              "name": "ojvidx"
+            }
+          ],
+          "columns": [
+            {
+              "name": "c1",
+              "type": "INT16"
+            },
+            {
+              "name": "c2",
+              "type": "INT16"
+            },
+            {
+              "name": "c3",
+              "type": "INT16"
+            },
+            {
+              "name": "c4",
+              "type": "INT16"
             }
           ]
         }

--- a/test/templates/unit_test.tpl
+++ b/test/templates/unit_test.tpl
@@ -6,7 +6,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Check if workflow needs to be skipped


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
upstream pr https://github.com/vitessio/vitess/pull/12256

An outer join query used to work in v12 but got a planner error: `unknown plan type for DISTINCT *planbuilder.filter`
a sample query:
```
 SELECT DISTINCT
       wie.id,
       wie.c2,
       wie.c3,
       wie.status,
       wie.data,
       wie.error,
       wie.created
     FROM wb_tbl wie
     INNER JOIN
       wb_tbl wie_f
       ON (
         wie.c2 = wie_f.c2
         AND wie.c3 = wie_f.c3
          AND wie_f.created >= "2023-01-24 00:00:00.000"
       )
     LEFT JOIN
       wb_tbl wie_g
       ON (
         wie.c2 = wie_g.c2
         AND wie.c3= wie_g.c3
         AND wie.created < "2023-01-24 00:00:00.000"
         AND wie.id < wie_g.id
       )
     WHERE
       wie_g.id IS NULL
       AND wie.c2 =10000
      AND wie.status = "completed"
      ORDER BY wie.created DESC, wie.id DESC LIMIT 10;
```


## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
