### PR TITLE
Ejortegau/larger runners

### DIFF
--- a/.github/workflows/cluster_endtoend_12.yml
+++ b/.github/workflows/cluster_endtoend_12.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (12)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_12.yml
+++ b/.github/workflows/cluster_endtoend_12.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (12)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_12.yml
+++ b/.github/workflows/cluster_endtoend_12.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (12)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_12.yml
+++ b/.github/workflows/cluster_endtoend_12.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (12)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (13)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (13)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (13)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (13)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (15)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (15)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (15)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (15)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_18.yml
+++ b/.github/workflows/cluster_endtoend_18.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (18)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_18.yml
+++ b/.github/workflows/cluster_endtoend_18.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (18)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_18.yml
+++ b/.github/workflows/cluster_endtoend_18.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (18)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_18.yml
+++ b/.github/workflows/cluster_endtoend_18.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (18)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_19.yml
+++ b/.github/workflows/cluster_endtoend_19.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (19)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_19.yml
+++ b/.github/workflows/cluster_endtoend_19.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (19)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_19.yml
+++ b/.github/workflows/cluster_endtoend_19.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (19)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_19.yml
+++ b/.github/workflows/cluster_endtoend_19.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (19)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (21)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (21)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (21)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (21)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (22)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (22)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (22)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (22)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_24.yml
+++ b/.github/workflows/cluster_endtoend_24.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (24)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_24.yml
+++ b/.github/workflows/cluster_endtoend_24.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (24)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_24.yml
+++ b/.github/workflows/cluster_endtoend_24.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (24)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_24.yml
+++ b/.github/workflows/cluster_endtoend_24.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (24)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_26.yml
+++ b/.github/workflows/cluster_endtoend_26.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (26)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_26.yml
+++ b/.github/workflows/cluster_endtoend_26.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (26)
-    runs-on: ubuntu-20.04
+    runs-on:
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
+++ b/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (ers_prs_newfeatures_heavy)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
+++ b/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (ers_prs_newfeatures_heavy)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
+++ b/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (ers_prs_newfeatures_heavy)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
+++ b/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (ers_prs_newfeatures_heavy)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
+++ b/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
@@ -9,8 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (ers_prs_newfeatures_heavy)
-    runs-on:
-      group: vitess-ubuntu20
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_mysql57.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (mysql57)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_mysql57.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (mysql57)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_mysql57.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (mysql57)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_mysql57.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (mysql57)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_mysql80.yml
+++ b/.github/workflows/cluster_endtoend_mysql80.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (mysql80)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_mysql80.yml
+++ b/.github/workflows/cluster_endtoend_mysql80.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (mysql80)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_mysql80.yml
+++ b/.github/workflows/cluster_endtoend_mysql80.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (mysql80)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_mysql80.yml
+++ b/.github/workflows/cluster_endtoend_mysql80.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (mysql80)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_declarative)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_declarative)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_declarative)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_declarative)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative_mysql57.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_declarative) mysql57
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative_mysql57.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_declarative) mysql57
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative_mysql57.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_declarative) mysql57
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative_mysql57.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_declarative) mysql57
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_ghost)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_ghost)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_ghost)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_ghost)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost_mysql57.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_ghost) mysql57
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost_mysql57.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_ghost) mysql57
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost_mysql57.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_ghost) mysql57
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost_mysql57.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_ghost) mysql57
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_revert)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_revert)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_revert)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_revert)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_revert_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert_mysql57.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_revert) mysql57
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_revert_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert_mysql57.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_revert) mysql57
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_revert_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert_mysql57.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_revert) mysql57
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_revert_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert_mysql57.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_revert) mysql57
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_revertible)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_revertible)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_revertible)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_revertible)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_revertible_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revertible_mysql57.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_revertible) mysql57
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_revertible_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revertible_mysql57.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_revertible) mysql57
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_revertible_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revertible_mysql57.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_revertible) mysql57
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_revertible_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revertible_mysql57.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_revertible) mysql57
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_scheduler)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_scheduler)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_scheduler)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_scheduler)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler_mysql57.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_scheduler) mysql57
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler_mysql57.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_scheduler) mysql57
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler_mysql57.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_scheduler) mysql57
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler_mysql57.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_scheduler) mysql57
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_singleton)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_singleton)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_singleton)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_singleton)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton_mysql57.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_singleton) mysql57
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton_mysql57.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_singleton) mysql57
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton_mysql57.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_singleton) mysql57
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton_mysql57.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_singleton) mysql57
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped
@@ -96,7 +96,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: nick-fields/retry@v2
       with:
