### PR TITLE
`slack-vitess-r14.0.5`: backport vitessio/vitess#14428 from v16

### DIFF
--- a/go/vt/vtgate/planbuilder/abstract/queryprojection.go
+++ b/go/vt/vtgate/planbuilder/abstract/queryprojection.go
@@ -151,17 +151,15 @@ func CreateQPFromSelect(sel *sqlparser.Select) (*QueryProjection, error) {
 	}
 	for _, group := range sel.GroupBy {
 		selectExprIdx, aliasExpr := qp.FindSelectExprIndexForExpr(group)
-		expr, weightStrExpr, err := qp.GetSimplifiedExpr(group)
-		if err != nil {
-			return nil, err
-		}
+		selectExprIdx, aliasExpr := qp.FindSelectExprIndexForExpr(ctx, group)
+		weightStrExpr := qp.GetSimplifiedExpr(group)
 		err = checkForInvalidGroupingExpressions(weightStrExpr)
 		if err != nil {
 			return nil, err
 		}
 
 		groupBy := GroupBy{
-			Inner:         expr,
+			Inner:         group,
 			WeightStrExpr: weightStrExpr,
 			InnerIndex:    selectExprIdx,
 			aliasedExpr:   aliasExpr,
@@ -274,17 +272,14 @@ func CreateQPFromUnion(union *sqlparser.Union) (*QueryProjection, error) {
 func (qp *QueryProjection) addOrderBy(orderBy sqlparser.OrderBy) error {
 	canPushDownSorting := true
 	for _, order := range orderBy {
-		expr, weightStrExpr, err := qp.GetSimplifiedExpr(order.Expr)
-		if err != nil {
-			return err
-		}
+		weightStrExpr := qp.GetSimplifiedExpr(order.Expr)
 		if sqlparser.IsNull(weightStrExpr) {
 			// ORDER BY null can safely be ignored
 			continue
 		}
 		qp.OrderExprs = append(qp.OrderExprs, OrderBy{
 			Inner: &sqlparser.Order{
-				Expr:      expr,
+				Expr:      order.Expr,
 				Direction: order.Direction,
 			},
 			WeightStrExpr: weightStrExpr,
@@ -360,34 +355,47 @@ func (qp *QueryProjection) isExprInGroupByExprs(expr SelectExpr) bool {
 }
 
 // GetSimplifiedExpr takes an expression used in ORDER BY or GROUP BY, and returns an expression that is simpler to evaluate
-func (qp *QueryProjection) GetSimplifiedExpr(e sqlparser.Expr) (expr sqlparser.Expr, weightStrExpr sqlparser.Expr, err error) {
+func (qp *QueryProjection) GetSimplifiedExpr(e sqlparser.Expr) (found sqlparser.Expr) {
+	if qp == nil {
+		return e
+	}
 	// If the ORDER BY is against a column alias, we need to remember the expression
 	// behind the alias. The weightstring(.) calls needs to be done against that expression and not the alias.
 	// Eg - select music.foo as bar, weightstring(music.foo) from music order by bar
 
-	colExpr, isColName := e.(*sqlparser.ColName)
-	if !isColName {
-		return e, e, nil
+	in, isColName := e.(*sqlparser.ColName)
+	if !(isColName && in.Qualifier.IsEmpty()) {
+		// we are only interested in unqualified column names. if it's not a column name and not unqualified, we're done
+		return e
 	}
 
-	if sqlparser.IsNull(e) {
-		return e, nil, nil
-	}
-
-	if colExpr.Qualifier.IsEmpty() {
-		for _, selectExpr := range qp.SelectExprs {
-			aliasedExpr, isAliasedExpr := selectExpr.Col.(*sqlparser.AliasedExpr)
-			if !isAliasedExpr {
+	for _, selectExpr := range qp.SelectExprs {
+		ae, ok := selectExpr.Col.(*sqlparser.AliasedExpr)
+		if !ok {
+			continue
+		}
+		aliased := !ae.As.IsEmpty()
+		if aliased {
+			if in.Name.Equal(ae.As) {
+				return ae.Expr
+			}
+		} else {
+			seCol, ok := ae.Expr.(*sqlparser.ColName)
+			if !ok {
 				continue
 			}
-			isAliasExpr := !aliasedExpr.As.IsEmpty()
-			if isAliasExpr && colExpr.Name.Equal(aliasedExpr.As) {
-				return e, aliasedExpr.Expr, nil
+			if seCol.Name.Equal(in.Name) {
+				// If the column name matches, we have a match, even if the table name is not listed
+				return ae.Expr
 			}
 		}
 	}
 
-	return e, e, nil
+	if found == nil {
+		found = e
+	}
+
+	return found
 }
 
 // toString should only be used for tests

--- a/go/vt/vtgate/planbuilder/abstract/queryprojection.go
+++ b/go/vt/vtgate/planbuilder/abstract/queryprojection.go
@@ -151,7 +151,6 @@ func CreateQPFromSelect(sel *sqlparser.Select) (*QueryProjection, error) {
 	}
 	for _, group := range sel.GroupBy {
 		selectExprIdx, aliasExpr := qp.FindSelectExprIndexForExpr(group)
-		selectExprIdx, aliasExpr := qp.FindSelectExprIndexForExpr(ctx, group)
 		weightStrExpr := qp.GetSimplifiedExpr(group)
 		err = checkForInvalidGroupingExpressions(weightStrExpr)
 		if err != nil {

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -4784,9 +4784,9 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select id, b as id, count(*), weight_string(b) from `user` where 1 != 1",
+            "FieldQuery": "select id, b as id, count(*), weight_string(id) from `user` where 1 != 1",
             "OrderBy": "(1|3) ASC",
-            "Query": "select id, b as id, count(*), weight_string(b) from `user` order by id asc",
+            "Query": "select id, b as id, count(*), weight_string(id) from `user` order by id asc",
             "Table": "`user`"
           }
         ]
@@ -4876,9 +4876,9 @@
                       "Name": "user",
                       "Sharded": true
                     },
-                    "FieldQuery": "select `user`.id, weight_string(id) from `user` where 1 != 1 group by id, weight_string(id)",
+                    "FieldQuery": "select id, weight_string(`user`.id) from `user` where 1 != 1 group by id, weight_string(`user`.id)",
                     "OrderBy": "(0|1) ASC",
-                    "Query": "select `user`.id, weight_string(id) from `user` group by id, weight_string(id) order by id asc",
+                    "Query": "select id, weight_string(`user`.id) from `user` group by id, weight_string(`user`.id) order by id asc",
                     "Table": "`user`"
                   },
                   {

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -4851,7 +4851,7 @@
       "Instructions": {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
-        "GroupBy": "(0|1)",
+        "GroupBy": "(1|0)",
         "ResultColumns": 1,
         "Inputs": [
           {

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -4851,14 +4851,12 @@
       "Instructions": {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
-        "Aggregates": "random(0) AS id",
-        "GroupBy": "(2|1)",
+        "GroupBy": "(0|1)",
         "ResultColumns": 1,
         "Inputs": [
           {
             "OperatorType": "Projection",
             "Expressions": [
-              "[COLUMN 2] as id",
               "[COLUMN 1]",
               "[COLUMN 0] as id"
             ],
@@ -4866,7 +4864,7 @@
               {
                 "OperatorType": "Join",
                 "Variant": "Join",
-                "JoinColumnIndexes": "L:0,L:1,L:0",
+                "JoinColumnIndexes": "L:0,L:1",
                 "TableName": "`user`_user_extra",
                 "Inputs": [
                   {
@@ -4888,8 +4886,8 @@
                       "Name": "user",
                       "Sharded": true
                     },
-                    "FieldQuery": "select 1 from user_extra where 1 != 1 group by 1",
-                    "Query": "select 1 from user_extra group by 1",
+                    "FieldQuery": "select 1 from user_extra where 1 != 1",
+                    "Query": "select 1 from user_extra",
                     "Table": "user_extra"
                   }
                 ]

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -5757,11 +5757,7 @@
             "Table": "user_extra"
           }
         ]
-      },
-      "TablesUsed": [
-        "user.user",
-        "user.user_extra"
-      ]
+      }
     }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -5684,5 +5684,84 @@
         "Table": "dual, unsharded_a"
       }
     }
+  },
+  {
+    "comment": "column with qualifier is correctly used",
+    "query": "select u.foo, ue.foo as apa from user u, user_extra ue order by foo ",
+    "v3-plan": {
+      "QueryType": "SELECT",
+      "Original": "select u.foo, ue.foo as apa from user u, user_extra ue order by foo ",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "L:0,R:0",
+        "TableName": "`user`_user_extra",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select u.foo, weight_string(u.foo) from `user` as u where 1 != 1",
+            "OrderBy": "(0|1) ASC",
+            "Query": "select u.foo, weight_string(u.foo) from `user` as u order by foo asc",
+            "ResultColumns": 1,
+            "Table": "`user`"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select ue.foo as apa from user_extra as ue where 1 != 1",
+            "Query": "select ue.foo as apa from user_extra as ue",
+            "Table": "user_extra"
+          }
+        ]
+      }
+    },
+    "gen4-plan": {
+      "QueryType": "SELECT",
+      "Original": "select u.foo, ue.foo as apa from user u, user_extra ue order by foo ",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "L:0,R:0",
+        "TableName": "`user`_user_extra",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select u.foo, weight_string(u.foo) from `user` as u where 1 != 1",
+            "OrderBy": "(0|1) ASC",
+            "Query": "select u.foo, weight_string(u.foo) from `user` as u order by foo asc",
+            "Table": "`user`"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select ue.foo as apa from user_extra as ue where 1 != 1",
+            "Query": "select ue.foo as apa from user_extra as ue",
+            "Table": "user_extra"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user",
+        "user.user_extra"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
## Description

This PR backports the upstream PR https://github.com/vitessio/vitess/pull/14426 using [the `v16` backport](https://github.com/vitessio/vitess/pull/14428) of this change, as that is the closest release to `v14`

## Related Issue(s)

1. https://github.com/vitessio/vitess/pull/14426 _(original PR)_
2. https://github.com/vitessio/vitess/pull/14428 _(v16 backport)_

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
