### PR TITLE
repairReplication deadlock fix

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -169,7 +169,6 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/cyphar/filepath-securejoin v0.2.3 h1:YX6ebbZCZP7VkM3scTTokDgBL2TY741X51MTk3ycuNI=
 github.com/cyphar/filepath-securejoin v0.2.3/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=

--- a/go/vt/vttablet/tabletmanager/replmanager.go
+++ b/go/vt/vttablet/tabletmanager/replmanager.go
@@ -112,7 +112,6 @@ func (rm *replManager) checkActionLocked() {
 		// If only one of the threads is stopped, it's probably
 		// intentional. So, we don't repair replication.
 		if status.SQLHealthy() || status.IOHealthy() {
-
 			return
 		}
 	}

--- a/go/vt/vttablet/tabletmanager/replmanager.go
+++ b/go/vt/vttablet/tabletmanager/replmanager.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/timer"
 	"vitess.io/vitess/go/vt/log"
@@ -119,6 +120,7 @@ func (rm *replManager) checkActionLocked() {
 		}
 	}
 
+	log.Infof("vm-debug: replManager=%s", spew.Sdump(rm))
 	if !rm.failed {
 		log.Infof("Replication is stopped, reconnecting to primary.")
 	}

--- a/go/vt/vttablet/tabletmanager/replmanager.go
+++ b/go/vt/vttablet/tabletmanager/replmanager.go
@@ -126,6 +126,7 @@ func (rm *replManager) checkActionLocked() {
 	ctx, cancel := context.WithTimeout(rm.ctx, 5*time.Second)
 	defer cancel()
 	if err := rm.tm.repairReplication(ctx); err != nil {
+		log.Infof("vm-debug: repairReplication failed with=%v", err)
 		if !rm.failed {
 			rm.failed = true
 			log.Infof("Failed to reconnect to primary: %v, will keep retrying.", err)

--- a/go/vt/vttablet/tabletmanager/replmanager.go
+++ b/go/vt/vttablet/tabletmanager/replmanager.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/timer"
 	"vitess.io/vitess/go/vt/log"
@@ -104,8 +103,9 @@ func (rm *replManager) check() {
 
 func (rm *replManager) checkActionLocked() {
 	status, err := rm.tm.MysqlDaemon.ReplicationStatus()
-	log.Infof("vm-debug: %s", spew.Sdump(status))
+	// log.Infof("vm-debug: %s", spew.Sdump(status))
 	if err != nil {
+		log.Infof("vm-debug: %v", err)
 		if err != mysql.ErrNotReplica {
 			return
 		}
@@ -113,7 +113,7 @@ func (rm *replManager) checkActionLocked() {
 		// If only one of the threads is stopped, it's probably
 		// intentional. So, we don't repair replication.
 		if status.SQLHealthy() || status.IOHealthy() {
-			log.Infof("vm-debug: status.SQLHealthy:%v status.IOHealthy:%v", status.SQLHealthy(), status.IOHealthy())
+			// log.Infof("vm-debug: status.SQLHealthy:%v status.IOHealthy:%v", status.SQLHealthy(), status.IOHealthy())
 
 			return
 		}

--- a/go/vt/vttablet/tabletmanager/replmanager.go
+++ b/go/vt/vttablet/tabletmanager/replmanager.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/timer"
 	"vitess.io/vitess/go/vt/log"
@@ -120,7 +119,7 @@ func (rm *replManager) checkActionLocked() {
 		}
 	}
 
-	log.Infof("vm-debug: replManager=%s", spew.Sdump(rm))
+	log.Infof("vm-debug: rm.failed=%v", rm.failed)
 	if !rm.failed {
 		log.Infof("Replication is stopped, reconnecting to primary.")
 	}

--- a/go/vt/vttablet/tabletmanager/replmanager.go
+++ b/go/vt/vttablet/tabletmanager/replmanager.go
@@ -17,13 +17,13 @@ limitations under the License.
 package tabletmanager
 
 import (
+	"context"
 	"os"
 	"path"
 	"sync"
 	"time"
 
-	"context"
-
+	"github.com/davecgh/go-spew/spew"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/timer"
 	"vitess.io/vitess/go/vt/log"
@@ -104,6 +104,7 @@ func (rm *replManager) check() {
 
 func (rm *replManager) checkActionLocked() {
 	status, err := rm.tm.MysqlDaemon.ReplicationStatus()
+	log.Infof("vm-debug: %s", spew.Sdump(status))
 	if err != nil {
 		if err != mysql.ErrNotReplica {
 			return
@@ -112,6 +113,8 @@ func (rm *replManager) checkActionLocked() {
 		// If only one of the threads is stopped, it's probably
 		// intentional. So, we don't repair replication.
 		if status.SQLHealthy() || status.IOHealthy() {
+			log.Infof("vm-debug: status.SQLHealthy:%v status.IOHealthy:%v", status.SQLHealthy(), status.IOHealthy())
+
 			return
 		}
 	}

--- a/go/vt/vttablet/tabletmanager/replmanager.go
+++ b/go/vt/vttablet/tabletmanager/replmanager.go
@@ -103,9 +103,8 @@ func (rm *replManager) check() {
 
 func (rm *replManager) checkActionLocked() {
 	status, err := rm.tm.MysqlDaemon.ReplicationStatus()
-	// log.Infof("vm-debug: %s", spew.Sdump(status))
 	if err != nil {
-		log.Infof("vm-debug: %v", err)
+		log.Infof("slack-debug: %v", err)
 		if err != mysql.ErrNotReplica {
 			return
 		}
@@ -113,20 +112,19 @@ func (rm *replManager) checkActionLocked() {
 		// If only one of the threads is stopped, it's probably
 		// intentional. So, we don't repair replication.
 		if status.SQLHealthy() || status.IOHealthy() {
-			// log.Infof("vm-debug: status.SQLHealthy:%v status.IOHealthy:%v", status.SQLHealthy(), status.IOHealthy())
 
 			return
 		}
 	}
 
-	log.Infof("vm-debug: rm.failed=%v", rm.failed)
+	log.Infof("slack-debug: rm.failed=%v", rm.failed)
 	if !rm.failed {
 		log.Infof("Replication is stopped, reconnecting to primary.")
 	}
 	ctx, cancel := context.WithTimeout(rm.ctx, 5*time.Second)
 	defer cancel()
 	if err := rm.tm.repairReplication(ctx); err != nil {
-		log.Infof("vm-debug: repairReplication failed with=%v", err)
+		log.Infof("slack-debug: repairReplication failed with=%v", err)
 		if !rm.failed {
 			rm.failed = true
 			log.Infof("Failed to reconnect to primary: %v, will keep retrying.", err)

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 
 	"vitess.io/vitess/go/mysql"
@@ -703,7 +702,7 @@ func (tm *TabletManager) setReplicationSourceRepairReplication(ctx context.Conte
 		return err
 	}
 
-	log.Infof("slack-debug: calling tm.TopoServer.LockShard ctx=%s", spew.Sdump(ctx))
+	log.Infof("slack-debug: calling tm.TopoServer.LockShard")
 	ctx, unlock, lockErr := tm.TopoServer.LockShard(ctx, parent.Tablet.GetKeyspace(), parent.Tablet.GetShard(), fmt.Sprintf("repairReplication to %v as parent)", topoproto.TabletAliasString(parentAlias)))
 	if lockErr != nil {
 		return lockErr

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -1149,6 +1149,7 @@ func (tm *TabletManager) handleRelayLogError(err error) error {
 // repairReplication tries to connect this server to whoever is
 // the current primary of the shard, and start replicating.
 func (tm *TabletManager) repairReplication(ctx context.Context) error {
+	log.Infof("vm-debug: entering repairReplication")
 	tablet := tm.Tablet()
 
 	si, err := tm.TopoServer.GetShard(ctx, tablet.Keyspace, tablet.Shard)

--- a/go/vt/vttablet/tabletmanager/tm_init.go
+++ b/go/vt/vttablet/tabletmanager/tm_init.go
@@ -195,7 +195,7 @@ type TabletManager struct {
 	_lockTablesTimer      *time.Timer
 	// _isBackupRunning tells us whether there is a backup that is currently running
 	_isBackupRunning bool
-	// _isSetReplicationSourceLockedRunning indicates we are actively running SetReplicationSource
+	// _isSetReplicationSourceLockedRunning indicates we are actively running setReplicationSourceLocked
 	_isSetReplicationSourceLockedRunning bool
 }
 

--- a/go/vt/vttablet/tabletmanager/tm_init.go
+++ b/go/vt/vttablet/tabletmanager/tm_init.go
@@ -195,8 +195,8 @@ type TabletManager struct {
 	_lockTablesTimer      *time.Timer
 	// _isBackupRunning tells us whether there is a backup that is currently running
 	_isBackupRunning bool
-	// _isSetReplicationSourceRunning indicates we are actively running SetReplicationSource
-	_isSetReplicationSourceRunning bool
+	// _isSetReplicationSourceLockedRunning indicates we are actively running SetReplicationSource
+	_isSetReplicationSourceLockedRunning bool
 }
 
 // BuildTabletFromInput builds a tablet record from input parameters.

--- a/go/vt/vttablet/tabletmanager/tm_init.go
+++ b/go/vt/vttablet/tabletmanager/tm_init.go
@@ -195,6 +195,8 @@ type TabletManager struct {
 	_lockTablesTimer      *time.Timer
 	// _isBackupRunning tells us whether there is a backup that is currently running
 	_isBackupRunning bool
+	// _isSetReplicationSourceRunning indicates we are actively running SetReplicationSource
+	_isSetReplicationSourceRunning bool
 }
 
 // BuildTabletFromInput builds a tablet record from input parameters.


### PR DESCRIPTION
## Description
This PR fixes slow PRS (17-18s hangs) bug caused by repairReplication causing a shard deadlock as described here: https://slack-pde.slack.com/archives/C8EJ0PTPF/p1705042056083619?thread_ts=1696929303.041269&cid=C8EJ0PTPF

## Testing
Extensively tested over 2 week period [here](https://slack-pde.slack.com/archives/CQGR39RA5/p1705456795968969) and [here](https://slack-pde.slack.com/archives/CQGR39RA5/p1705991224894969).

## Backport/Upstream Plans
see [this thread](https://slack-pde.slack.com/archives/CQGR39RA5/p1706213026103819)

## Rollout
After making a new build off of slack-vitess-r14.0.5:
1. [ ] soak the new build in `dev` ( all keyspaces )
2. [ ] wait until vtgate v14 rollout is 100% completed to avoid adding any new variables
3. [ ] vttablet canary phase in `prod` using `vtops-go upgrade plan`
4. [ ] vttablet default build in `prod` rollout via u22/high-uptime recycling
