### PR TITLE
`slack-vitess-r15.0.5`: forward-port consul topo limits PR #111

### DIFF
--- a/go/flags/endtoend/vtbackup.txt
+++ b/go/flags/endtoend/vtbackup.txt
@@ -150,9 +150,12 @@ Usage of vtbackup:
       --tablet_manager_grpc_key string                  the key to use to connect
       --tablet_manager_grpc_server_name string          the server name to use to validate server certificate
       --tablet_manager_protocol string                  Protocol to use to make tabletmanager RPCs to vttablets. (default "grpc")
+      --topo_consul_idle_conn_timeout duration          Maximum amount of time to pool idle connections. (default 1m30s)
       --topo_consul_lock_delay duration                 LockDelay for consul session. (default 15s)
       --topo_consul_lock_session_checks string          List of checks for consul session. (default "serfHealth")
       --topo_consul_lock_session_ttl string             TTL for consul session.
+      --topo_consul_max_conns_per_host int              Maximum number of consul connections per host.
+      --topo_consul_max_idle_conns int                  Maximum number of idle consul connections. (default 100)
       --topo_consul_watch_poll_duration duration        time of the long poll for watch queries. (default 30s)
       --topo_etcd_lease_ttl int                         Lease TTL for locks and leader election. The client will use KeepAlive to keep the lease going. (default 30)
       --topo_etcd_tls_ca string                         path to the ca to use to validate the server cert when connecting to the etcd topo server

--- a/go/flags/endtoend/vtctld.txt
+++ b/go/flags/endtoend/vtctld.txt
@@ -119,9 +119,12 @@ Usage of vtctld:
       --tablet_refresh_interval duration                                 Tablet refresh interval. (default 1m0s)
       --tablet_refresh_known_tablets                                     Whether to reload the tablet's address/port map from topo in case they change. (default true)
       --tablet_url_template string                                       Format string describing debug tablet url formatting. See getTabletDebugURL() for how to customize this. (default "http://{{.GetTabletHostPort}}")
+      --topo_consul_idle_conn_timeout duration                           Maximum amount of time to pool idle connections. (default 1m30s)
       --topo_consul_lock_delay duration                                  LockDelay for consul session. (default 15s)
       --topo_consul_lock_session_checks string                           List of checks for consul session. (default "serfHealth")
       --topo_consul_lock_session_ttl string                              TTL for consul session.
+      --topo_consul_max_conns_per_host int                               Maximum number of consul connections per host.
+      --topo_consul_max_idle_conns int                                   Maximum number of idle consul connections. (default 100)
       --topo_consul_watch_poll_duration duration                         time of the long poll for watch queries. (default 30s)
       --topo_etcd_lease_ttl int                                          Lease TTL for locks and leader election. The client will use KeepAlive to keep the lease going. (default 30)
       --topo_etcd_tls_ca string                                          path to the ca to use to validate the server cert when connecting to the etcd topo server

--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -165,9 +165,12 @@ Usage of vtgate:
       --tablet_refresh_known_tablets                                     Whether to reload the tablet's address/port map from topo in case they change. (default true)
       --tablet_types_to_wait strings                                     Wait till connected for specified tablet types during Gateway initialization. Should be provided as a comma-separated set of tablet types.
       --tablet_url_template string                                       Format string describing debug tablet url formatting. See getTabletDebugURL() for how to customize this. (default "http://{{.GetTabletHostPort}}")
+      --topo_consul_idle_conn_timeout duration                           Maximum amount of time to pool idle connections. (default 1m30s)
       --topo_consul_lock_delay duration                                  LockDelay for consul session. (default 15s)
       --topo_consul_lock_session_checks string                           List of checks for consul session. (default "serfHealth")
       --topo_consul_lock_session_ttl string                              TTL for consul session.