-        timeout_minutes: 60
+        timeout_minutes: 45
         max_attempts: 3
         retry_on: error
         command: |

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_mysql57.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl) mysql57
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_mysql57.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl) mysql57
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_mysql57.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl) mysql57
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_mysql57.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl) mysql57
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_stress)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_stress)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_stress)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_stress)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_mysql57.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_stress) mysql57
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_mysql57.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_stress) mysql57
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_mysql57.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_stress) mysql57
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_mysql57.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_stress) mysql57
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_stress_suite)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_stress_suite)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_stress_suite)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_stress_suite)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite_mysql57.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_stress_suite) mysql57
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite_mysql57.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_stress_suite) mysql57
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite_mysql57.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_stress_suite) mysql57
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite_mysql57.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_stress_suite) mysql57
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_suite)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_suite)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_suite)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_suite)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite_mysql57.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_suite) mysql57
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite_mysql57.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_suite) mysql57
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite_mysql57.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_suite) mysql57
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite_mysql57.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_suite) mysql57
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_resharding.yml
+++ b/.github/workflows/cluster_endtoend_resharding.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (resharding)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_resharding.yml
+++ b/.github/workflows/cluster_endtoend_resharding.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (resharding)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_resharding.yml
+++ b/.github/workflows/cluster_endtoend_resharding.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (resharding)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_resharding.yml
+++ b/.github/workflows/cluster_endtoend_resharding.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (resharding)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_resharding_bytes.yml
+++ b/.github/workflows/cluster_endtoend_resharding_bytes.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (resharding_bytes)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_resharding_bytes.yml
+++ b/.github/workflows/cluster_endtoend_resharding_bytes.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (resharding_bytes)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_resharding_bytes.yml
+++ b/.github/workflows/cluster_endtoend_resharding_bytes.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (resharding_bytes)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_resharding_bytes.yml
+++ b/.github/workflows/cluster_endtoend_resharding_bytes.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (resharding_bytes)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (schemadiff_vrepl)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (schemadiff_vrepl)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (schemadiff_vrepl)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (schemadiff_vrepl)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl_mysql57.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (schemadiff_vrepl) mysql57
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl_mysql57.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (schemadiff_vrepl) mysql57
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl_mysql57.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (schemadiff_vrepl) mysql57
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl_mysql57.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (schemadiff_vrepl) mysql57
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
+++ b/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (shardedrecovery_stress_verticalsplit_heavy)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
+++ b/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (shardedrecovery_stress_verticalsplit_heavy)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
+++ b/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (shardedrecovery_stress_verticalsplit_heavy)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped
@@ -96,7 +96,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: nick-fields/retry@v2
       with:
-        timeout_minutes: 60
+        timeout_minutes: 45
         max_attempts: 3
         retry_on: error
         command: |

