### PR TITLE
`slack-vitess-r14.0.5`: load `--grpc_auth_static_client_creds` file once

### DIFF
--- a/go/vt/grpcclient/client_auth_static.go
+++ b/go/vt/grpcclient/client_auth_static.go
@@ -27,6 +27,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+
 	"vitess.io/vitess/go/vt/servenv"
 )
 

--- a/go/vt/grpcclient/client_auth_static.go
+++ b/go/vt/grpcclient/client_auth_static.go
@@ -27,6 +27,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"vitess.io/vitess/go/vt/servenv"
 )
 
 var (
@@ -129,8 +130,10 @@ func loadStaticAuthCredsFromFile(path string) (*StaticAuthClientCreds, error) {
 }
 
 func init() {
-	clientCredsSigChan = make(chan os.Signal, 1)
-	signal.Notify(clientCredsSigChan, syscall.SIGHUP)
-	_, _ = getStaticAuthCreds() // preload static auth credentials
+	servenv.OnInit(func() {
+		clientCredsSigChan = make(chan os.Signal, 1)
+		signal.Notify(clientCredsSigChan, syscall.SIGHUP)
+		_, _ = getStaticAuthCreds() // preload static auth credentials
+	})
 	RegisterGRPCDialOptions(AppendStaticAuth)
 }

--- a/go/vt/grpcclient/client_auth_static_test.go
+++ b/go/vt/grpcclient/client_auth_static_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpcclient
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+)
+
+func TestAppendStaticAuth(t *testing.T) {
+	{
+		clientCreds = nil
+		clientCredsErr = nil
+		opts, err := AppendStaticAuth([]grpc.DialOption{})
+		assert.Nil(t, err)
+		assert.Len(t, opts, 0)
+	}
+	{
+		clientCreds = nil
+		clientCredsErr = errors.New("test err")
+		opts, err := AppendStaticAuth([]grpc.DialOption{})
+		assert.NotNil(t, err)
+		assert.Len(t, opts, 0)
+	}
+	{
+		clientCreds = &StaticAuthClientCreds{Username: "test", Password: "123456"}
+		clientCredsErr = nil
+		opts, err := AppendStaticAuth([]grpc.DialOption{})
+		assert.Nil(t, err)
+		assert.Len(t, opts, 1)
+	}
+}
+
+func TestLoadStaticAuthCredsFromFile(t *testing.T) {
+	{
+		f, err := os.CreateTemp("", t.Name())
+		if !assert.Nil(t, err) {
+			assert.FailNowf(t, "cannot create temp file: %s", err.Error())
+		}
+		_, err = f.Write([]byte(`{
+			"Username": "test",
+			"Password": "correct horse battery staple"
+		}`))
+		if !assert.Nil(t, err) {
+			assert.FailNowf(t, "cannot read auth file: %s", err.Error())
+		}
+		defer os.Remove(f.Name())
+
+		creds, err := loadStaticAuthCredsFromFile(f.Name())
+		assert.Nil(t, err)
+		assert.Equal(t, "test", creds.Username)
+		assert.Equal(t, "correct horse battery staple", creds.Password)
+	}
+	{
+		_, err := loadStaticAuthCredsFromFile(`does-not-exist`)
+		assert.NotNil(t, err)
+	}
+}

--- a/go/vt/grpcclient/client_auth_static_test.go
+++ b/go/vt/grpcclient/client_auth_static_test.go
@@ -81,9 +81,10 @@ func TestGetStaticAuthCreds(t *testing.T) {
 	// test SIGHUP signal triggers reload
 	credsOld := creds
 	clientCredsSigChan <- syscall.SIGHUP
+	timeoutChan := time.After(time.Second * 10)
 	for {
 		select {
-		case <-time.After(time.Second * 10):
+		case <-timeoutChan:
 			assert.Fail(t, "timed out waiting for SIGHUP reload of static auth creds")
 			return
 		default:
@@ -105,14 +106,14 @@ func TestLoadStaticAuthCredsFromFile(t *testing.T) {
 		if !assert.Nil(t, err) {
 			assert.FailNowf(t, "cannot create temp file: %s", err.Error())
 		}
-		_, err = f.Write([]byte(`{
+		defer os.Remove(f.Name())
+		fmt.Fprint(f, `{
 			"Username": "test",
 			"Password": "correct horse battery staple"
-		}`))
+		}`)
 		if !assert.Nil(t, err) {
 			assert.FailNowf(t, "cannot read auth file: %s", err.Error())
 		}
-		defer os.Remove(f.Name())
 
 		creds, err := loadStaticAuthCredsFromFile(f.Name())
 		assert.Nil(t, err)

--- a/go/vt/grpcclient/client_auth_static_test.go
+++ b/go/vt/grpcclient/client_auth_static_test.go
@@ -59,6 +59,7 @@ func TestGetStaticAuthCreds(t *testing.T) {
 	defer os.Remove(tmp.Name())
 	credsFileTmp := tmp.Name()
 	credsFile = &credsFileTmp
+	clientCredsSigChan = make(chan os.Signal, 1)
 
 	// load old creds
 	fmt.Fprint(tmp, `{"Username": "old", "Password": "123456"}`)

--- a/go/vt/grpcclient/client_auth_static_test.go
+++ b/go/vt/grpcclient/client_auth_static_test.go
@@ -89,10 +89,10 @@ func TestHandleStaticAuthCredsFileSignals(t *testing.T) {
 	// load old creds
 	fmt.Fprintln(tmp, `{"Username": "old", "Password": "123456"}`)
 	ResetStaticAuth()
-	AppendStaticAuth([]grpc.DialOption{})
+	_, _ = AppendStaticAuth([]grpc.DialOption{})
 
 	// write new creds to the same file
-	tmp.Truncate(0)
+	_ = tmp.Truncate(0)
 	_, _ = tmp.Seek(0, 0)
 	fmt.Fprintln(tmp, `{"Username": "new", "Password": "123456789"}`)
 

--- a/go/vt/vtgate/grpcvtgateconn/conn_rpc_test.go
+++ b/go/vt/vtgate/grpcvtgateconn/conn_rpc_test.go
@@ -27,6 +27,7 @@ import (
 
 	"context"
 
+	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/vtgate/grpcvtgateservice"
 	"vitess.io/vitess/go/vt/vtgate/vtgateconn"
@@ -105,6 +106,7 @@ func TestGRPCVTGateConnAuth(t *testing.T) {
 	// Create a Go RPC client connecting to the server
 	ctx := context.Background()
 	flag.Set("grpc_auth_static_client_creds", f.Name())
+	grpcclient.ResetStaticAuth()
 	client, err := dial(ctx, listener.Addr().String())
 	if err != nil {
 		t.Fatalf("dial failed: %v", err)
@@ -138,6 +140,7 @@ func TestGRPCVTGateConnAuth(t *testing.T) {
 	// Create a Go RPC client connecting to the server
 	ctx = context.Background()
 	flag.Set("grpc_auth_static_client_creds", f.Name())
+	grpcclient.ResetStaticAuth()
 	client, err = dial(ctx, listener.Addr().String())
 	if err != nil {
 		t.Fatalf("dial failed: %v", err)


### PR DESCRIPTION
## Description

This PR backports https://github.com/vitessio/vitess/pull/15030 to our v14 branch

This is currently unmerged [but got a LGTM 👍 from upstream](https://github.com/vitessio/vitess/pull/15030#pullrequestreview-1870627261). If there are further changes I will sync them down

## Related Issue(s)

https://github.com/vitessio/vitess/pull/15030

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