+      --topo_consul_max_conns_per_host int                               Maximum number of consul connections per host.
+      --topo_consul_max_idle_conns int                                   Maximum number of idle consul connections. (default 100)
       --topo_consul_watch_poll_duration duration                         time of the long poll for watch queries. (default 30s)
       --topo_etcd_lease_ttl int                                          Lease TTL for locks and leader election. The client will use KeepAlive to keep the lease going. (default 30)
       --topo_etcd_tls_ca string                                          path to the ca to use to validate the server cert when connecting to the etcd topo server

--- a/go/flags/endtoend/vtgr.txt
+++ b/go/flags/endtoend/vtgr.txt
@@ -49,9 +49,12 @@ Usage of vtgr:
       --tablet_manager_grpc_key string             the key to use to connect
       --tablet_manager_grpc_server_name string     the server name to use to validate server certificate
       --tablet_manager_protocol string             Protocol to use to make tabletmanager RPCs to vttablets. (default "grpc")
+      --topo_consul_idle_conn_timeout duration     Maximum amount of time to pool idle connections. (default 1m30s)
       --topo_consul_lock_delay duration            LockDelay for consul session. (default 15s)
       --topo_consul_lock_session_checks string     List of checks for consul session. (default "serfHealth")
       --topo_consul_lock_session_ttl string        TTL for consul session.
+      --topo_consul_max_conns_per_host int         Maximum number of consul connections per host.
+      --topo_consul_max_idle_conns int             Maximum number of idle consul connections. (default 100)
       --topo_consul_watch_poll_duration duration   time of the long poll for watch queries. (default 30s)
       --topo_etcd_lease_ttl int                    Lease TTL for locks and leader election. The client will use KeepAlive to keep the lease going. (default 30)
       --topo_etcd_tls_ca string                    path to the ca to use to validate the server cert when connecting to the etcd topo server

--- a/go/flags/endtoend/vtorc.txt
+++ b/go/flags/endtoend/vtorc.txt
@@ -60,9 +60,12 @@ Usage of vtorc:
       --tablet_manager_grpc_server_name string       the server name to use to validate server certificate
       --tablet_manager_protocol string               Protocol to use to make tabletmanager RPCs to vttablets. (default "grpc")
       --topo-information-refresh-duration duration   Timer duration on which VTOrc refreshes the keyspace and vttablet records from the topology server (default 15s)
+      --topo_consul_idle_conn_timeout duration       Maximum amount of time to pool idle connections. (default 1m30s)
       --topo_consul_lock_delay duration              LockDelay for consul session. (default 15s)
       --topo_consul_lock_session_checks string       List of checks for consul session. (default "serfHealth")
       --topo_consul_lock_session_ttl string          TTL for consul session.
+      --topo_consul_max_conns_per_host int           Maximum number of consul connections per host.
+      --topo_consul_max_idle_conns int               Maximum number of idle consul connections. (default 100)
       --topo_consul_watch_poll_duration duration     time of the long poll for watch queries. (default 30s)
       --topo_etcd_lease_ttl int                      Lease TTL for locks and leader election. The client will use KeepAlive to keep the lease going. (default 30)
       --topo_etcd_tls_ca string                      path to the ca to use to validate the server cert when connecting to the etcd topo server

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -302,9 +302,12 @@ Usage of vttablet:
       --throttle_metrics_threshold float                                 Override default throttle threshold, respective to -throttle_metrics_query (default 1.7976931348623157e+308)
       --throttle_tablet_types string                                     Comma separated VTTablet types to be considered by the throttler. default: 'replica'. example: 'replica,rdonly'. 'replica' aways implicitly included (default "replica")
       --throttle_threshold duration                                      Replication lag threshold for default lag throttling (default 1s)
+      --topo_consul_idle_conn_timeout duration                           Maximum amount of time to pool idle connections. (default 1m30s)
       --topo_consul_lock_delay duration                                  LockDelay for consul session. (default 15s)
       --topo_consul_lock_session_checks string                           List of checks for consul session. (default "serfHealth")
       --topo_consul_lock_session_ttl string                              TTL for consul session.