--- a/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
+++ b/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (shardedrecovery_stress_verticalsplit_heavy)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (tabletmanager_consul)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (tabletmanager_consul)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (tabletmanager_consul)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (tabletmanager_consul)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (tabletmanager_tablegc)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (tabletmanager_tablegc)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (tabletmanager_tablegc)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (tabletmanager_tablegc)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc_mysql57.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (tabletmanager_tablegc) mysql57
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc_mysql57.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (tabletmanager_tablegc) mysql57
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc_mysql57.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (tabletmanager_tablegc) mysql57
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc_mysql57.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (tabletmanager_tablegc) mysql57
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (tabletmanager_throttler)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (tabletmanager_throttler)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (tabletmanager_throttler)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (tabletmanager_throttler)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (tabletmanager_throttler_custom_config)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (tabletmanager_throttler_custom_config)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (tabletmanager_throttler_custom_config)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (tabletmanager_throttler_custom_config)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_topo_connection_cache.yml
+++ b/.github/workflows/cluster_endtoend_topo_connection_cache.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (topo_connection_cache)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_topo_connection_cache.yml
+++ b/.github/workflows/cluster_endtoend_topo_connection_cache.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (topo_connection_cache)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_topo_connection_cache.yml
+++ b/.github/workflows/cluster_endtoend_topo_connection_cache.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (topo_connection_cache)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_topo_connection_cache.yml
+++ b/.github/workflows/cluster_endtoend_topo_connection_cache.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (topo_connection_cache)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_across_db_versions)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_across_db_versions)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_across_db_versions)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_across_db_versions)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_basic)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_basic)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_basic)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_basic)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_cellalias)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_cellalias)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_cellalias)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_cellalias)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vreplication_migrate.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_migrate)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vreplication_migrate.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_migrate)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vreplication_migrate.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_migrate)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vreplication_migrate.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_migrate)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vreplication_migrate_vdiff2_convert_tz.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate_vdiff2_convert_tz.yml
@@ -14,7 +14,8 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_migrate_vdiff2_convert_tz)
-    runs-on: ubuntu-20.04
+    runs-on:
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vreplication_migrate_vdiff2_convert_tz.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate_vdiff2_convert_tz.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_migrate_vdiff2_convert_tz)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_multicell)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_multicell)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_multicell)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_multicell)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_v2)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_v2)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_v2)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_v2)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vstream_failover.yml
+++ b/.github/workflows/cluster_endtoend_vstream_failover.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vstream_failover)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vstream_failover.yml
+++ b/.github/workflows/cluster_endtoend_vstream_failover.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vstream_failover)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vstream_failover.yml
+++ b/.github/workflows/cluster_endtoend_vstream_failover.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vstream_failover)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vstream_failover.yml
+++ b/.github/workflows/cluster_endtoend_vstream_failover.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vstream_failover)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vstream_stoponreshard_false)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vstream_stoponreshard_false)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vstream_stoponreshard_false)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vstream_stoponreshard_false)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vstream_stoponreshard_true)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vstream_stoponreshard_true)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vstream_stoponreshard_true)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vstream_stoponreshard_true)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
+++ b/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vstream_with_keyspaces_to_watch)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
+++ b/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vstream_with_keyspaces_to_watch)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
+++ b/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vstream_with_keyspaces_to_watch)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
+++ b/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vstream_with_keyspaces_to_watch)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtbackup_transform.yml
+++ b/.github/workflows/cluster_endtoend_vtbackup_transform.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtbackup_transform)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtbackup_transform.yml
+++ b/.github/workflows/cluster_endtoend_vtbackup_transform.yml
@@ -14,7 +14,8 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtbackup_transform)
-    runs-on: ubuntu-20.04
+    runs-on:
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtctlbackup_sharded_clustertest_heavy)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtctlbackup_sharded_clustertest_heavy)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtctlbackup_sharded_clustertest_heavy)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtctlbackup_sharded_clustertest_heavy)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_concurrentdml)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_concurrentdml)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_concurrentdml)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_concurrentdml)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_gen4)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_gen4)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_gen4)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_gen4)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_general_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_general_heavy.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_general_heavy)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_general_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_general_heavy.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_general_heavy)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_general_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_general_heavy.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_general_heavy)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_general_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_general_heavy.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_general_heavy)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_godriver.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_godriver.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_godriver)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_godriver.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_godriver.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_godriver)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_godriver.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_godriver.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_godriver)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_godriver.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_godriver.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_godriver)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_partial_keyspace.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_partial_keyspace.yml
@@ -14,7 +14,8 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_partial_keyspace)
-    runs-on: ubuntu-20.04
+    runs-on:
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_partial_keyspace.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_partial_keyspace.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_partial_keyspace)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_queries.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_queries.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_queries)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_queries.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_queries.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_queries)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_queries.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_queries.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_queries)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_queries.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_queries.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_queries)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_readafterwrite)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_readafterwrite)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_readafterwrite)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_readafterwrite)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_reservedconn)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_reservedconn)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_reservedconn)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_reservedconn)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_schema)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_schema)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_schema)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_schema)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_schema_tracker)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_schema_tracker)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_schema_tracker)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_schema_tracker)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_tablet_healthcheck_cache)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_tablet_healthcheck_cache)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_tablet_healthcheck_cache)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_tablet_healthcheck_cache)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_topo)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_topo)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_topo)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_topo)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_topo_consul)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_topo_consul)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_topo_consul)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_topo_consul)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_topo_etcd)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_topo_etcd)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_topo_etcd)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_topo_etcd)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_transaction)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_transaction)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_transaction)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_transaction)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_unsharded)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_unsharded)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_unsharded)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_unsharded)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_vindex_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex_heavy.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_vindex_heavy)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_vindex_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex_heavy.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_vindex_heavy)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_vindex_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex_heavy.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_vindex_heavy)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_vindex_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex_heavy.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_vindex_heavy)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_vschema)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_vschema)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_vschema)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_vschema)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtorc)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtorc)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtorc)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtorc)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtorc_8.0.yml
+++ b/.github/workflows/cluster_endtoend_vtorc_8.0.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtorc_8.0)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtorc_8.0.yml
+++ b/.github/workflows/cluster_endtoend_vtorc_8.0.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtorc_8.0)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtorc_8.0.yml
+++ b/.github/workflows/cluster_endtoend_vtorc_8.0.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtorc_8.0)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_vtorc_8.0.yml
+++ b/.github/workflows/cluster_endtoend_vtorc_8.0.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (vtorc_8.0)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
+++ b/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (worker_vault_heavy)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
+++ b/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (worker_vault_heavy)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
+++ b/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
@@ -9,7 +9,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (worker_vault_heavy)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
+++ b/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (worker_vault_heavy)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_xb_backup.yml
+++ b/.github/workflows/cluster_endtoend_xb_backup.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (xb_backup)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_xb_backup.yml
+++ b/.github/workflows/cluster_endtoend_xb_backup.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (xb_backup)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_xb_backup.yml
+++ b/.github/workflows/cluster_endtoend_xb_backup.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (xb_backup)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_xb_backup.yml
+++ b/.github/workflows/cluster_endtoend_xb_backup.yml
@@ -14,7 +14,8 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (xb_backup)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_xb_backup_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_xb_backup_mysql57.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (xb_backup) mysql57
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_xb_backup_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_xb_backup_mysql57.yml
@@ -18,7 +18,8 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (xb_backup) mysql57
-    runs-on: ubuntu-20.04
+    runs-on:
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (xb_recovery)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (xb_recovery)
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -14,7 +14,8 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (xb_recovery)
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (xb_recovery)
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_xb_recovery_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery_mysql57.yml
@@ -18,7 +18,8 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (xb_recovery) mysql57
-    runs-on: ubuntu-20.04
+    runs-on:
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_endtoend_xb_recovery_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery_mysql57.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     name: Run endtoend tests on Cluster (xb_recovery) mysql57
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_initial_sharding_multi.yml
+++ b/.github/workflows/cluster_initial_sharding_multi.yml
@@ -4,7 +4,8 @@ jobs:
 
   build:
     name: cluster initial sharding multi
