### PR TITLE
Revert change of runner type for shardedrecovery_stress_verticalsplitheavy

### DIFF
--- a/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
+++ b/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
@@ -9,8 +9,7 @@ concurrency:
 jobs:
   build:
     name: Run endtoend tests on Cluster (shardedrecovery_stress_verticalsplit_heavy)
-    runs-on:
-      group: vitess-ubuntu20
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Check if workflow needs to be skipped


### PR DESCRIPTION
## Description

This aims at solving new failure modes seen with the larger runners, such as 

```
panic: test timed out after 20m0s
```

seen, for example, [here](https://github.com/slackhq/vitess/actions/runs/5747772848/job/15581935154?pr=112).

## Related Issue(s)

https://jira.tinyspeck.com/browse/DRE-8938

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

