### PR TITLE
check keyspace snapshot time for restore

### DIFF
--- a/.github/workflows/cluster_endtoend_xb_recovery_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery_mysql57.yml
@@ -58,7 +58,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19.3
+        go-version: 1.18.7
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'

--- a/go/test/endtoend/recovery/recovery_util.go
+++ b/go/test/endtoend/recovery/recovery_util.go
@@ -51,18 +51,21 @@ func VerifyQueriesUsingVtgate(t *testing.T, session *vtgateconn.VTGateSession, q
 }
 
 // RestoreTablet performs a PITR restore.
-func RestoreTablet(t *testing.T, localCluster *cluster.LocalProcessCluster, tablet *cluster.Vttablet, restoreKSName string, shardName string, keyspaceName string, commonTabletArg []string) {
+func RestoreTablet(t *testing.T, localCluster *cluster.LocalProcessCluster, tablet *cluster.Vttablet, restoreKSName string, shardName string, keyspaceName string, commonTabletArg []string, backupTime time.Time) {
 	tablet.ValidateTabletRestart(t)
 	replicaTabletArgs := commonTabletArg
 
 	_, err := localCluster.VtctlProcess.ExecuteCommandWithOutput("GetKeyspace", restoreKSName)
 
 	if err != nil {
-		tm := time.Now().UTC()
-		tm.Format(time.RFC3339)
+		if backupTime.IsZero() {
+			backupTime = time.Now().UTC()
+		}
+		backupTime.Format(time.RFC3339)
+
 		_, err := localCluster.VtctlProcess.ExecuteCommandWithOutput("CreateKeyspace", "--",
 			"--keyspace_type=SNAPSHOT", "--base_keyspace="+keyspaceName,
-			"--snapshot_time", tm.Format(time.RFC3339), restoreKSName)
+			"--snapshot_time", backupTime.Format(time.RFC3339), restoreKSName)
 		require.Nil(t, err)
 	}
 

--- a/go/test/endtoend/recovery/recovery_util.go
+++ b/go/test/endtoend/recovery/recovery_util.go
@@ -51,21 +51,21 @@ func VerifyQueriesUsingVtgate(t *testing.T, session *vtgateconn.VTGateSession, q
 }
 
 // RestoreTablet performs a PITR restore.
-func RestoreTablet(t *testing.T, localCluster *cluster.LocalProcessCluster, tablet *cluster.Vttablet, restoreKSName string, shardName string, keyspaceName string, commonTabletArg []string, backupTime time.Time) {
+func RestoreTablet(t *testing.T, localCluster *cluster.LocalProcessCluster, tablet *cluster.Vttablet, restoreKSName string, shardName string, keyspaceName string, commonTabletArg []string, restoreTime time.Time) {
 	tablet.ValidateTabletRestart(t)
 	replicaTabletArgs := commonTabletArg
 
 	_, err := localCluster.VtctlProcess.ExecuteCommandWithOutput("GetKeyspace", restoreKSName)
 
 	if err != nil {
-		if backupTime.IsZero() {
-			backupTime = time.Now().UTC()
+		if restoreTime.IsZero() {
+			restoreTime = time.Now().UTC()
 		}
-		backupTime.Format(time.RFC3339)
+		restoreTime.Format(time.RFC3339)
 
 		_, err := localCluster.VtctlProcess.ExecuteCommandWithOutput("CreateKeyspace", "--",
 			"--keyspace_type=SNAPSHOT", "--base_keyspace="+keyspaceName,
-			"--snapshot_time", backupTime.Format(time.RFC3339), restoreKSName)
+			"--snapshot_time", restoreTime.Format(time.RFC3339), restoreKSName)
 		require.Nil(t, err)
 	}
 

--- a/go/test/endtoend/recovery/shardedrecovery/sharded_recovery_test.go
+++ b/go/test/endtoend/recovery/shardedrecovery/sharded_recovery_test.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -194,7 +195,7 @@ func TestUnShardedRecoveryAfterSharding(t *testing.T) {
 	require.NoError(t, err)
 
 	// now bring up the recovery keyspace and a tablet, letting it restore from backup.
-	recovery.RestoreTablet(t, localCluster, replica2, recoveryKS, "0", keyspaceName, commonTabletArg)
+	recovery.RestoreTablet(t, localCluster, replica2, recoveryKS, "0", keyspaceName, commonTabletAr, time.Time{})
 
 	// check the new replica does not have the data
 	cluster.VerifyRowsInTablet(t, replica2, keyspaceName, 2)
@@ -395,8 +396,8 @@ func TestShardedRecovery(t *testing.T) {
 	require.NoError(t, err)
 
 	// now bring up the recovery keyspace and 2 tablets, letting it restore from backup.
-	recovery.RestoreTablet(t, localCluster, replica2, recoveryKS, "-80", keyspaceName, commonTabletArg)
-	recovery.RestoreTablet(t, localCluster, replica3, recoveryKS, "80-", keyspaceName, commonTabletArg)
+	recovery.RestoreTablet(t, localCluster, replica2, recoveryKS, "-80", keyspaceName, commonTabletArg, time.Time{})
+	recovery.RestoreTablet(t, localCluster, replica3, recoveryKS, "80-", keyspaceName, commonTabletArg, time.Time{})
 
 	// check the new replicas have the correct number of rows
 	cluster.VerifyRowsInTablet(t, replica2, keyspaceName, shard0Count)

--- a/go/test/endtoend/recovery/shardedrecovery/sharded_recovery_test.go
+++ b/go/test/endtoend/recovery/shardedrecovery/sharded_recovery_test.go
@@ -195,7 +195,7 @@ func TestUnShardedRecoveryAfterSharding(t *testing.T) {
 	require.NoError(t, err)
 
 	// now bring up the recovery keyspace and a tablet, letting it restore from backup.
-	recovery.RestoreTablet(t, localCluster, replica2, recoveryKS, "0", keyspaceName, commonTabletAr, time.Time{})
+	recovery.RestoreTablet(t, localCluster, replica2, recoveryKS, "0", keyspaceName, commonTabletArg, time.Time{})
 
 	// check the new replica does not have the data
 	cluster.VerifyRowsInTablet(t, replica2, keyspaceName, 2)

--- a/go/test/endtoend/recovery/unshardedrecovery/recovery.go
+++ b/go/test/endtoend/recovery/unshardedrecovery/recovery.go
@@ -177,18 +177,23 @@ SET GLOBAL old_alter_table = ON;
 }
 
 // TestRecoveryImpl does following
-// - create a shard with primary and replica1 only
-// - run InitShardPrimary
-// - insert some data
-// - take a backup
-// - insert more data on the primary
-// - take another backup
-// - create a recovery keyspace after first backup
-// - bring up tablet_replica2 in the new keyspace
-// - check that new tablet does not have data created after backup1
-// - create second recovery keyspace after second backup
-// - bring up tablet_replica3 in second keyspace
-// - check that new tablet has data created after backup1 but not data created after backup2
+// 1. create a shard with primary and replica1 only
+// 	- run InitShardPrimary
+// 	- insert some data
+// 2. take a backup
+// 3.create a recovery keyspace after first backup
+// 	- bring up tablet_replica2 in the new keyspace
+// 	- check that new tablet has data from backup1
+// 4. insert more data on the primary
+// 5. take another backup
+// 6. create a recovery keyspace after second backup
+// 	- bring up tablet_replica3 in the new keyspace
+// 	- check that new tablet has data from backup2
+// 7. insert more data on the primary
+// 8. take another backup
+// 9. create a recovery keyspace after second backup again
+// 	- bring up tablet_replica4 in the new keyspace
+// 	- check that new tablet has data from backup2 but not backup3
 // - check that vtgate queries work correctly
 func TestRecoveryImpl(t *testing.T) {
 	defer cluster.PanicHandler(t)

--- a/go/test/endtoend/recovery/unshardedrecovery/recovery.go
+++ b/go/test/endtoend/recovery/unshardedrecovery/recovery.go
@@ -307,14 +307,7 @@ func TestRecoveryImpl(t *testing.T) {
 	recovery.VerifyQueriesUsingVtgate(t, session, "select count(*) from vt_insert_test", "INT64(1)")
 
 	cluster.ExecuteQueriesUsingVtgate(t, session, "use "+recoveryKS2+"@replica")
-	recovery.VerifyQueriesUsingVtgate(t, session, "select count(*) from vt_insert_test", "INT64(2)")
-
-	// check that new tablet is accessible with use `ks:shard`
-	cluster.ExecuteQueriesUsingVtgate(t, session, "use `"+recoveryKS1+":0@replica`")
 	recovery.VerifyQueriesUsingVtgate(t, session, "select count(*) from vt_insert_test", "INT64(1)")
-
-	cluster.ExecuteQueriesUsingVtgate(t, session, "use `"+recoveryKS2+":0@replica`")
-	recovery.VerifyQueriesUsingVtgate(t, session, "select count(*) from vt_insert_test", "INT64(2)")
 }
 
 // verifyInitialReplication will create schema in primary, insert some data to primary and verify the same data in replica.

--- a/go/test/endtoend/recovery/unshardedrecovery/recovery.go
+++ b/go/test/endtoend/recovery/unshardedrecovery/recovery.go
@@ -295,12 +295,12 @@ func TestRecoveryImpl(t *testing.T) {
 	session := vtgateConn.Session("@replica", nil)
 
 	//check that vtgate doesn't route queries to new tablet
-	recovery.VerifyQueriesUsingVtgate(t, session, "select count(*) from vt_insert_test", "INT64(3)")
-	recovery.VerifyQueriesUsingVtgate(t, session, "select msg from vt_insert_test where id = 1", `VARCHAR("msgx2")`)
+	recovery.VerifyQueriesUsingVtgate(t, session, "select count(*) from vt_insert_test", "INT64(2)")
+	recovery.VerifyQueriesUsingVtgate(t, session, "select msg from vt_insert_test where id = 1", `VARCHAR("msgx1")`)
 	recovery.VerifyQueriesUsingVtgate(t, session, fmt.Sprintf("select count(*) from %s.vt_insert_test", recoveryKS1), "INT64(1)")
 	recovery.VerifyQueriesUsingVtgate(t, session, fmt.Sprintf("select msg from %s.vt_insert_test where id = 1", recoveryKS1), `VARCHAR("test1")`)
-	recovery.VerifyQueriesUsingVtgate(t, session, fmt.Sprintf("select count(*) from %s.vt_insert_test", recoveryKS2), "INT64(2)")
-	recovery.VerifyQueriesUsingVtgate(t, session, fmt.Sprintf("select msg from %s.vt_insert_test where id = 1", recoveryKS2), `VARCHAR("msgx1")`)
+	recovery.VerifyQueriesUsingVtgate(t, session, fmt.Sprintf("select count(*) from %s.vt_insert_test", recoveryKS2), "INT64(1)")
+	recovery.VerifyQueriesUsingVtgate(t, session, fmt.Sprintf("select msg from %s.vt_insert_test where id = 1", recoveryKS2), `VARCHAR("test1")`)
 
 	// check that new keyspace is accessible with 'use ks'
 	cluster.ExecuteQueriesUsingVtgate(t, session, "use "+recoveryKS1+"@replica")

--- a/go/test/endtoend/recovery/unshardedrecovery/recovery.go
+++ b/go/test/endtoend/recovery/unshardedrecovery/recovery.go
@@ -253,6 +253,28 @@ func TestRecoveryImpl(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "msgx1", qr.Rows[0][0].ToString())
 
+	// check that replica1, used for the backup, has the new value
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for {
+		qr, err = replica1.VttabletProcess.QueryTablet("select msg from vt_insert_test where id = 1", keyspaceName, true)
+		assert.NoError(t, err)
+		if qr.Rows[0][0].ToString() == "msgx1" {
+			break
+		}
+
+		select {
+		case <-ctx.Done():
+			t.Error("timeout waiting for new value to be replicated on replica 1")
+			break
+		case <-ticker.C:
+		}
+	}
+
 	// take second backup of value = msgx1
 	err = localCluster.VtctlclientProcess.ExecuteCommand("Backup", replica1.Alias)
 	assert.NoError(t, err)

--- a/go/vt/vttablet/tabletmanager/restore.go
+++ b/go/vt/vttablet/tabletmanager/restore.go
@@ -154,11 +154,11 @@ func (tm *TabletManager) restoreDataLocked(ctx context.Context, logger logutil.L
 		return err
 	}
 
-	// If backupTime not specified in restore_from_backup_ts, check to see if the keyspace has a SNAPSHOT time
-	// to restore from (for PITR)
-	if backupTime.IsZero() {
-		backupTime = logutil.ProtoToTime(keyspaceInfo.SnapshotTime)
-	}
+	// // If backupTime not specified in restore_from_backup_ts, check to see if the keyspace has a SNAPSHOT time
+	// // to restore from (for PITR)
+	// if backupTime.IsZero() {
+	// 	backupTime = logutil.ProtoToTime(keyspaceInfo.SnapshotTime)
+	// }
 
 	// For a SNAPSHOT keyspace, we have to look for backups of BaseKeyspace
 	// so we will pass the BaseKeyspace in RestoreParams instead of tablet.Keyspace

--- a/go/vt/vttablet/tabletmanager/restore.go
+++ b/go/vt/vttablet/tabletmanager/restore.go
@@ -154,6 +154,12 @@ func (tm *TabletManager) restoreDataLocked(ctx context.Context, logger logutil.L
 		return err
 	}
 
+	// If backupTime not specified in restore_from_backup_ts, check to see if the keyspace has a SNAPSHOT time
+	// to restore from (for PITR)
+	if backupTime.IsZero() {
+		backupTime = logutil.ProtoToTime(keyspaceInfo.SnapshotTime)
+	}
+
 	// For a SNAPSHOT keyspace, we have to look for backups of BaseKeyspace
 	// so we will pass the BaseKeyspace in RestoreParams instead of tablet.Keyspace
 	if keyspaceInfo.KeyspaceType == topodatapb.KeyspaceType_SNAPSHOT {

--- a/go/vt/vttablet/tabletmanager/restore.go
+++ b/go/vt/vttablet/tabletmanager/restore.go
@@ -154,11 +154,11 @@ func (tm *TabletManager) restoreDataLocked(ctx context.Context, logger logutil.L
 		return err
 	}
 
-	// // If backupTime not specified in restore_from_backup_ts, check to see if the keyspace has a SNAPSHOT time
-	// // to restore from (for PITR)
-	// if backupTime.IsZero() {
-	// 	backupTime = logutil.ProtoToTime(keyspaceInfo.SnapshotTime)
-	// }
+	// If backupTime not specified in restore_from_backup_ts, check to see if the keyspace has a SNAPSHOT time
+	// to restore from (for PITR)
+	if backupTime.IsZero() {
+		backupTime = logutil.ProtoToTime(keyspaceInfo.SnapshotTime)
+	}
 
 	// For a SNAPSHOT keyspace, we have to look for backups of BaseKeyspace
 	// so we will pass the BaseKeyspace in RestoreParams instead of tablet.Keyspace


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

Snapshot restores are no longer restoring from the backup before or at the snapshot time. Regression introduced here: https://github.com/vitessio/vitess/pull/8824

This is breaking our PITR workflow. v14 is no longer supported upstream so adding the fix in our fork. Opened an [issue](https://github.com/vitessio/vitess/issues/13556) and [PR](https://github.com/vitessio/vitess/pull/13557) upstream, but in discussion about the eventual deprecation of snapshot keyspaces in favor of [incremental backups/restores](https://github.com/vitessio/vitess/issues/11227).


## Testing

Before, PITR tablets always restoring to latest backup 

After:
```
pbibra@tablet-iad-dev-pitrincd1234loadtest-80-00-fsmq:~$ cat /mnt/vitess/vttablet/log/vttablet.log | grep found
I0718 12:08:11.547793   30934 backup.go:256] Restore: No restore_in_progress file found, checking no existing data is present
I0718 12:08:11.913137   30934 backupengine.go:223] Restore: found backup loadtest/80- 2023-07-15.110009.us_east_1c-0173597869 to restore using the specified timestamp of '2023-07-15.150000'
```

Also modified the existing `TestRestoreImpl` to properly check for custom backup times. 

Before: 
<img width="1292" alt="Screenshot 2023-07-24 at 9 10 00 AM" src="https://github.com/slackhq/vitess/assets/15112506/f3e4009a-8ee0-49f1-a930-d1d002714e7f">

After: CI passes