-    runs-on: ubuntu-latest
+    runs-on:
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/cluster_initial_sharding_multi.yml
+++ b/.github/workflows/cluster_initial_sharding_multi.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     name: cluster initial sharding multi
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/docker_test_cluster_10.yml
+++ b/.github/workflows/docker_test_cluster_10.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     name: Docker Test Cluster 10
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/docker_test_cluster_10.yml
+++ b/.github/workflows/docker_test_cluster_10.yml
@@ -4,7 +4,8 @@ jobs:
 
   build:
     name: Docker Test Cluster 10
-    runs-on: ubuntu-latest
+    runs-on:
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/docker_test_cluster_25.yml
+++ b/.github/workflows/docker_test_cluster_25.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     name: Docker Test Cluster 25
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/docker_test_cluster_25.yml
+++ b/.github/workflows/docker_test_cluster_25.yml
@@ -4,7 +4,8 @@ jobs:
 
   build:
     name: Docker Test Cluster 25
-    runs-on: ubuntu-latest
+    runs-on:
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/e2e_race.yml
+++ b/.github/workflows/e2e_race.yml
@@ -4,7 +4,8 @@ jobs:
 
   build:
     name: End-to-End Test (Race)
-    runs-on: ubuntu-latest
+    runs-on:
+      group: vitess-ubuntu22
     steps:
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/e2e_race.yml
+++ b/.github/workflows/e2e_race.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     name: End-to-End Test (Race)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     steps:
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -4,7 +4,8 @@ jobs:
 
   build:
     name: End-to-End Test
