### PR TITLE
`slack-vitess-r12.0.5`: allow conn overrides in consul topo

### DIFF
--- a/go/vt/topo/consultopo/server.go
+++ b/go/vt/topo/consultopo/server.go
@@ -37,11 +37,15 @@ import (
 )
 
 var (
+	defaultTransportConfig     = api.DefaultConfig().Transport
 	consulAuthClientStaticFile = flag.String("consul_auth_static_file", "", "JSON File to read the topos/tokens from.")
 	// serfHealth is the default check from consul
 	consulLockSessionChecks = flag.String("topo_consul_lock_session_checks", "serfHealth", "List of checks for consul session.")
 	consulLockSessionTTL    = flag.String("topo_consul_lock_session_ttl", "", "TTL for consul session.")
 	consulLockDelay         = flag.Duration("topo_consul_lock_delay", 15*time.Second, "LockDelay for consul session.")
+	consulMaxConnsPerHost   = flag.Int("topo_consul_max_conns_per_host", defaultTransportConfig.MaxConnsPerHost, "Maximum number of consul connections per host.")
+	consulMaxIdleConns      = flag.Int("topo_consul_max_idle_conns", defaultTransportConfig.MaxIdleConns, "Maximum number of idle consul connections.")
+	consulIdleConnTimeout   = flag.Duration("topo_consul_idle_conn_timeout", defaultTransportConfig.IdleConnTimeout, "Maximum amount of time to pool idle connections.")
 )
 
 // ClientAuthCred credential to use for consul clusters
@@ -129,6 +133,10 @@ func NewServer(cell, serverAddr, root string) (*Server, error) {
 			log.Warningf("Client auth not configured for cell: %v", cell)
 		}
 	}
