### PR TITLE
`slack-vitess-r14.0.5-dsdefense`: add `Uptime` metric (#12712)

### DIFF
--- a/go/vt/servenv/servenv.go
+++ b/go/vt/servenv/servenv.go
@@ -91,6 +91,11 @@ func Init() {
 		return int64(time.Since(serverStart).Nanoseconds())
 	})
 
+	// Uptime metric
+	_ = stats.NewGaugeFunc("Uptime", "Uptime in nanoseconds", func() int64 {
+		return int64(time.Since(serverStart).Nanoseconds())
+	})
+
 	// Ignore SIGPIPE if specified
 	// The Go runtime catches SIGPIPE for us on all fds except stdout/stderr
 	// See https://golang.org/pkg/os/signal/#hdr-SIGPIPE


### PR DESCRIPTION
## Description

* Add `Uptime` metric to `vtgate`+`vttablet`

## Related Issue(s)

https://github.com/vitessio/vitess/pull/12712

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