-    runs-on: ubuntu-20.04
+    runs-on:
+      group: vitess-ubuntu22
     steps:
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     name: End-to-End Test
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     steps:
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/unit_race.yml
+++ b/.github/workflows/unit_race.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     name: Unit Test (Race)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     steps:
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/unit_race.yml
+++ b/.github/workflows/unit_race.yml
@@ -8,7 +8,8 @@ jobs:
 
   build:
     name: Unit Test (Race)
-    runs-on: ubuntu-20.04
+    runs-on:
+      group: vitess-ubuntu22
     steps:
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/unit_test_mysql57.yml
+++ b/.github/workflows/unit_test_mysql57.yml
@@ -8,7 +8,8 @@ concurrency:
 
 jobs:
   test:
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/unit_test_mysql57.yml
+++ b/.github/workflows/unit_test_mysql57.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   test:
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/unit_test_mysql57.yml
+++ b/.github/workflows/unit_test_mysql57.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/unit_test_mysql57.yml
+++ b/.github/workflows/unit_test_mysql57.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   test:
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/unit_test_mysql80.yml
+++ b/.github/workflows/unit_test_mysql80.yml
@@ -8,7 +8,8 @@ concurrency:
 
 jobs:
   test:
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/unit_test_mysql80.yml
+++ b/.github/workflows/unit_test_mysql80.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   test:
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/unit_test_mysql80.yml
+++ b/.github/workflows/unit_test_mysql80.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/unit_test_mysql80.yml
+++ b/.github/workflows/unit_test_mysql80.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   test:
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -11,7 +11,8 @@ jobs:
   get_previous_release:
     if: always()
     name: Get Previous Release - Backups - E2E
-    runs-on: ubuntu-latest
+    runs-on:
+      group: vitess-ubuntu22
     needs:
       - get_upgrade_downgrade_label
     outputs:
@@ -34,7 +35,8 @@ jobs:
     timeout-minutes: 60
     if: always() && needs.get_previous_release.result == 'success'
     name: Run Upgrade Downgrade Test - Backups - E2E
-    runs-on: ubuntu-20.04
+    runs-on:
+      group: vitess-ubuntu22
     needs:
       - get_previous_release
 

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -12,7 +12,7 @@ jobs:
     if: always()
     name: Get Previous Release - Backups - E2E
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     needs:
       - get_upgrade_downgrade_label
     outputs:
@@ -36,7 +36,7 @@ jobs:
     if: always() && needs.get_previous_release.result == 'success'
     name: Run Upgrade Downgrade Test - Backups - E2E
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     needs:
       - get_previous_release
 

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
@@ -12,7 +12,7 @@ jobs:
     if: always()
     name: Get Latest Release - Backups - E2E - Next Release
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -34,7 +34,7 @@ jobs:
     if: always() && needs.get_next_release.result == 'success'
     name: Run Upgrade Downgrade Test - Backups - E2E - Next Release
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
@@ -11,7 +11,8 @@ jobs:
   get_next_release:
     if: always()
     name: Get Latest Release - Backups - E2E - Next Release
-    runs-on: ubuntu-latest
+    runs-on:
+      group: vitess-ubuntu22
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -32,7 +33,8 @@ jobs:
     timeout-minutes: 60
     if: always() && needs.get_next_release.result == 'success'
     name: Run Upgrade Downgrade Test - Backups - E2E - Next Release
-    runs-on: ubuntu-20.04
+    runs-on:
+      group: vitess-ubuntu22
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -12,7 +12,7 @@ jobs:
     if: always()
     name: Get Previous Release - Backups - Manual
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -35,7 +35,7 @@ jobs:
     if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test - Backups - Manual
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     needs:
       - get_previous_release
 

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -11,7 +11,8 @@ jobs:
   get_previous_release:
     if: always()
     name: Get Previous Release - Backups - Manual
-    runs-on: ubuntu-latest
+    runs-on:
+      group: vitess-ubuntu22
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -33,7 +34,8 @@ jobs:
     timeout-minutes: 40
     if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test - Backups - Manual
