### PR TITLE
VStreams  NOT_FOUND Error Retries and Omits Tablet

### DIFF
--- a/go/vt/vtgate/vstream_manager.go
+++ b/go/vt/vtgate/vstream_manager.go
@@ -726,7 +726,8 @@ func (vs *vstream) shouldRetry(err error) (bool, bool) {
 
 	// If there is a GTIDSet Mismatch on the tablet, omit it from the candidate
 	// list in the TabletPicker on retry.
-	if errCode == vtrpcpb.Code_INVALID_ARGUMENT && strings.Contains(err.Error(), "GTIDSet Mismatch") {
+	if (errCode == vtrpcpb.Code_INVALID_ARGUMENT && strings.Contains(err.Error(), "GTIDSet Mismatch")) ||
+		errCode == vtrpc.Code_NOT_FOUND {
 		return true, true
 	}
 

--- a/go/vt/vtgate/vstream_manager_test.go
+++ b/go/vt/vtgate/vstream_manager_test.go
@@ -428,6 +428,13 @@ func TestVStreamRetriableErrors(t *testing.T) {
 			shouldRetry:  false,
 			ignoreTablet: false,
 		},
+		{
+			name:         "not found",
+			code:         vtrpcpb.Code_NOT_FOUND,
+			msg:          "",
+			shouldRetry:  true,
+			ignoreTablet: true,
+		},
 	}
 
 	commit := []*binlogdatapb.VEvent{


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
Currently, vstreams fail as expected when trying to stream from a tablet that is being replaced for _some_ reason. However, when the `NOT_FOUND` error is returned to the vstream client it does not omit the restore tablet from being used during the next retry. This can lead to streams being blocked for multiple hours. 

The reason this is added to our fork instead of committed upstream is because this has been fixed in future versions of Vitess, but, when bringing that fix in, there were many dependencies that caused issues with the merge. This change will be added in order to unblock CDC until we are more caught up with upstream.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
## Testing
This change has been in dev over the last several weeks and recently it was [noted](https://slack-pde.slack.com/archives/C01P84R7L02/p1702586748407959) that the `NOT_FOUND` errors have not been in over [4 weeks](https://logstash-dev.tinyspeck.com/app/discover?#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-4w,to:now))&_a=(columns:!(message,host,msg),filters:!(),index:kube,interval:auto,query:(language:lucene,query:'host:%22dbzium-*%22%20AND%20message:*NOT_FOUND*'),sort:!(!('@timestamp',desc)))).
## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
