### PR TITLE
update go version for test workflows

### DIFF
--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -70,7 +70,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.5
+        go-version: 1.18.7
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -95,7 +95,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.5
+        go-version: 1.18.7
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_query_serving.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving.yml
@@ -70,7 +70,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.5
+        go-version: 1.18.7
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -71,7 +71,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.5
+        go-version: 1.18.7
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -69,7 +69,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.5
+        go-version: 1.18.7
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/go/mysql/collations/integration/coercion_test.go
+++ b/go/mysql/collations/integration/coercion_test.go
@@ -135,8 +135,8 @@ func TestComparisonSemantics(t *testing.T) {
 	conn := mysqlconn(t)
 	defer conn.Close()
 
-	if strings.HasPrefix(conn.ServerVersion, "8.0.31") {
-		t.Skipf("Coercion semantics have changed in 8.0.31")
+	if strings.HasPrefix(conn.ServerVersion, "8.0.32") {
+		t.Skipf("Coercion semantics have changed in 8.0.32")
 	}
 
 	for _, coll := range collations.Local().AllCollations() {


### PR DESCRIPTION
Signed-off-by: 'Priya Bibra' <pbibra@slack-corp.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
 
Some of the tests against the v13 branch are failing due to a bump in the upgrade tests from v14.0.2 to v14.0.4
The latter requires a higher go version and since this tag is fixed, I'm bumping the version manually.
Discussion here: https://slack-pde.slack.com/archives/C021CPS1BNF/p1675708897542689?thread_ts=1674777609.913009&cid=C021CPS1BNF

Bumping mysql version from `8.0.31` to `8.0.32` for coercion semantics test as well.