-    runs-on: ubuntu-20.04
+    runs-on:
+      group: vitess-ubuntu22
     needs:
       - get_previous_release
 

--- a/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
@@ -12,7 +12,7 @@ jobs:
     if: always()
     name: Get Previous Release - Backups - Manual - Next Release
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -35,7 +35,7 @@ jobs:
     if: always() && (needs.get_next_release.result == 'success')
     name: Run Upgrade Downgrade Test - Backups - Manual - Next Release
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
@@ -11,7 +11,8 @@ jobs:
   get_next_release:
     if: always()
     name: Get Previous Release - Backups - Manual - Next Release
-    runs-on: ubuntu-20.04
+    runs-on:
+      group: vitess-ubuntu22
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -33,7 +34,8 @@ jobs:
     timeout-minutes: 40
     if: always() && (needs.get_next_release.result == 'success')
     name: Run Upgrade Downgrade Test - Backups - Manual - Next Release
-    runs-on: ubuntu-20.04
+    runs-on:
+      group: vitess-ubuntu22
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
@@ -14,7 +14,8 @@ jobs:
   get_previous_release:
     if: always()
     name: Get Previous Release - Query Serving (Queries)
-    runs-on: ubuntu-latest
+    runs-on:
+      group: vitess-ubuntu22
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -34,7 +35,8 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test - Query Serving (Queries)
-    runs-on: ubuntu-latest
+    runs-on:
+      group: vitess-ubuntu22
     needs:
       - get_previous_release
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
@@ -15,7 +15,7 @@ jobs:
     if: always()
     name: Get Previous Release - Query Serving (Queries)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
     if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test - Query Serving (Queries)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     needs:
       - get_previous_release
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
@@ -14,7 +14,8 @@ jobs:
   get_next_release:
     if: always()
     name: Get Latest Release - Query Serving (Queries) Next Release
-    runs-on: ubuntu-latest
+    runs-on:
+      group: vitess-ubuntu22
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -34,7 +35,8 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_next_release.result == 'success')
     name: Run Upgrade Downgrade Test - Query Serving (Queries) Next Release
-    runs-on: ubuntu-latest
+    runs-on:
+      group: vitess-ubuntu22
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
@@ -15,7 +15,7 @@ jobs:
     if: always()
     name: Get Latest Release - Query Serving (Queries) Next Release
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
     if: always() && (needs.get_next_release.result == 'success')
     name: Run Upgrade Downgrade Test - Query Serving (Queries) Next Release
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
@@ -14,7 +14,8 @@ jobs:
   get_previous_release:
     if: always()
     name: Get Previous Release - Query Serving (Schema)
-    runs-on: ubuntu-latest
+    runs-on:
+      group: vitess-ubuntu22
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -34,7 +35,8 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test - Query Serving (Schema)
-    runs-on: ubuntu-latest
+    runs-on:
+      group: vitess-ubuntu22
     needs:
       - get_previous_release
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
@@ -15,7 +15,7 @@ jobs:
     if: always()
     name: Get Previous Release - Query Serving (Schema)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
     if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test - Query Serving (Schema)
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     needs:
       - get_previous_release
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
@@ -14,7 +14,8 @@ jobs:
   get_next_release:
     if: always()
     name: Get Latest Release - Query Serving (Schema) Next Release
-    runs-on: ubuntu-latest
+    runs-on:
+      group: vitess-ubuntu22
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -34,7 +35,8 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_next_release.result == 'success')
     name: Run Upgrade Downgrade Test - Query Serving (Schema) Next Release
-    runs-on: ubuntu-latest
+    runs-on:
+      group: vitess-ubuntu22
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
@@ -15,7 +15,7 @@ jobs:
     if: always()
     name: Get Latest Release - Query Serving (Schema) Next Release
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
     if: always() && (needs.get_next_release.result == 'success')
     name: Run Upgrade Downgrade Test - Query Serving (Schema) Next Release
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
@@ -15,7 +15,7 @@ jobs:
     if: always()
     name: Get Latest Release - Reparent New Vtctl
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
     if: always() && (needs.get_next_release.result == 'success')
     name: Run Upgrade Downgrade Test - Reparent New Vtctl
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
@@ -14,7 +14,8 @@ jobs:
   get_next_release:
     if: always()
     name: Get Latest Release - Reparent New Vtctl
