### PR TITLE
`slack-vitess-r15.0.5`: backport upstream PR #11968

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -32,6 +32,12 @@ ARG CGO_ENABLED=0
 # Allows docker builds to set the BUILD_NUMBER
 ARG BUILD_NUMBER
 
+# Allows docker builds to set the BUILD_GIT_BRANCH
+ARG BUILD_GIT_BRANCH
+
+# Allows docker builds to set the BUILD_GIT_REV
+ARG BUILD_GIT_REV
+
 # Re-copy sources from working tree
 USER root
 COPY . /vt/src/vitess.io/vitess

--- a/docker/base/Dockerfile.mariadb
+++ b/docker/base/Dockerfile.mariadb
@@ -9,6 +9,12 @@ ARG CGO_ENABLED=0
 # Allows docker builds to set the BUILD_NUMBER
 ARG BUILD_NUMBER
 
+# Allows docker builds to set the BUILD_GIT_BRANCH
+ARG BUILD_GIT_BRANCH
+
+# Allows docker builds to set the BUILD_GIT_REV
+ARG BUILD_GIT_REV
+
 # Re-copy sources from working tree
 USER root
 COPY . /vt/src/vitess.io/vitess

--- a/docker/base/Dockerfile.mariadb103
+++ b/docker/base/Dockerfile.mariadb103
@@ -9,6 +9,12 @@ ARG CGO_ENABLED=0
 # Allows docker builds to set the BUILD_NUMBER
 ARG BUILD_NUMBER
 
+# Allows docker builds to set the BUILD_GIT_BRANCH
+ARG BUILD_GIT_BRANCH
+
+# Allows docker builds to set the BUILD_GIT_REV
+ARG BUILD_GIT_REV
+
 # Re-copy sources from working tree
 USER root
 COPY . /vt/src/vitess.io/vitess

--- a/docker/base/Dockerfile.mysql80
+++ b/docker/base/Dockerfile.mysql80
@@ -9,6 +9,12 @@ ARG CGO_ENABLED=0
 # Allows docker builds to set the BUILD_NUMBER
 ARG BUILD_NUMBER
 
+# Allows docker builds to set the BUILD_GIT_BRANCH
+ARG BUILD_GIT_BRANCH
+
+# Allows docker builds to set the BUILD_GIT_REV
+ARG BUILD_GIT_REV
+
 # Re-copy sources from working tree
 USER root
 COPY . /vt/src/vitess.io/vitess

--- a/docker/base/Dockerfile.percona57
+++ b/docker/base/Dockerfile.percona57
@@ -9,6 +9,12 @@ ARG CGO_ENABLED=0
 # Allows docker builds to set the BUILD_NUMBER
 ARG BUILD_NUMBER
 
+# Allows docker builds to set the BUILD_GIT_BRANCH
+ARG BUILD_GIT_BRANCH
+
+# Allows docker builds to set the BUILD_GIT_REV
+ARG BUILD_GIT_REV
+
 # Re-copy sources from working tree
 USER root
 COPY . /vt/src/vitess.io/vitess

--- a/docker/base/Dockerfile.percona80
+++ b/docker/base/Dockerfile.percona80
@@ -9,6 +9,12 @@ ARG CGO_ENABLED=0
 # Allows docker builds to set the BUILD_NUMBER
 ARG BUILD_NUMBER
 
+# Allows docker builds to set the BUILD_GIT_BRANCH
+ARG BUILD_GIT_BRANCH
+
+# Allows docker builds to set the BUILD_GIT_REV
+ARG BUILD_GIT_REV
+
 # Re-copy sources from working tree
 USER root
 COPY . /vt/src/vitess.io/vitess


### PR DESCRIPTION
## Description

This PR backports v16 PR https://github.com/vitessio/vitess/pull/11968 that fixes build-related metrics/vars so the git branch, commit, etc is displayed correctly

We currently rely on this backport in v12 + v14. The debt is payed down in v16

## Related Issue(s)

https://github.com/vitessio/vitess/pull/11968

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
