### PR TITLE
enable go-upgrade job for slack-vitess-r14.0.5

### DIFF
--- a/.github/workflows/update_golang_version.yml
+++ b/.github/workflows/update_golang_version.yml
@@ -9,7 +9,7 @@ jobs:
   update_golang_version:
     strategy:
       matrix:
-        branch: [ main, release-16.0, release-15.0, release-14.0 ]
+        branch: [ main, release-16.0, release-15.0, release-14.0, slack-vitess-r14.0.5 ]
     name: Update Golang Version
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

I wonder if a computer can be better at upgrading Go than a human. I think this is how you are meant to upgrade Go version in Vitess anyway ¯\_(ツ)_/¯

It won't upgrade the major version on a release branch (only does it on the main), but I'm willing to experiment with this.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