+      --topo_consul_max_conns_per_host int                               Maximum number of consul connections per host.
+      --topo_consul_max_idle_conns int                                   Maximum number of idle consul connections. (default 100)
       --topo_consul_watch_poll_duration duration                         time of the long poll for watch queries. (default 30s)
       --topo_etcd_lease_ttl int                                          Lease TTL for locks and leader election. The client will use KeepAlive to keep the lease going. (default 30)
       --topo_etcd_tls_ca string                                          path to the ca to use to validate the server cert when connecting to the etcd topo server

--- a/go/flags/endtoend/vttestserver.txt
+++ b/go/flags/endtoend/vttestserver.txt
@@ -108,9 +108,12 @@ Usage of vttestserver:
       --tablet_manager_grpc_key string                                   the key to use to connect
       --tablet_manager_grpc_server_name string                           the server name to use to validate server certificate
       --tablet_manager_protocol string                                   Protocol to use to make tabletmanager RPCs to vttablets. (default "grpc")
+      --topo_consul_idle_conn_timeout duration                           Maximum amount of time to pool idle connections. (default 1m30s)
       --topo_consul_lock_delay duration                                  LockDelay for consul session. (default 15s)
       --topo_consul_lock_session_checks string                           List of checks for consul session. (default "serfHealth")
       --topo_consul_lock_session_ttl string                              TTL for consul session.
+      --topo_consul_max_conns_per_host int                               Maximum number of consul connections per host.
+      --topo_consul_max_idle_conns int                                   Maximum number of idle consul connections. (default 100)
       --topo_consul_watch_poll_duration duration                         time of the long poll for watch queries. (default 30s)
       --topo_zk_auth_file string                                         auth to use when connecting to the zk topo server, file contents should be <scheme>:<auth>, e.g., digest:user:pass
       --topo_zk_base_timeout duration                                    zk base timeout (see zk.Connect) (default 30s)

--- a/go/vt/topo/consultopo/server.go
+++ b/go/vt/topo/consultopo/server.go
@@ -38,6 +38,7 @@ import (
 
 var (
 	consulAuthClientStaticFile string
+	consulConfig               = api.DefaultConfig()
 	// serfHealth is the default check from consul
 	consulLockSessionChecks = "serfHealth"
 	consulLockSessionTTL    string
@@ -53,6 +54,9 @@ func registerServerFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&consulLockSessionChecks, "topo_consul_lock_session_checks", consulLockSessionChecks, "List of checks for consul session.")
 	fs.StringVar(&consulLockSessionTTL, "topo_consul_lock_session_ttl", consulLockSessionTTL, "TTL for consul session.")
 	fs.DurationVar(&consulLockDelay, "topo_consul_lock_delay", consulLockDelay, "LockDelay for consul session.")
+	fs.IntVar(&consulConfig.Transport.MaxConnsPerHost, "topo_consul_max_conns_per_host", consulConfig.Transport.MaxConnsPerHost, "Maximum number of consul connections per host.")
+	fs.IntVar(&consulConfig.Transport.MaxIdleConns, "topo_consul_max_idle_conns", consulConfig.Transport.MaxIdleConns, "Maximum number of idle consul connections.")
+	fs.DurationVar(&consulConfig.Transport.IdleConnTimeout, "topo_consul_idle_conn_timeout", consulConfig.Transport.IdleConnTimeout, "Maximum amount of time to pool idle connections.")
 }
 
 // ClientAuthCred credential to use for consul clusters
@@ -131,7 +135,7 @@ func NewServer(cell, serverAddr, root string) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
-	cfg := api.DefaultConfig()
+	cfg := consulConfig
 	cfg.Address = serverAddr
 	if creds != nil {
 		if creds[cell] != nil {


### PR DESCRIPTION
## Description

This PR is a forward-port of #111, which addressed issues with the consul connection pool being unbounded. These flags are required by our existing v14 components

An upstream PR of this was made but is blocked on a request for an end-to-end test I haven't found the time to complete 🤦. Hoping to get to that soon 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
