### PR TITLE
`slack-vitess-r14.0.5`: load `--grpc_auth_static_client_creds` file once

### DIFF
--- a/go/vt/grpcclient/client_auth_static.go
+++ b/go/vt/grpcclient/client_auth_static.go
@@ -71,17 +71,17 @@ func loadStaticAuthCredsFromFile(credsFile string) (*StaticAuthClientCreds, erro
 
 // AppendStaticAuth optionally appends static auth credentials if provided.
 func AppendStaticAuth(opts []grpc.DialOption) ([]grpc.DialOption, error) {
-	if credsFile == "" {
+	if *credsFile == "" {
 		return opts, nil
 	}
 	var err error
 	credsFileOnce.Do(func() {
-		clientCreds, err = loadStaticAuthCredsFromFile(credsFile)
+		clientCreds, err = loadStaticAuthCredsFromFile(*credsFile)
 	})
 	if err != nil {
 		return nil, err
 	}
-	creds := grpc.WithPerRPCCredentials(*clientCreds)
+	creds := grpc.WithPerRPCCredentials(clientCreds)
 	opts = append(opts, creds)
 	return opts, nil
 }


### PR DESCRIPTION
## Description

This PR is a sideport(?) of upstream PR https://github.com/vitessio/vitess/pull/15030 to our v14 branch

This change will cause the gRPC static client auth file to be read once vs `N x tablet` times, which reduces the snowballing of OS-threads

cc @tanjinx 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