-    runs-on: ubuntu-latest
+    runs-on:
+      group: vitess-ubuntu22
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -34,7 +35,8 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_next_release.result == 'success')
     name: Run Upgrade Downgrade Test - Reparent New Vtctl
-    runs-on: ubuntu-latest
+    runs-on:
+      group: vitess-ubuntu22
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
@@ -15,7 +15,7 @@ jobs:
     if: always()
     name: Get Latest Release - Reparent New VTTablet
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
     if: always() && (needs.get_next_release.result == 'success')
     name: Run Upgrade Downgrade Test - Reparent New VTTablet
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
@@ -14,7 +14,8 @@ jobs:
   get_next_release:
     if: always()
     name: Get Latest Release - Reparent New VTTablet
-    runs-on: ubuntu-latest
+    runs-on:
+      group: vitess-ubuntu22
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -34,7 +35,8 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_next_release.result == 'success')
     name: Run Upgrade Downgrade Test - Reparent New VTTablet
-    runs-on: ubuntu-latest
+    runs-on:
+      group: vitess-ubuntu22
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -14,7 +14,8 @@ jobs:
   get_previous_release:
     if: always()
     name: Get Previous Release - Reparent Old Vtctl
-    runs-on: ubuntu-latest
+    runs-on:
+      group: vitess-ubuntu22
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -34,7 +35,8 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test - Reparent Old Vtctl
-    runs-on: ubuntu-latest
+    runs-on:
+      group: vitess-ubuntu22
     needs:
       - get_previous_release
 

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -15,7 +15,7 @@ jobs:
     if: always()
     name: Get Previous Release - Reparent Old Vtctl
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
     if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test - Reparent Old Vtctl
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     needs:
       - get_previous_release
 

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -15,7 +15,7 @@ jobs:
     if: always()
     name: Get Previous Release - Reparent Old VTTablet
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
     if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test - Reparent Old VTTablet
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     needs:
       - get_previous_release
 

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -14,7 +14,8 @@ jobs:
   get_previous_release:
     if: always()
     name: Get Previous Release - Reparent Old VTTablet
-    runs-on: ubuntu-latest
+    runs-on:
+      group: vitess-ubuntu22
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -34,7 +35,8 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test - Reparent Old VTTablet
-    runs-on: ubuntu-latest
+    runs-on:
+      group: vitess-ubuntu22
     needs:
       - get_previous_release
 

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -15,7 +15,7 @@ jobs:
   build:
     name: Run endtoend tests on {{.Name}}
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -15,7 +15,7 @@ jobs:
   build:
     name: Run endtoend tests on {{.Name}}
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -14,7 +14,8 @@ env:
 jobs:
   build:
     name: Run endtoend tests on {{.Name}}
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -14,7 +14,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on {{.Name}}
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/test/templates/cluster_endtoend_test_docker.tpl
+++ b/test/templates/cluster_endtoend_test_docker.tpl
@@ -5,7 +5,7 @@ jobs:
   build:
     name: Run endtoend tests on {{.Name}}
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/test/templates/cluster_endtoend_test_docker.tpl
+++ b/test/templates/cluster_endtoend_test_docker.tpl
@@ -4,7 +4,8 @@ on: [push, pull_request]
 jobs:
   build:
     name: Run endtoend tests on {{.Name}}
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/test/templates/cluster_endtoend_test_docker.tpl
+++ b/test/templates/cluster_endtoend_test_docker.tpl
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: Run endtoend tests on {{.Name}}
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/test/templates/cluster_endtoend_test_docker.tpl
+++ b/test/templates/cluster_endtoend_test_docker.tpl
@@ -5,7 +5,7 @@ jobs:
   build:
     name: Run endtoend tests on {{.Name}}
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/test/templates/cluster_endtoend_test_mysql57.tpl
+++ b/test/templates/cluster_endtoend_test_mysql57.tpl
@@ -8,7 +8,7 @@ jobs:
   build:
     name: Run endtoend tests on {{.Name}}
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
     timeout-minutes: 45
 
     steps:

