### PR TITLE
restructure discovery to do more up front

### DIFF
--- a/go/vt/vtgateproxy/discovery.go
+++ b/go/vt/vtgateproxy/discovery.go
@@ -57,6 +57,19 @@ import (
 // type: Only select from hosts of this type (required)
 //
 
+// Resolver(https://godoc.org/google.golang.org/grpc/resolver#Resolver).
+type JSONGateResolver struct {
+	target     resolver.Target
+	clientConn resolver.ClientConn
+	poolType   string
+}
+
+func (r *JSONGateResolver) ResolveNow(o resolver.ResolveNowOptions) {}
+
+func (r *JSONGateResolver) Close() {
+	log.Infof("Closing resolver for target %s", r.target.URL.String())
+}
+
 type JSONGateResolverBuilder struct {
 	jsonPath      string
 	addressField  string
@@ -78,13 +91,6 @@ type targetHost struct {
 	Addr     string
 	PoolType string
 	Affinity string
-}
-
-// Resolver(https://godoc.org/google.golang.org/grpc/resolver#Resolver).
-type JSONGateResolver struct {
-	target     resolver.Target
-	clientConn resolver.ClientConn
-	poolType   string
 }
 
 var (
@@ -401,12 +407,6 @@ func (b *JSONGateResolverBuilder) debugTargets() any {
 		Pools:   pools,
 		Targets: targets,
 	}
-}
-
-func (r *JSONGateResolver) ResolveNow(o resolver.ResolveNowOptions) {}
-
-func (r *JSONGateResolver) Close() {
-	log.Infof("Closing resolver for target %s", r.target.URL.String())
 }
 
 const (

--- a/go/vt/vtgateproxy/discovery.go
+++ b/go/vt/vtgateproxy/discovery.go
@@ -191,11 +191,11 @@ func (b *JSONGateResolverBuilder) start() error {
 				}
 				continue
 			}
+			parseErr = nil
 			if !contentsChanged {
 				parseCount.Add("unchanged", 1)
 				continue
 			}
-			parseErr = nil
 			parseCount.Add("changed", 1)
 
 			// notify all the resolvers that the targets changed

--- a/go/vt/vtgateproxy/vtgateproxy.go
+++ b/go/vt/vtgateproxy/vtgateproxy.go
@@ -43,7 +43,8 @@ var (
 	vtgateHostsFile = flag.String("vtgate_hosts_file", "", "json file describing the host list to use for vtgate:// resolution")
 	numConnections  = flag.Int("num_connections", 4, "number of outbound GPRC connections to maintain")
 	poolTypeField   = flag.String("pool_type_field", "", "Field name used to specify the target vtgate type and filter the hosts")
-	affinityField   = flag.String("affinity_field", "", "Attribute (both mysql protocol connection and JSON file) used to specify the routing affinity , e.g. 'az_id'")
+	affinityField   = flag.String("affinity_field", "", "Attribute (JSON file) used to specify the routing affinity , e.g. 'az_id'")
+	affinityValue   = flag.String("affinity_value", "", "Value to match for routing affinity , e.g. 'use-az1'")
 	addressField    = flag.String("address_field", "address", "field name in the json file containing the address")
 	portField       = flag.String("port_field", "port", "field name in the json file containing the port")
 
@@ -194,5 +195,6 @@ func Init() {
 		*portField,
 		*poolTypeField,
 		*affinityField,
+		*affinityValue,
 	)
 }


### PR DESCRIPTION
## Description

- move organization of target hosts to parse time so we do it less often
- pass affinityValue in at run time instead of in the connection attributes
- rework discovery metrics
- add discovery data to the `/debug/status` endpoint