+
+	cfg.Transport.MaxConnsPerHost = *consulMaxConnsPerHost
+	cfg.Transport.MaxIdleConns = *consulMaxIdleConns
+	cfg.Transport.IdleConnTimeout = *consulIdleConnTimeout
 
 	client, err := api.NewClient(cfg)
 	if err != nil {

--- a/go/vt/topo/consultopo/server.go
+++ b/go/vt/topo/consultopo/server.go
@@ -37,16 +37,19 @@ import (
 )
 
 var (
-	defaultTransportConfig     = api.DefaultConfig().Transport
+	consulTransportConfig      = api.DefaultConfig().Transport
 	consulAuthClientStaticFile = flag.String("consul_auth_static_file", "", "JSON File to read the topos/tokens from.")
 	// serfHealth is the default check from consul
 	consulLockSessionChecks = flag.String("topo_consul_lock_session_checks", "serfHealth", "List of checks for consul session.")
 	consulLockSessionTTL    = flag.String("topo_consul_lock_session_ttl", "", "TTL for consul session.")
 	consulLockDelay         = flag.Duration("topo_consul_lock_delay", 15*time.Second, "LockDelay for consul session.")
-	consulMaxConnsPerHost   = flag.Int("topo_consul_max_conns_per_host", defaultTransportConfig.MaxConnsPerHost, "Maximum number of consul connections per host.")
-	consulMaxIdleConns      = flag.Int("topo_consul_max_idle_conns", defaultTransportConfig.MaxIdleConns, "Maximum number of idle consul connections.")
-	consulIdleConnTimeout   = flag.Duration("topo_consul_idle_conn_timeout", defaultTransportConfig.IdleConnTimeout, "Maximum amount of time to pool idle connections.")
 )
+
+func init() {
+	flag.IntVar(&consulTransportConfig.MaxConnsPerHost, "topo_consul_max_conns_per_host", consulTransportConfig.MaxConnsPerHost, "Maximum number of consul connections per host.")
+	flag.IntVar(&consulTransportConfig.MaxIdleConns, "topo_consul_max_idle_conns", consulTransportConfig.MaxIdleConns, "Maximum number of idle consul connections.")
+	flag.DurationVar(&consulTransportConfig.IdleConnTimeout, "topo_consul_idle_conn_timeout", consulTransportConfig.IdleConnTimeout, "Maximum amount of time to pool idle connections.")
+}
 
 // ClientAuthCred credential to use for consul clusters
 type ClientAuthCred struct {
@@ -126,6 +129,7 @@ func NewServer(cell, serverAddr, root string) (*Server, error) {
 	}
 	cfg := api.DefaultConfig()
 	cfg.Address = serverAddr
+	cfg.Transport = consulTransportConfig
 	if creds != nil {
 		if creds[cell] != nil {
 			cfg.Token = creds[cell].ACLToken
@@ -133,10 +137,6 @@ func NewServer(cell, serverAddr, root string) (*Server, error) {
 			log.Warningf("Client auth not configured for cell: %v", cell)
 		}
 	}
-
-	cfg.Transport.MaxConnsPerHost = *consulMaxConnsPerHost
-	cfg.Transport.MaxIdleConns = *consulMaxIdleConns
-	cfg.Transport.IdleConnTimeout = *consulIdleConnTimeout
 
 	client, err := api.NewClient(cfg)
 	if err != nil {

--- a/go/vt/topo/consultopo/server.go
+++ b/go/vt/topo/consultopo/server.go
@@ -30,14 +30,13 @@ import (
 
 	"github.com/hashicorp/consul/api"
 
-	"vitess.io/vitess/go/vt/vterrors"
-
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/vterrors"
 )
 
 var (
-	consulTransportConfig      = api.DefaultConfig().Transport
+	consulConfig               = api.DefaultConfig()
 	consulAuthClientStaticFile = flag.String("consul_auth_static_file", "", "JSON File to read the topos/tokens from.")
 	// serfHealth is the default check from consul
 	consulLockSessionChecks = flag.String("topo_consul_lock_session_checks", "serfHealth", "List of checks for consul session.")
@@ -46,9 +45,9 @@ var (
 )
 
 func init() {
-	flag.IntVar(&consulTransportConfig.MaxConnsPerHost, "topo_consul_max_conns_per_host", consulTransportConfig.MaxConnsPerHost, "Maximum number of consul connections per host.")
-	flag.IntVar(&consulTransportConfig.MaxIdleConns, "topo_consul_max_idle_conns", consulTransportConfig.MaxIdleConns, "Maximum number of idle consul connections.")
-	flag.DurationVar(&consulTransportConfig.IdleConnTimeout, "topo_consul_idle_conn_timeout", consulTransportConfig.IdleConnTimeout, "Maximum amount of time to pool idle connections.")
+	flag.IntVar(&consulConfig.Transport.MaxConnsPerHost, "topo_consul_max_conns_per_host", consulConfig.Transport.MaxConnsPerHost, "Maximum number of consul connections per host.")
+	flag.IntVar(&consulConfig.Transport.MaxIdleConns, "topo_consul_max_idle_conns", consulConfig.Transport.MaxIdleConns, "Maximum number of idle consul connections.")
+	flag.DurationVar(&consulConfig.Transport.IdleConnTimeout, "topo_consul_idle_conn_timeout", consulConfig.Transport.IdleConnTimeout, "Maximum amount of time to pool idle connections.")
 }
 
 // ClientAuthCred credential to use for consul clusters
@@ -127,9 +126,8 @@ func NewServer(cell, serverAddr, root string) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
-	cfg := api.DefaultConfig()
+	cfg := consulConfig
 	cfg.Address = serverAddr
-	cfg.Transport = consulTransportConfig
 	if creds != nil {
 		if creds[cell] != nil {
 			cfg.Token = creds[cell].ACLToken


### PR DESCRIPTION
## Description

This PR allows overrides to `http.Transport` settings of the Consul topo client

This is to help address crashes we're seeing when too many consul connections are opened by vtctld

`vtctld --help`:
```
tvaillancourt@tvailla-ltmxctu vitess % ./vtctld --help 2>&1|grep -A1 topo_consul
  -topo_consul_idle_conn_timeout duration
    	Maximum amount of time to pool idle connections. (default 1m30s)
  -topo_consul_lock_delay duration
    	LockDelay for consul session. (default 15s)
  -topo_consul_lock_session_checks string
    	List of checks for consul session. (default "serfHealth")
  -topo_consul_lock_session_ttl string
    	TTL for consul session.
  -topo_consul_max_conns_per_host int
    	Maximum number of consul connections per host.
  -topo_consul_max_idle_conns int
    	Maximum number of idle consul connections. (default 100)
  -topo_consul_watch_poll_duration duration
    	time of the long poll for watch queries. (default 30s)
```

cc @rvrangel

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
