### PR TITLE
`slack-vitess-r14.0.5`: allow conn overrides in consul topo

### DIFF
--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -335,12 +335,18 @@ Usage of vtgate:
 	wait till connected for specified tablet types during Gateway initialization
   --tablet_url_template string
 	format string describing debug tablet url formatting. See the Go code for getTabletDebugURL() how to customize this. (default http://{{.GetTabletHostPort}})
+  --topo_consul_idle_conn_timeout duration
+	Maximum amount of time to pool idle connections. (default 1m30s)
   --topo_consul_lock_delay duration
 	LockDelay for consul session. (default 15s)
   --topo_consul_lock_session_checks string
 	List of checks for consul session. (default serfHealth)
   --topo_consul_lock_session_ttl string
 	TTL for consul session.
+  --topo_consul_max_conns_per_host int
+	Maximum number of consul connections per host.
+  --topo_consul_max_idle_conns int
+	Maximum number of idle consul connections. (default 100)
   --topo_consul_watch_poll_duration duration
 	time of the long poll for watch queries. (default 30s)
   --topo_etcd_lease_ttl int

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -847,12 +847,18 @@ Usage of vttablet:
 	Comma separated VTTablet types to be considered by the throttler. default: 'replica'. example: 'replica,rdonly'. 'replica' aways implicitly included (default replica)
   --throttle_threshold duration
 	Replication lag threshold for default lag throttling (default 1s)
+  --topo_consul_idle_conn_timeout duration
+	Maximum amount of time to pool idle connections. (default 1m30s)
   --topo_consul_lock_delay duration
 	LockDelay for consul session. (default 15s)
   --topo_consul_lock_session_checks string
 	List of checks for consul session. (default serfHealth)
   --topo_consul_lock_session_ttl string
 	TTL for consul session.
+  --topo_consul_max_conns_per_host int
+	Maximum number of consul connections per host.
+  --topo_consul_max_idle_conns int
+	Maximum number of idle consul connections. (default 100)
   --topo_consul_watch_poll_duration duration
 	time of the long poll for watch queries. (default 30s)
   --topo_etcd_lease_ttl int


### PR DESCRIPTION
## Description

This PR is a copy of the v12 PR https://github.com/slackhq/vitess/pull/108

This adds flags to tune the connection usage of the consul topo

cc @vmogilev / @rvrangel / @ejortegau 

## Related Issue(s)

https://github.com/slackhq/vitess/pull/108

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
