### PR TITLE
Suppress non-critical messages to prevent logs spamming

### DIFF
--- a/go/vt/discovery/keyspace_events.go
+++ b/go/vt/discovery/keyspace_events.go
@@ -269,10 +269,10 @@ func (kss *keyspaceState) ensureConsistentLocked() {
 			Serving: sstate.serving,
 		})
 
-		log.Infof("keyspace event resolved: %s/%s is now consistent (serving: %v)",
-			sstate.target.Keyspace, sstate.target.Keyspace,
-			sstate.serving,
-		)
+		//log.Infof("keyspace event resolved: %s/%s is now consistent (serving: %v)",
+		//	sstate.target.Keyspace, sstate.target.Keyspace,
+		//	sstate.serving,
+		//)
 
 		if !sstate.serving {
 			delete(kss.shards, shard)

--- a/go/vt/discovery/tablet_health_check.go
+++ b/go/vt/discovery/tablet_health_check.go
@@ -350,7 +350,10 @@ func (thc *tabletHealthCheck) checkConn(hc *HealthCheckImpl) {
 }
 
 func (thc *tabletHealthCheck) closeConnection(ctx context.Context, err error) {
-	log.Warningf("tablet %v healthcheck stream error: %v", thc.Tablet, err)
+	if thc.Tablet.Type != topodata.TabletType_RESTORE {
+		log.Warningf("tablet %v healthcheck stream error: %v", thc.Tablet, err)
+	}
+
 	thc.setServingState(false, err.Error())
 	thc.LastError = err
 	_ = thc.Conn.Close(ctx)

--- a/go/vt/logutil/vts_logger.go
+++ b/go/vt/logutil/vts_logger.go
@@ -32,7 +32,7 @@ func SetVTStructureLogger(conf *zap.Config) (vtSLogger *zap.SugaredLogger, err e
 	// Use the passed configuration instead of the default configuration
 	if conf == nil {
 		defaultProdConf := zap.NewProductionConfig()
-		defaultProdConf.Level.SetLevel(zap.WarnLevel)
+		//defaultProdConf.Level.SetLevel(zap.WarnLevel)
 		conf = &defaultProdConf
 	}
 

--- a/go/vt/logutil/vts_logger.go
+++ b/go/vt/logutil/vts_logger.go
@@ -32,6 +32,7 @@ func SetVTStructureLogger(conf *zap.Config) (vtSLogger *zap.SugaredLogger, err e
 	// Use the passed configuration instead of the default configuration
 	if conf == nil {
 		defaultProdConf := zap.NewProductionConfig()
+		defaultProdConf.Level.SetLevel(zap.WarnLevel)
 		conf = &defaultProdConf
 	}
 

--- a/go/vt/vtgate/buffer/shard_buffer.go
+++ b/go/vt/vtgate/buffer/shard_buffer.go
@@ -480,7 +480,7 @@ func (sb *shardBuffer) recordKeyspaceEvent(alias *topodatapb.TabletAlias, stillS
 	sb.mu.Lock()
 	defer sb.mu.Unlock()
 
-	log.Infof("disruption in shard %s/%s resolved (serving: %v)", sb.keyspace, sb.shard, stillServing)
+	//log.Infof("disruption in shard %s/%s resolved (serving: %v)", sb.keyspace, sb.shard, stillServing)
 
 	if !topoproto.TabletAliasEqual(alias, sb.currentPrimary) {
 		if sb.currentPrimary != nil {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

suppress these 2 massive logging messages:
```
"keyspace event resolved: msgdata/msgdata is now consistent (serving: true)"
"disruption in shard msgdata/4780-47c0 resolved (serving: true)"
```
```
$ jq .msg jq.log|awk '{print $1}'|sort|uniq -c
     29 "Adding
    138 "[core]
  13000 "disruption
     53 "Error
     91 "HealthCheckUpdate(Serving
   1708 "keyspace
     26 "Removing
   7661 "tablet
     17 "Tablet

$ jq .level jq.log|sort|uniq -c
     57 "error"
  14867 "info"
   7799 "warn"
```


## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
