### PR TITLE
Don't crash when gRPC metrics are enabled without a server

### DIFF
--- a/go/cmd/vtgateproxy/vtgateproxy.go
+++ b/go/cmd/vtgateproxy/vtgateproxy.go
@@ -21,11 +21,10 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/exit"
+	"vitess.io/vitess/go/stats/prometheusbackend"
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/vtgateproxy"
 )
-
-var ()
 
 func init() {
 	rand.Seed(time.Now().UnixNano())
@@ -37,6 +36,8 @@ func main() {
 
 	servenv.ParseFlags("vtgateproxy")
 	servenv.Init()
+
+	prometheusbackend.Init("vtgateproxy")
 
 	servenv.OnRun(func() {
 		// Flags are parsed now. Parse the template using the actual flag value and overwrite the current template.

--- a/go/vt/servenv/grpc_server.go
+++ b/go/vt/servenv/grpc_server.go
@@ -219,13 +219,14 @@ func interceptors() []grpc.ServerOption {
 }
 
 func serveGRPC() {
-	if *grpccommon.EnableGRPCPrometheus {
-		grpc_prometheus.Register(GRPCServer)
-		grpc_prometheus.EnableHandlingTimeHistogram()
-	}
 	// skip if not registered
 	if GRPCPort == nil || *GRPCPort == 0 {
 		return
+	}
+
+	if *grpccommon.EnableGRPCPrometheus {
+		grpc_prometheus.Register(GRPCServer)
+		grpc_prometheus.EnableHandlingTimeHistogram()
 	}
 
 	// register reflection to support list calls :)


### PR DESCRIPTION
`--grpc_prometheus` enables server and client gRPC metrics. But if we don't have a gRPC server, but call `servenv.Run()` like we're doing here, the process will crash because of some uninitialized server state. Fix by moving the prom enable logic after the check to see if we actually have a server.

This is still a bug upstream, so I'll send the fix there as well. 