--- a/test/templates/cluster_endtoend_test_mysql57.tpl
+++ b/test/templates/cluster_endtoend_test_mysql57.tpl
@@ -7,7 +7,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on {{.Name}}
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
     timeout-minutes: 45
 
     steps:

--- a/test/templates/cluster_endtoend_test_mysql57.tpl
+++ b/test/templates/cluster_endtoend_test_mysql57.tpl
@@ -8,7 +8,7 @@ jobs:
   build:
     name: Run endtoend tests on {{.Name}}
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
     timeout-minutes: 45
 
     steps:

--- a/test/templates/cluster_endtoend_test_mysql57.tpl
+++ b/test/templates/cluster_endtoend_test_mysql57.tpl
@@ -7,7 +7,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on {{.Name}}
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
     timeout-minutes: 45
 
     steps:

--- a/test/templates/cluster_endtoend_test_self_hosted.tpl
+++ b/test/templates/cluster_endtoend_test_self_hosted.tpl
@@ -7,7 +7,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on {{.Name}}
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
       - name: Check if workflow needs to be skipped

--- a/test/templates/cluster_endtoend_test_self_hosted.tpl
+++ b/test/templates/cluster_endtoend_test_self_hosted.tpl
@@ -7,7 +7,8 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on {{.Name}}
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
       - name: Check if workflow needs to be skipped

--- a/test/templates/cluster_endtoend_test_self_hosted.tpl
+++ b/test/templates/cluster_endtoend_test_self_hosted.tpl
@@ -8,7 +8,7 @@ jobs:
   build:
     name: Run endtoend tests on {{.Name}}
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
       - name: Check if workflow needs to be skipped

--- a/test/templates/cluster_endtoend_test_self_hosted.tpl
+++ b/test/templates/cluster_endtoend_test_self_hosted.tpl
@@ -8,7 +8,7 @@ jobs:
   build:
     name: Run endtoend tests on {{.Name}}
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
       - name: Check if workflow needs to be skipped

--- a/test/templates/unit_test.tpl
+++ b/test/templates/unit_test.tpl
@@ -7,7 +7,7 @@ concurrency:
 jobs:
   test:
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/test/templates/unit_test.tpl
+++ b/test/templates/unit_test.tpl
@@ -7,7 +7,7 @@ concurrency:
 jobs:
   test:
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/test/templates/unit_test.tpl
+++ b/test/templates/unit_test.tpl
@@ -6,7 +6,8 @@ concurrency:
 
 jobs:
   test:
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/test/templates/unit_test.tpl
+++ b/test/templates/unit_test.tpl
@@ -6,7 +6,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
     - name: Check if workflow needs to be skipped

--- a/test/templates/unit_test_self_hosted.tpl
+++ b/test/templates/unit_test_self_hosted.tpl
@@ -7,7 +7,7 @@ concurrency:
 jobs:
   test:
     runs-on:
-      group: vitess-ubuntu22
+      group: vitess-ubuntu20
 
     steps:
       - name: Check if workflow needs to be skipped

--- a/test/templates/unit_test_self_hosted.tpl
+++ b/test/templates/unit_test_self_hosted.tpl
@@ -6,7 +6,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: vitess-ci
 
     steps:
       - name: Check if workflow needs to be skipped

--- a/test/templates/unit_test_self_hosted.tpl
+++ b/test/templates/unit_test_self_hosted.tpl
@@ -7,7 +7,7 @@ concurrency:
 jobs:
   test:
     runs-on:
-      group: vitess
+      group: vitess-ubuntu22
 
     steps:
       - name: Check if workflow needs to be skipped

--- a/test/templates/unit_test_self_hosted.tpl
+++ b/test/templates/unit_test_self_hosted.tpl
@@ -6,7 +6,8 @@ concurrency:
 
 jobs:
   test:
-    runs-on: vitess-ci
+    runs-on:
+      group: vitess
 
     steps:
       - name: Check if workflow needs to be skipped


### PR DESCRIPTION
## Description

This PR introduces @timvaillancourt 's changes for CI piepeline worker sizes to v14 branch - excluding a test for which it actually leads to not yet fully understood failures. For that particular test, leaving the current worker size actually succeeds. All. other workers sizes were increased and all tests are passing - none were skipped except for the check on PR labels.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

