### PR TITLE
Add timeout to MysqlDaemon.ReplicationStatus()

### DIFF
--- a/go/cmd/vtbackup/vtbackup.go
+++ b/go/cmd/vtbackup/vtbackup.go
@@ -362,7 +362,7 @@ func takeBackup(ctx context.Context, topoServer *topo.Server, backupStorage back
 		case <-time.After(time.Second):
 		}
 
-		status, statusErr := mysqld.ReplicationStatus()
+		status, statusErr := mysqld.ReplicationStatus(ctx)
 		if statusErr != nil {
 			log.Warningf("Error getting replication status: %v", statusErr)
 			continue
@@ -387,7 +387,7 @@ func takeBackup(ctx context.Context, topoServer *topo.Server, backupStorage back
 	}
 
 	// Did we make any progress?
-	status, err := mysqld.ReplicationStatus()
+	status, err := mysqld.ReplicationStatus(ctx)
 	if err != nil {
 		return fmt.Errorf("can't get replication status: %v", err)
 	}

--- a/go/vt/mysqlctl/builtinbackupengine.go
+++ b/go/vt/mysqlctl/builtinbackupengine.go
@@ -148,7 +148,7 @@ func (be *BuiltinBackupEngine) ExecuteBackup(ctx context.Context, params BackupP
 
 	// See if we need to restart replication after backup.
 	params.Logger.Infof("getting current replication status")
-	replicaStatus, err := params.Mysqld.ReplicationStatus()
+	replicaStatus, err := params.Mysqld.ReplicationStatus(context.TODO())
 	switch err {
 	case nil:
 		replicaStartRequired = replicaStatus.ReplicationRunning() && !*DisableActiveReparents
@@ -182,7 +182,7 @@ func (be *BuiltinBackupEngine) ExecuteBackup(ctx context.Context, params BackupP
 			return false, vterrors.Wrapf(err, "can't stop replica")
 		}
 		var replicaStatus mysql.ReplicationStatus
-		replicaStatus, err = params.Mysqld.ReplicationStatus()
+		replicaStatus, err = params.Mysqld.ReplicationStatus(context.TODO())
 		if err != nil {
 			return false, vterrors.Wrap(err, "can't get replica status")
 		}
@@ -258,7 +258,7 @@ func (be *BuiltinBackupEngine) ExecuteBackup(ctx context.Context, params BackupP
 				if err := ctx.Err(); err != nil {
 					return usable, err
 				}
-				status, err := params.Mysqld.ReplicationStatus()
+				status, err := params.Mysqld.ReplicationStatus(context.TODO())
 				if err != nil {
 					return usable, err
 				}

--- a/go/vt/mysqlctl/builtinbackupengine.go
+++ b/go/vt/mysqlctl/builtinbackupengine.go
@@ -148,7 +148,7 @@ func (be *BuiltinBackupEngine) ExecuteBackup(ctx context.Context, params BackupP
 
 	// See if we need to restart replication after backup.
 	params.Logger.Infof("getting current replication status")
-	replicaStatus, err := params.Mysqld.ReplicationStatus(context.TODO())
+	replicaStatus, err := params.Mysqld.ReplicationStatus(ctx)
 	switch err {
 	case nil:
 		replicaStartRequired = replicaStatus.ReplicationRunning() && !*DisableActiveReparents
@@ -182,7 +182,7 @@ func (be *BuiltinBackupEngine) ExecuteBackup(ctx context.Context, params BackupP
 			return false, vterrors.Wrapf(err, "can't stop replica")
 		}
 		var replicaStatus mysql.ReplicationStatus
-		replicaStatus, err = params.Mysqld.ReplicationStatus(context.TODO())
+		replicaStatus, err = params.Mysqld.ReplicationStatus(ctx)
 		if err != nil {
 			return false, vterrors.Wrap(err, "can't get replica status")
 		}

--- a/go/vt/mysqlctl/builtinbackupengine.go
+++ b/go/vt/mysqlctl/builtinbackupengine.go
@@ -258,7 +258,7 @@ func (be *BuiltinBackupEngine) ExecuteBackup(ctx context.Context, params BackupP
 				if err := ctx.Err(); err != nil {
 					return usable, err
 				}
-				status, err := params.Mysqld.ReplicationStatus(context.TODO())
+				status, err := params.Mysqld.ReplicationStatus(ctx)
 				if err != nil {
 					return usable, err
 				}

--- a/go/vt/mysqlctl/fakemysqldaemon/fakemysqldaemon.go
+++ b/go/vt/mysqlctl/fakemysqldaemon/fakemysqldaemon.go
@@ -261,7 +261,7 @@ func (fmd *FakeMysqlDaemon) CurrentPrimaryPositionLocked(pos mysql.Position) {
 }
 
 // ReplicationStatus is part of the MysqlDaemon interface
-func (fmd *FakeMysqlDaemon) ReplicationStatus() (mysql.ReplicationStatus, error) {
+func (fmd *FakeMysqlDaemon) ReplicationStatus(ctx context.Context) (mysql.ReplicationStatus, error) {
 	if fmd.ReplicationStatusError != nil {
 		return mysql.ReplicationStatus{}, fmd.ReplicationStatusError
 	}

--- a/go/vt/mysqlctl/mysql_daemon.go
+++ b/go/vt/mysqlctl/mysql_daemon.go
@@ -46,7 +46,7 @@ type MysqlDaemon interface {
 	StartReplicationUntilAfter(ctx context.Context, pos mysql.Position) error
 	StopReplication(hookExtraEnv map[string]string) error
 	StopIOThread(ctx context.Context) error
-	ReplicationStatus() (mysql.ReplicationStatus, error)
+	ReplicationStatus(ctx context.Context) (mysql.ReplicationStatus, error)
 	PrimaryStatus(ctx context.Context) (mysql.PrimaryStatus, error)
 	SetSemiSyncEnabled(source, replica bool) error
 	SemiSyncEnabled() (source, replica bool)

--- a/go/vt/mysqlctl/query.go
+++ b/go/vt/mysqlctl/query.go
@@ -31,8 +31,8 @@ import (
 
 // getPoolReconnect gets a connection from a pool, tests it, and reconnects if
 // the connection is lost.
-func (mysqld *Mysqld) getPoolReconnect(ctx context.Context) (*dbconnpool.PooledDBConnection, error) {
-	conn, err := mysqld.dbaPool.Get(ctx)
+func (mysqld *Mysqld) getPoolReconnect(ctx context.Context, pool *dbconnpool.ConnectionPool) (*dbconnpool.PooledDBConnection, error) {
+	conn, err := pool.Get(ctx)
 	if err != nil {
 		return conn, err
 	}
@@ -59,7 +59,7 @@ func (mysqld *Mysqld) ExecuteSuperQuery(ctx context.Context, query string) error
 
 // ExecuteSuperQueryList alows the user to execute queries as a super user.
 func (mysqld *Mysqld) ExecuteSuperQueryList(ctx context.Context, queryList []string) error {
-	conn, err := mysqld.getPoolReconnect(ctx)
+	conn, err := mysqld.getPoolReconnect(ctx, mysqld.dbaPool)
 	if err != nil {
 		return err
 	}
@@ -89,7 +89,7 @@ func (mysqld *Mysqld) executeSuperQueryListConn(ctx context.Context, conn *dbcon
 
 // FetchSuperQuery returns the results of executing a query as a super user.
 func (mysqld *Mysqld) FetchSuperQuery(ctx context.Context, query string) (*sqltypes.Result, error) {
-	conn, connErr := mysqld.getPoolReconnect(ctx)
+	conn, connErr := mysqld.getPoolReconnect(ctx, mysqld.dbaPool)
 	if connErr != nil {
 		return nil, connErr
 	}
@@ -171,7 +171,7 @@ func (mysqld *Mysqld) killConnection(connID int64) error {
 	// which is the reason we're being asked to kill the connection.
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	if poolConn, connErr := mysqld.getPoolReconnect(ctx); connErr == nil {
+	if poolConn, connErr := mysqld.dbaPool.Get(ctx); connErr == nil {
 		// We got a pool connection.
 		defer poolConn.Recycle()
 		killConn = poolConn

--- a/go/vt/mysqlctl/reparent.go
+++ b/go/vt/mysqlctl/reparent.go
@@ -95,7 +95,7 @@ func (mysqld *Mysqld) WaitForReparentJournal(ctx context.Context, timeCreatedNS 
 // Promote will promote this server to be the new primary.
 func (mysqld *Mysqld) Promote(hookExtraEnv map[string]string) (mysql.Position, error) {
 	ctx := context.TODO()
-	conn, err := getPoolReconnect(ctx, mysqld.dbaPool)
+	conn, err := mysqld.getPoolReconnect(ctx)
 	if err != nil {
 		return mysql.Position{}, err
 	}

--- a/go/vt/mysqlctl/reparent.go
+++ b/go/vt/mysqlctl/reparent.go
@@ -95,7 +95,7 @@ func (mysqld *Mysqld) WaitForReparentJournal(ctx context.Context, timeCreatedNS 
 // Promote will promote this server to be the new primary.
 func (mysqld *Mysqld) Promote(hookExtraEnv map[string]string) (mysql.Position, error) {
 	ctx := context.TODO()
-	conn, err := mysqld.getPoolReconnect(ctx)
+	conn, err := mysqld.getPoolReconnect(ctx, mysqld.dbaPool)
 	if err != nil {
 		return mysql.Position{}, err
 	}

--- a/go/vt/mysqlctl/replication.go
+++ b/go/vt/mysqlctl/replication.go
@@ -70,7 +70,7 @@ func WaitForReplicationStart(mysqld MysqlDaemon, replicaStartDeadline int) error
 // StartReplication starts replication.
 func (mysqld *Mysqld) StartReplication(hookExtraEnv map[string]string) error {
 	ctx := context.TODO()
-	conn, err := mysqld.getPoolReconnect(ctx)
+	conn, err := mysqld.getPoolReconnect(ctx, mysqld.dbaPool)
 	if err != nil {
 		return err
 	}
@@ -87,7 +87,7 @@ func (mysqld *Mysqld) StartReplication(hookExtraEnv map[string]string) error {
 
 // StartReplicationUntilAfter starts replication until replication has come to `targetPos`, then it stops replication
 func (mysqld *Mysqld) StartReplicationUntilAfter(ctx context.Context, targetPos mysql.Position) error {
-	conn, err := mysqld.getPoolReconnect(ctx)
+	conn, err := mysqld.getPoolReconnect(ctx, mysqld.dbaPool)
 	if err != nil {
 		return err
 	}
@@ -106,7 +106,7 @@ func (mysqld *Mysqld) StopReplication(hookExtraEnv map[string]string) error {
 		return err
 	}
 	ctx := context.TODO()
-	conn, err := mysqld.getPoolReconnect(ctx)
+	conn, err := mysqld.getPoolReconnect(ctx, mysqld.dbaPool)
 	if err != nil {
 		return err
 	}
@@ -117,7 +117,7 @@ func (mysqld *Mysqld) StopReplication(hookExtraEnv map[string]string) error {
 
 // StopIOThread stops a replica's IO thread only.
 func (mysqld *Mysqld) StopIOThread(ctx context.Context) error {
-	conn, err := mysqld.getPoolReconnect(ctx)
+	conn, err := mysqld.getPoolReconnect(ctx, mysqld.dbaPool)
 	if err != nil {
 		return err
 	}
@@ -134,7 +134,7 @@ func (mysqld *Mysqld) RestartReplication(hookExtraEnv map[string]string) error {
 		return err
 	}
 	ctx := context.TODO()
-	conn, err := mysqld.getPoolReconnect(ctx)
+	conn, err := mysqld.getPoolReconnect(ctx, mysqld.dbaPool)
 	if err != nil {
 		return err
 	}
@@ -205,7 +205,7 @@ func (mysqld *Mysqld) SetSuperReadOnly(on bool) error {
 // WaitSourcePos lets replicas wait to given replication position
 func (mysqld *Mysqld) WaitSourcePos(ctx context.Context, targetPos mysql.Position) error {
 	// Get a connection.
-	conn, err := mysqld.getPoolReconnect(ctx)
+	conn, err := mysqld.getPoolReconnect(ctx, mysqld.dbaPool)
 	if err != nil {
 		return err
 	}
@@ -272,7 +272,7 @@ func (mysqld *Mysqld) WaitSourcePos(ctx context.Context, targetPos mysql.Positio
 
 // ReplicationStatus returns the server replication status
 func (mysqld *Mysqld) ReplicationStatus(ctx context.Context) (mysql.ReplicationStatus, error) {
-	conn, err := mysqld.getPoolReconnect(ctx)
+	conn, err := mysqld.getPoolReconnect(ctx, mysqld.dbaPool)
 	if err != nil {
 		return mysql.ReplicationStatus{}, err
 	}
@@ -283,7 +283,7 @@ func (mysqld *Mysqld) ReplicationStatus(ctx context.Context) (mysql.ReplicationS
 
 // PrimaryStatus returns the primary replication statuses
 func (mysqld *Mysqld) PrimaryStatus(ctx context.Context) (mysql.PrimaryStatus, error) {
-	conn, err := mysqld.getPoolReconnect(ctx)
+	conn, err := mysqld.getPoolReconnect(ctx, mysqld.dbaPool)
 	if err != nil {
 		return mysql.PrimaryStatus{}, err
 	}
@@ -295,7 +295,7 @@ func (mysqld *Mysqld) PrimaryStatus(ctx context.Context) (mysql.PrimaryStatus, e
 // PrimaryPosition returns the primary replication position.
 func (mysqld *Mysqld) PrimaryPosition() (mysql.Position, error) {
 	ctx := context.TODO()
-	conn, err := mysqld.getPoolReconnect(ctx)
+	conn, err := mysqld.getPoolReconnect(ctx, mysqld.dbaPool)
 	if err != nil {
 		return mysql.Position{}, err
 	}
@@ -307,7 +307,7 @@ func (mysqld *Mysqld) PrimaryPosition() (mysql.Position, error) {
 // SetReplicationPosition sets the replication position at which the replica will resume
 // when its replication is started.
 func (mysqld *Mysqld) SetReplicationPosition(ctx context.Context, pos mysql.Position) error {
-	conn, err := mysqld.getPoolReconnect(ctx)
+	conn, err := mysqld.getPoolReconnect(ctx, mysqld.dbaPool)
 	if err != nil {
 		return err
 	}
@@ -325,7 +325,7 @@ func (mysqld *Mysqld) SetReplicationSource(ctx context.Context, host string, por
 	if err != nil {
 		return err
 	}
-	conn, err := mysqld.getPoolReconnect(ctx)
+	conn, err := mysqld.getPoolReconnect(ctx, mysqld.dbaPool)
 	if err != nil {
 		return err
 	}
@@ -349,7 +349,7 @@ func (mysqld *Mysqld) SetReplicationSource(ctx context.Context, host string, por
 
 // ResetReplication resets all replication for this host.
 func (mysqld *Mysqld) ResetReplication(ctx context.Context) error {
-	conn, connErr := mysqld.getPoolReconnect(ctx)
+	conn, connErr := mysqld.getPoolReconnect(ctx, mysqld.dbaPool)
 	if connErr != nil {
 		return connErr
 	}
@@ -419,7 +419,7 @@ func FindReplicas(mysqld MysqlDaemon) ([]string, error) {
 func (mysqld *Mysqld) EnableBinlogPlayback() error {
 	// Get a connection.
 	ctx := context.TODO()
-	conn, err := mysqld.getPoolReconnect(ctx)
+	conn, err := mysqld.getPoolReconnect(ctx, mysqld.dbaPool)
 	if err != nil {
 		return err
 	}
@@ -444,7 +444,7 @@ func (mysqld *Mysqld) EnableBinlogPlayback() error {
 func (mysqld *Mysqld) DisableBinlogPlayback() error {
 	// Get a connection.
 	ctx := context.TODO()
-	conn, err := mysqld.getPoolReconnect(ctx)
+	conn, err := mysqld.getPoolReconnect(ctx, mysqld.dbaPool)
 	if err != nil {
 		return err
 	}

--- a/go/vt/mysqlctl/replication.go
+++ b/go/vt/mysqlctl/replication.go
@@ -42,7 +42,8 @@ import (
 func WaitForReplicationStart(mysqld MysqlDaemon, replicaStartDeadline int) error {
 	var rowMap map[string]string
 	for replicaWait := 0; replicaWait < replicaStartDeadline; replicaWait++ {
-		status, err := mysqld.ReplicationStatus(context.TODO())
+		ctx := context.TODO()
+		status, err := mysqld.ReplicationStatus(ctx)
 		if err != nil {
 			return err
 		}
@@ -293,7 +294,8 @@ func (mysqld *Mysqld) PrimaryStatus(ctx context.Context) (mysql.PrimaryStatus, e
 
 // PrimaryPosition returns the primary replication position.
 func (mysqld *Mysqld) PrimaryPosition() (mysql.Position, error) {
-	conn, err := mysqld.getPoolReconnect(context.TODO())
+	ctx := context.TODO()
+	conn, err := mysqld.getPoolReconnect(ctx)
 	if err != nil {
 		return mysql.Position{}, err
 	}
@@ -416,7 +418,8 @@ func FindReplicas(mysqld MysqlDaemon) ([]string, error) {
 // Whatever it does for a given flavor, it must be idempotent.
 func (mysqld *Mysqld) EnableBinlogPlayback() error {
 	// Get a connection.
-	conn, err := mysqld.getPoolReconnect(context.TODO())
+	ctx := context.TODO()
+	conn, err := mysqld.getPoolReconnect(ctx)
 	if err != nil {
 		return err
 	}
@@ -440,7 +443,8 @@ func (mysqld *Mysqld) EnableBinlogPlayback() error {
 // Whatever it does for a given flavor, it must be idempotent.
 func (mysqld *Mysqld) DisableBinlogPlayback() error {
 	// Get a connection.
-	conn, err := mysqld.getPoolReconnect(context.TODO())
+	ctx := context.TODO()
+	conn, err := mysqld.getPoolReconnect(ctx)
 	if err != nil {
 		return err
 	}

--- a/go/vt/mysqlctl/replication.go
+++ b/go/vt/mysqlctl/replication.go
@@ -42,7 +42,7 @@ import (
 func WaitForReplicationStart(mysqld MysqlDaemon, replicaStartDeadline int) error {
 	var rowMap map[string]string
 	for replicaWait := 0; replicaWait < replicaStartDeadline; replicaWait++ {
-		status, err := mysqld.ReplicationStatus()
+		status, err := mysqld.ReplicationStatus(context.TODO())
 		if err != nil {
 			return err
 		}
@@ -270,8 +270,8 @@ func (mysqld *Mysqld) WaitSourcePos(ctx context.Context, targetPos mysql.Positio
 }
 
 // ReplicationStatus returns the server replication status
-func (mysqld *Mysqld) ReplicationStatus() (mysql.ReplicationStatus, error) {
-	conn, err := getPoolReconnect(context.TODO(), mysqld.dbaPool)
+func (mysqld *Mysqld) ReplicationStatus(ctx context.Context) (mysql.ReplicationStatus, error) {
+	conn, err := getPoolReconnect(ctx, mysqld.dbaPool)
 	if err != nil {
 		return mysql.ReplicationStatus{}, err
 	}

--- a/go/vt/mysqlctl/replication.go
+++ b/go/vt/mysqlctl/replication.go
@@ -69,7 +69,7 @@ func WaitForReplicationStart(mysqld MysqlDaemon, replicaStartDeadline int) error
 // StartReplication starts replication.
 func (mysqld *Mysqld) StartReplication(hookExtraEnv map[string]string) error {
 	ctx := context.TODO()
-	conn, err := getPoolReconnect(ctx, mysqld.dbaPool)
+	conn, err := mysqld.getPoolReconnect(ctx)
 	if err != nil {
 		return err
 	}
@@ -86,7 +86,7 @@ func (mysqld *Mysqld) StartReplication(hookExtraEnv map[string]string) error {
 
 // StartReplicationUntilAfter starts replication until replication has come to `targetPos`, then it stops replication
 func (mysqld *Mysqld) StartReplicationUntilAfter(ctx context.Context, targetPos mysql.Position) error {
-	conn, err := getPoolReconnect(ctx, mysqld.dbaPool)
+	conn, err := mysqld.getPoolReconnect(ctx)
 	if err != nil {
 		return err
 	}
@@ -105,7 +105,7 @@ func (mysqld *Mysqld) StopReplication(hookExtraEnv map[string]string) error {
 		return err
 	}
 	ctx := context.TODO()
-	conn, err := getPoolReconnect(ctx, mysqld.dbaPool)
+	conn, err := mysqld.getPoolReconnect(ctx)
 	if err != nil {
 		return err
 	}
@@ -116,7 +116,7 @@ func (mysqld *Mysqld) StopReplication(hookExtraEnv map[string]string) error {
 
 // StopIOThread stops a replica's IO thread only.
 func (mysqld *Mysqld) StopIOThread(ctx context.Context) error {
-	conn, err := getPoolReconnect(ctx, mysqld.dbaPool)
+	conn, err := mysqld.getPoolReconnect(ctx)
 	if err != nil {
 		return err
 	}
@@ -133,7 +133,7 @@ func (mysqld *Mysqld) RestartReplication(hookExtraEnv map[string]string) error {
 		return err
 	}
 	ctx := context.TODO()
-	conn, err := getPoolReconnect(ctx, mysqld.dbaPool)
+	conn, err := mysqld.getPoolReconnect(ctx)
 	if err != nil {
 		return err
 	}
@@ -204,7 +204,7 @@ func (mysqld *Mysqld) SetSuperReadOnly(on bool) error {
 // WaitSourcePos lets replicas wait to given replication position
 func (mysqld *Mysqld) WaitSourcePos(ctx context.Context, targetPos mysql.Position) error {
 	// Get a connection.
-	conn, err := getPoolReconnect(ctx, mysqld.dbaPool)
+	conn, err := mysqld.getPoolReconnect(ctx)
 	if err != nil {
 		return err
 	}
@@ -271,7 +271,7 @@ func (mysqld *Mysqld) WaitSourcePos(ctx context.Context, targetPos mysql.Positio
 
 // ReplicationStatus returns the server replication status
 func (mysqld *Mysqld) ReplicationStatus(ctx context.Context) (mysql.ReplicationStatus, error) {
-	conn, err := getPoolReconnect(ctx, mysqld.dbaPool)
+	conn, err := mysqld.getPoolReconnect(ctx)
 	if err != nil {
 		return mysql.ReplicationStatus{}, err
 	}
@@ -282,7 +282,7 @@ func (mysqld *Mysqld) ReplicationStatus(ctx context.Context) (mysql.ReplicationS
 
 // PrimaryStatus returns the primary replication statuses
 func (mysqld *Mysqld) PrimaryStatus(ctx context.Context) (mysql.PrimaryStatus, error) {
-	conn, err := getPoolReconnect(ctx, mysqld.dbaPool)
+	conn, err := mysqld.getPoolReconnect(ctx)
 	if err != nil {
 		return mysql.PrimaryStatus{}, err
 	}
@@ -293,7 +293,7 @@ func (mysqld *Mysqld) PrimaryStatus(ctx context.Context) (mysql.PrimaryStatus, e
 
 // PrimaryPosition returns the primary replication position.
 func (mysqld *Mysqld) PrimaryPosition() (mysql.Position, error) {
-	conn, err := getPoolReconnect(context.TODO(), mysqld.dbaPool)
+	conn, err := mysqld.getPoolReconnect(context.TODO())
 	if err != nil {
 		return mysql.Position{}, err
 	}
@@ -305,7 +305,7 @@ func (mysqld *Mysqld) PrimaryPosition() (mysql.Position, error) {
 // SetReplicationPosition sets the replication position at which the replica will resume
 // when its replication is started.
 func (mysqld *Mysqld) SetReplicationPosition(ctx context.Context, pos mysql.Position) error {
-	conn, err := getPoolReconnect(ctx, mysqld.dbaPool)
+	conn, err := mysqld.getPoolReconnect(ctx)
 	if err != nil {
 		return err
 	}
@@ -323,7 +323,7 @@ func (mysqld *Mysqld) SetReplicationSource(ctx context.Context, host string, por
 	if err != nil {
 		return err
 	}
-	conn, err := getPoolReconnect(ctx, mysqld.dbaPool)
+	conn, err := mysqld.getPoolReconnect(ctx)
 	if err != nil {
 		return err
 	}
@@ -347,7 +347,7 @@ func (mysqld *Mysqld) SetReplicationSource(ctx context.Context, host string, por
 
 // ResetReplication resets all replication for this host.
 func (mysqld *Mysqld) ResetReplication(ctx context.Context) error {
-	conn, connErr := getPoolReconnect(ctx, mysqld.dbaPool)
+	conn, connErr := mysqld.getPoolReconnect(ctx)
 	if connErr != nil {
 		return connErr
 	}
@@ -416,7 +416,7 @@ func FindReplicas(mysqld MysqlDaemon) ([]string, error) {
 // Whatever it does for a given flavor, it must be idempotent.
 func (mysqld *Mysqld) EnableBinlogPlayback() error {
 	// Get a connection.
-	conn, err := getPoolReconnect(context.TODO(), mysqld.dbaPool)
+	conn, err := mysqld.getPoolReconnect(context.TODO())
 	if err != nil {
 		return err
 	}
@@ -440,7 +440,7 @@ func (mysqld *Mysqld) EnableBinlogPlayback() error {
 // Whatever it does for a given flavor, it must be idempotent.
 func (mysqld *Mysqld) DisableBinlogPlayback() error {
 	// Get a connection.
-	conn, err := getPoolReconnect(context.TODO(), mysqld.dbaPool)
+	conn, err := mysqld.getPoolReconnect(context.TODO())
 	if err != nil {
 		return err
 	}

--- a/go/vt/mysqlctl/schema.go
+++ b/go/vt/mysqlctl/schema.go
@@ -268,7 +268,7 @@ func ResolveTables(ctx context.Context, mysqld MysqlDaemon, dbName string, table
 
 // GetColumns returns the columns of table.
 func (mysqld *Mysqld) GetColumns(ctx context.Context, dbName, table string) ([]*querypb.Field, []string, error) {
-	conn, err := mysqld.getPoolReconnect(ctx)
+	conn, err := mysqld.getPoolReconnect(ctx, mysqld.dbaPool)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -298,7 +298,7 @@ func (mysqld *Mysqld) GetPrimaryKeyColumns(ctx context.Context, dbName, table st
 }
 
 func (mysqld *Mysqld) getPrimaryKeyColumns(ctx context.Context, dbName string, tables ...string) (map[string][]string, error) {
-	conn, err := mysqld.getPoolReconnect(ctx)
+	conn, err := mysqld.getPoolReconnect(ctx, mysqld.dbaPool)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/mysqlctl/schema.go
+++ b/go/vt/mysqlctl/schema.go
@@ -268,7 +268,7 @@ func ResolveTables(ctx context.Context, mysqld MysqlDaemon, dbName string, table
 
 // GetColumns returns the columns of table.
 func (mysqld *Mysqld) GetColumns(ctx context.Context, dbName, table string) ([]*querypb.Field, []string, error) {
-	conn, err := getPoolReconnect(ctx, mysqld.dbaPool)
+	conn, err := mysqld.getPoolReconnect(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -298,7 +298,7 @@ func (mysqld *Mysqld) GetPrimaryKeyColumns(ctx context.Context, dbName, table st
 }
 
 func (mysqld *Mysqld) getPrimaryKeyColumns(ctx context.Context, dbName string, tables ...string) (map[string][]string, error) {
-	conn, err := getPoolReconnect(ctx, mysqld.dbaPool)
+	conn, err := mysqld.getPoolReconnect(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vttablet/tabletmanager/restore.go
+++ b/go/vt/vttablet/tabletmanager/restore.go
@@ -570,7 +570,7 @@ func (tm *TabletManager) startReplication(ctx context.Context, pos mysql.Positio
 			if err := ctx.Err(); err != nil {
 				return err
 			}
-			status, err := tm.MysqlDaemon.ReplicationStatus(context.TODO())
+			status, err := tm.MysqlDaemon.ReplicationStatus(ctx)
 			if err != nil {
 				return vterrors.Wrap(err, "can't get replication status")
 			}

--- a/go/vt/vttablet/tabletmanager/restore.go
+++ b/go/vt/vttablet/tabletmanager/restore.go
@@ -570,7 +570,7 @@ func (tm *TabletManager) startReplication(ctx context.Context, pos mysql.Positio
 			if err := ctx.Err(); err != nil {
 				return err
 			}
-			status, err := tm.MysqlDaemon.ReplicationStatus()
+			status, err := tm.MysqlDaemon.ReplicationStatus(context.TODO())
 			if err != nil {
 				return vterrors.Wrap(err, "can't get replication status")
 			}

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -44,7 +44,7 @@ var (
 
 // ReplicationStatus returns the replication status
 func (tm *TabletManager) ReplicationStatus(ctx context.Context) (*replicationdatapb.Status, error) {
-	status, err := tm.MysqlDaemon.ReplicationStatus()
+	status, err := tm.MysqlDaemon.ReplicationStatus(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -581,7 +581,7 @@ func (tm *TabletManager) setReplicationSourceLocked(ctx context.Context, parentA
 	// See if we were replicating at all, and should be replicating.
 	wasReplicating := false
 	shouldbeReplicating := false
-	status, err := tm.MysqlDaemon.ReplicationStatus()
+	status, err := tm.MysqlDaemon.ReplicationStatus(ctx)
 	if err == mysql.ErrNotReplica {
 		// This is a special error that means we actually succeeded in reading
 		// the status, but the status is empty because replication is not
@@ -697,7 +697,7 @@ func (tm *TabletManager) StopReplicationAndGetStatus(ctx context.Context, stopRe
 	// Get the status before we stop replication.
 	// Doing this first allows us to return the status in the case that stopping replication
 	// returns an error, so a user can optionally inspect the status before a stop was called.
-	rs, err := tm.MysqlDaemon.ReplicationStatus()
+	rs, err := tm.MysqlDaemon.ReplicationStatus(ctx)
 	if err != nil {
 		return StopReplicationAndGetStatusResponse{}, vterrors.Wrap(err, "before status failed")
 	}
@@ -741,7 +741,7 @@ func (tm *TabletManager) StopReplicationAndGetStatus(ctx context.Context, stopRe
 	}
 
 	// Get the status after we stop replication so we have up to date position and relay log positions.
-	rsAfter, err := tm.MysqlDaemon.ReplicationStatus()
+	rsAfter, err := tm.MysqlDaemon.ReplicationStatus(ctx)
 	if err != nil {
 		return StopReplicationAndGetStatusResponse{
 			Status: &replicationdatapb.StopReplicationStatus{
@@ -863,7 +863,7 @@ func (tm *TabletManager) fixSemiSyncAndReplication(tabletType topodatapb.TabletT
 	// If replication is running, but the status is wrong,
 	// we should restart replication. First, let's make sure
 	// replication is running.
-	status, err := tm.MysqlDaemon.ReplicationStatus()
+	status, err := tm.MysqlDaemon.ReplicationStatus(context.TODO())
 	if err != nil {
 		// Replication is not configured, nothing to do.
 		return nil

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -863,7 +863,8 @@ func (tm *TabletManager) fixSemiSyncAndReplication(tabletType topodatapb.TabletT
 	// If replication is running, but the status is wrong,
 	// we should restart replication. First, let's make sure
 	// replication is running.
-	status, err := tm.MysqlDaemon.ReplicationStatus(context.TODO())
+	ctx := context.TODO()
+	status, err := tm.MysqlDaemon.ReplicationStatus(ctx)
 	if err != nil {
 		// Replication is not configured, nothing to do.
 		return nil

--- a/go/vt/vttablet/tabletserver/repltracker/poller.go
+++ b/go/vt/vttablet/tabletserver/repltracker/poller.go
@@ -17,6 +17,7 @@ limitations under the License.
 package repltracker
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -45,7 +46,11 @@ func (p *poller) Status() (time.Duration, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	status, err := p.mysqld.ReplicationStatus()
+	// TODO: how long to timeout?
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*5)
+	defer cancel()
+
+	status, err := p.mysqld.ReplicationStatus(ctx)
 	if err != nil {
 		return 0, err
 	}

--- a/go/vt/vttablet/tabletserver/repltracker/poller.go
+++ b/go/vt/vttablet/tabletserver/repltracker/poller.go
@@ -47,7 +47,7 @@ func (p *poller) Status() (time.Duration, error) {
 	defer p.mu.Unlock()
 
 	// TODO: how long to timeout?
-	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*5)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
 	status, err := p.mysqld.ReplicationStatus(ctx)


### PR DESCRIPTION
## Description

This PR hopes to address https://github.com/vitessio/vitess/issues/11884 by adding a `context`-based timeout to `.ReplicationStatus()` method of `MysqlDaemon` _(in `go/vt/mysqlctl`)_

The lack of this timeout causes queries to be routed to unhealthy tablets in some situations

## Related Issue(s)

https://github.com/vitessio/vitess/issues/11884

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
