### PR TITLE
`slack-vitess-r15.0.5`: retry CI tests with `nick-fields/retry@v2`

### DIFF
--- a/.github/workflows/cluster_endtoend_12.yml
+++ b/.github/workflows/cluster_endtoend_12.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard 12
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard 12

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard 13
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard 13

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard 15
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard 15

--- a/.github/workflows/cluster_endtoend_18.yml
+++ b/.github/workflows/cluster_endtoend_18.yml
@@ -95,14 +95,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard 18
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard 18

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard 21
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard 21

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard 22
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard 22

--- a/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
+++ b/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
@@ -90,34 +90,38 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # Increase our local ephemeral port range as we could exhaust this
-        sudo sysctl -w net.ipv4.ip_local_port_range="22768 61999"
-        # Increase our open file descriptor limit as we could hit this
-        ulimit -n 65536
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
-        innodb_buffer_pool_dump_at_shutdown=OFF
-        innodb_buffer_pool_in_core_file=OFF
-        innodb_buffer_pool_load_at_startup=OFF
-        innodb_buffer_pool_size=64M
-        innodb_doublewrite=OFF
-        innodb_flush_log_at_trx_commit=0
-        innodb_flush_method=O_DIRECT
-        innodb_numa_interleave=ON
-        innodb_adaptive_hash_index=OFF
-        sync_binlog=0
-        sync_relay_log=0
-        performance_schema=OFF
-        slow-query-log=OFF
-        EOF
-        
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard ers_prs_newfeatures_heavy
+          # Increase our local ephemeral port range as we could exhaust this
+          sudo sysctl -w net.ipv4.ip_local_port_range="22768 61999"
+          # Increase our open file descriptor limit as we could hit this
+          ulimit -n 65536
+          cat <<-EOF>>./config/mycnf/mysql80.cnf
+          innodb_buffer_pool_dump_at_shutdown=OFF
+          innodb_buffer_pool_in_core_file=OFF
+          innodb_buffer_pool_load_at_startup=OFF
+          innodb_buffer_pool_size=64M
+          innodb_doublewrite=OFF
+          innodb_flush_log_at_trx_commit=0
+          innodb_flush_method=O_DIRECT
+          innodb_numa_interleave=ON
+          innodb_adaptive_hash_index=OFF
+          sync_binlog=0
+          sync_relay_log=0
+          performance_schema=OFF
+          slow-query-log=OFF
+          EOF
+          
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard ers_prs_newfeatures_heavy

--- a/.github/workflows/cluster_endtoend_mysql80.yml
+++ b/.github/workflows/cluster_endtoend_mysql80.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard mysql80
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard mysql80

--- a/.github/workflows/cluster_endtoend_mysql_server_vault.yml
+++ b/.github/workflows/cluster_endtoend_mysql_server_vault.yml
@@ -95,14 +95,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard mysql_server_vault
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard mysql_server_vault

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard onlineddl_declarative
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard onlineddl_declarative

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard onlineddl_ghost
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard onlineddl_ghost

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard onlineddl_revert
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard onlineddl_revert

--- a/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard onlineddl_revertible
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard onlineddl_revertible

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard onlineddl_scheduler
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard onlineddl_scheduler

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard onlineddl_singleton
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard onlineddl_singleton

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard onlineddl_vrepl
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard onlineddl_vrepl

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard onlineddl_vrepl_stress
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard onlineddl_vrepl_stress

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard onlineddl_vrepl_stress_suite
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard onlineddl_vrepl_stress_suite

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard onlineddl_vrepl_suite
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard onlineddl_vrepl_suite

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard schemadiff_vrepl
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard schemadiff_vrepl

--- a/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
@@ -95,14 +95,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard tabletmanager_consul
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard tabletmanager_consul

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard tabletmanager_tablegc
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard tabletmanager_tablegc

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard tabletmanager_throttler
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard tabletmanager_throttler

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard tabletmanager_throttler_custom_config
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard tabletmanager_throttler_custom_config

--- a/.github/workflows/cluster_endtoend_topo_connection_cache.yml
+++ b/.github/workflows/cluster_endtoend_topo_connection_cache.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard topo_connection_cache
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard topo_connection_cache

--- a/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
@@ -90,34 +90,38 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # Increase our local ephemeral port range as we could exhaust this
-        sudo sysctl -w net.ipv4.ip_local_port_range="22768 61999"
-        # Increase our open file descriptor limit as we could hit this
-        ulimit -n 65536
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
-        innodb_buffer_pool_dump_at_shutdown=OFF
-        innodb_buffer_pool_in_core_file=OFF
-        innodb_buffer_pool_load_at_startup=OFF
-        innodb_buffer_pool_size=64M
-        innodb_doublewrite=OFF
-        innodb_flush_log_at_trx_commit=0
-        innodb_flush_method=O_DIRECT
-        innodb_numa_interleave=ON
-        innodb_adaptive_hash_index=OFF
-        sync_binlog=0
-        sync_relay_log=0
-        performance_schema=OFF
-        slow-query-log=OFF
-        EOF
-        
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vreplication_across_db_versions
+          # Increase our local ephemeral port range as we could exhaust this
+          sudo sysctl -w net.ipv4.ip_local_port_range="22768 61999"
+          # Increase our open file descriptor limit as we could hit this
+          ulimit -n 65536
+          cat <<-EOF>>./config/mycnf/mysql80.cnf
+          innodb_buffer_pool_dump_at_shutdown=OFF
+          innodb_buffer_pool_in_core_file=OFF
+          innodb_buffer_pool_load_at_startup=OFF
+          innodb_buffer_pool_size=64M
+          innodb_doublewrite=OFF
+          innodb_flush_log_at_trx_commit=0
+          innodb_flush_method=O_DIRECT
+          innodb_numa_interleave=ON
+          innodb_adaptive_hash_index=OFF
+          sync_binlog=0
+          sync_relay_log=0
+          performance_schema=OFF
+          slow-query-log=OFF
+          EOF
+          
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard vreplication_across_db_versions

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -90,34 +90,38 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # Increase our local ephemeral port range as we could exhaust this
-        sudo sysctl -w net.ipv4.ip_local_port_range="22768 61999"
-        # Increase our open file descriptor limit as we could hit this
-        ulimit -n 65536
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
-        innodb_buffer_pool_dump_at_shutdown=OFF
-        innodb_buffer_pool_in_core_file=OFF
-        innodb_buffer_pool_load_at_startup=OFF
-        innodb_buffer_pool_size=64M
-        innodb_doublewrite=OFF
-        innodb_flush_log_at_trx_commit=0
-        innodb_flush_method=O_DIRECT
-        innodb_numa_interleave=ON
-        innodb_adaptive_hash_index=OFF
-        sync_binlog=0
-        sync_relay_log=0
-        performance_schema=OFF
-        slow-query-log=OFF
-        EOF
-        
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vreplication_basic
+          # Increase our local ephemeral port range as we could exhaust this
+          sudo sysctl -w net.ipv4.ip_local_port_range="22768 61999"
+          # Increase our open file descriptor limit as we could hit this
+          ulimit -n 65536
+          cat <<-EOF>>./config/mycnf/mysql80.cnf
+          innodb_buffer_pool_dump_at_shutdown=OFF
+          innodb_buffer_pool_in_core_file=OFF
+          innodb_buffer_pool_load_at_startup=OFF
+          innodb_buffer_pool_size=64M
+          innodb_doublewrite=OFF
+          innodb_flush_log_at_trx_commit=0
+          innodb_flush_method=O_DIRECT
+          innodb_numa_interleave=ON
+          innodb_adaptive_hash_index=OFF
+          sync_binlog=0
+          sync_relay_log=0
+          performance_schema=OFF
+          slow-query-log=OFF
+          EOF
+          
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard vreplication_basic

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -90,34 +90,38 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # Increase our local ephemeral port range as we could exhaust this
-        sudo sysctl -w net.ipv4.ip_local_port_range="22768 61999"
-        # Increase our open file descriptor limit as we could hit this
-        ulimit -n 65536
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
-        innodb_buffer_pool_dump_at_shutdown=OFF
-        innodb_buffer_pool_in_core_file=OFF
-        innodb_buffer_pool_load_at_startup=OFF
-        innodb_buffer_pool_size=64M
-        innodb_doublewrite=OFF
-        innodb_flush_log_at_trx_commit=0
-        innodb_flush_method=O_DIRECT
-        innodb_numa_interleave=ON
-        innodb_adaptive_hash_index=OFF
-        sync_binlog=0
-        sync_relay_log=0
-        performance_schema=OFF
-        slow-query-log=OFF
-        EOF
-        
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vreplication_cellalias
+          # Increase our local ephemeral port range as we could exhaust this
+          sudo sysctl -w net.ipv4.ip_local_port_range="22768 61999"
+          # Increase our open file descriptor limit as we could hit this
+          ulimit -n 65536
+          cat <<-EOF>>./config/mycnf/mysql80.cnf
+          innodb_buffer_pool_dump_at_shutdown=OFF
+          innodb_buffer_pool_in_core_file=OFF
+          innodb_buffer_pool_load_at_startup=OFF
+          innodb_buffer_pool_size=64M
+          innodb_doublewrite=OFF
+          innodb_flush_log_at_trx_commit=0
+          innodb_flush_method=O_DIRECT
+          innodb_numa_interleave=ON
+          innodb_adaptive_hash_index=OFF
+          sync_binlog=0
+          sync_relay_log=0
+          performance_schema=OFF
+          slow-query-log=OFF
+          EOF
+          
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard vreplication_cellalias

--- a/.github/workflows/cluster_endtoend_vreplication_migrate_vdiff2_convert_tz.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate_vdiff2_convert_tz.yml
@@ -90,34 +90,38 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # Increase our local ephemeral port range as we could exhaust this
-        sudo sysctl -w net.ipv4.ip_local_port_range="22768 61999"
-        # Increase our open file descriptor limit as we could hit this
-        ulimit -n 65536
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
-        innodb_buffer_pool_dump_at_shutdown=OFF
-        innodb_buffer_pool_in_core_file=OFF
-        innodb_buffer_pool_load_at_startup=OFF
-        innodb_buffer_pool_size=64M
-        innodb_doublewrite=OFF
-        innodb_flush_log_at_trx_commit=0
-        innodb_flush_method=O_DIRECT
-        innodb_numa_interleave=ON
-        innodb_adaptive_hash_index=OFF
-        sync_binlog=0
-        sync_relay_log=0
-        performance_schema=OFF
-        slow-query-log=OFF
-        EOF
-        
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vreplication_migrate_vdiff2_convert_tz
+          # Increase our local ephemeral port range as we could exhaust this
+          sudo sysctl -w net.ipv4.ip_local_port_range="22768 61999"
+          # Increase our open file descriptor limit as we could hit this
+          ulimit -n 65536
+          cat <<-EOF>>./config/mycnf/mysql80.cnf
+          innodb_buffer_pool_dump_at_shutdown=OFF
+          innodb_buffer_pool_in_core_file=OFF
+          innodb_buffer_pool_load_at_startup=OFF
+          innodb_buffer_pool_size=64M
+          innodb_doublewrite=OFF
+          innodb_flush_log_at_trx_commit=0
+          innodb_flush_method=O_DIRECT
+          innodb_numa_interleave=ON
+          innodb_adaptive_hash_index=OFF
+          sync_binlog=0
+          sync_relay_log=0
+          performance_schema=OFF
+          slow-query-log=OFF
+          EOF
+          
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard vreplication_migrate_vdiff2_convert_tz

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -90,34 +90,38 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # Increase our local ephemeral port range as we could exhaust this
-        sudo sysctl -w net.ipv4.ip_local_port_range="22768 61999"
-        # Increase our open file descriptor limit as we could hit this
-        ulimit -n 65536
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
-        innodb_buffer_pool_dump_at_shutdown=OFF
-        innodb_buffer_pool_in_core_file=OFF
-        innodb_buffer_pool_load_at_startup=OFF
-        innodb_buffer_pool_size=64M
-        innodb_doublewrite=OFF
-        innodb_flush_log_at_trx_commit=0
-        innodb_flush_method=O_DIRECT
-        innodb_numa_interleave=ON
-        innodb_adaptive_hash_index=OFF
-        sync_binlog=0
-        sync_relay_log=0
-        performance_schema=OFF
-        slow-query-log=OFF
-        EOF
-        
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vreplication_multicell
+          # Increase our local ephemeral port range as we could exhaust this
+          sudo sysctl -w net.ipv4.ip_local_port_range="22768 61999"
+          # Increase our open file descriptor limit as we could hit this
+          ulimit -n 65536
+          cat <<-EOF>>./config/mycnf/mysql80.cnf
+          innodb_buffer_pool_dump_at_shutdown=OFF
+          innodb_buffer_pool_in_core_file=OFF
+          innodb_buffer_pool_load_at_startup=OFF
+          innodb_buffer_pool_size=64M
+          innodb_doublewrite=OFF
+          innodb_flush_log_at_trx_commit=0
+          innodb_flush_method=O_DIRECT
+          innodb_numa_interleave=ON
+          innodb_adaptive_hash_index=OFF
+          sync_binlog=0
+          sync_relay_log=0
+          performance_schema=OFF
+          slow-query-log=OFF
+          EOF
+          
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard vreplication_multicell

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -90,34 +90,38 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # Increase our local ephemeral port range as we could exhaust this
-        sudo sysctl -w net.ipv4.ip_local_port_range="22768 61999"
-        # Increase our open file descriptor limit as we could hit this
-        ulimit -n 65536
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
-        innodb_buffer_pool_dump_at_shutdown=OFF
-        innodb_buffer_pool_in_core_file=OFF
-        innodb_buffer_pool_load_at_startup=OFF
-        innodb_buffer_pool_size=64M
-        innodb_doublewrite=OFF
-        innodb_flush_log_at_trx_commit=0
-        innodb_flush_method=O_DIRECT
-        innodb_numa_interleave=ON
-        innodb_adaptive_hash_index=OFF
-        sync_binlog=0
-        sync_relay_log=0
-        performance_schema=OFF
-        slow-query-log=OFF
-        EOF
-        
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vreplication_v2
+          # Increase our local ephemeral port range as we could exhaust this
+          sudo sysctl -w net.ipv4.ip_local_port_range="22768 61999"
+          # Increase our open file descriptor limit as we could hit this
+          ulimit -n 65536
+          cat <<-EOF>>./config/mycnf/mysql80.cnf
+          innodb_buffer_pool_dump_at_shutdown=OFF
+          innodb_buffer_pool_in_core_file=OFF
+          innodb_buffer_pool_load_at_startup=OFF
+          innodb_buffer_pool_size=64M
+          innodb_doublewrite=OFF
+          innodb_flush_log_at_trx_commit=0
+          innodb_flush_method=O_DIRECT
+          innodb_numa_interleave=ON
+          innodb_adaptive_hash_index=OFF
+          sync_binlog=0
+          sync_relay_log=0
+          performance_schema=OFF
+          slow-query-log=OFF
+          EOF
+          
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard vreplication_v2

--- a/.github/workflows/cluster_endtoend_vstream_failover.yml
+++ b/.github/workflows/cluster_endtoend_vstream_failover.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vstream_failover
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard vstream_failover

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vstream_stoponreshard_false
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard vstream_stoponreshard_false

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vstream_stoponreshard_true
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard vstream_stoponreshard_true

--- a/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
+++ b/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vstream_with_keyspaces_to_watch
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard vstream_with_keyspaces_to_watch

--- a/.github/workflows/cluster_endtoend_vtbackup_transform.yml
+++ b/.github/workflows/cluster_endtoend_vtbackup_transform.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vtbackup_transform
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard vtbackup_transform

--- a/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
@@ -90,34 +90,38 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # Increase our local ephemeral port range as we could exhaust this
-        sudo sysctl -w net.ipv4.ip_local_port_range="22768 61999"
-        # Increase our open file descriptor limit as we could hit this
-        ulimit -n 65536
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
-        innodb_buffer_pool_dump_at_shutdown=OFF
-        innodb_buffer_pool_in_core_file=OFF
-        innodb_buffer_pool_load_at_startup=OFF
-        innodb_buffer_pool_size=64M
-        innodb_doublewrite=OFF
-        innodb_flush_log_at_trx_commit=0
-        innodb_flush_method=O_DIRECT
-        innodb_numa_interleave=ON
-        innodb_adaptive_hash_index=OFF
-        sync_binlog=0
-        sync_relay_log=0
-        performance_schema=OFF
-        slow-query-log=OFF
-        EOF
-        
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vtctlbackup_sharded_clustertest_heavy
+          # Increase our local ephemeral port range as we could exhaust this
+          sudo sysctl -w net.ipv4.ip_local_port_range="22768 61999"
+          # Increase our open file descriptor limit as we could hit this
+          ulimit -n 65536
+          cat <<-EOF>>./config/mycnf/mysql80.cnf
+          innodb_buffer_pool_dump_at_shutdown=OFF
+          innodb_buffer_pool_in_core_file=OFF
+          innodb_buffer_pool_load_at_startup=OFF
+          innodb_buffer_pool_size=64M
+          innodb_doublewrite=OFF
+          innodb_flush_log_at_trx_commit=0
+          innodb_flush_method=O_DIRECT
+          innodb_numa_interleave=ON
+          innodb_adaptive_hash_index=OFF
+          sync_binlog=0
+          sync_relay_log=0
+          performance_schema=OFF
+          slow-query-log=OFF
+          EOF
+          
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard vtctlbackup_sharded_clustertest_heavy

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vtgate_concurrentdml
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard vtgate_concurrentdml

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vtgate_gen4
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard vtgate_gen4

--- a/.github/workflows/cluster_endtoend_vtgate_general_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_general_heavy.yml
@@ -90,34 +90,38 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # Increase our local ephemeral port range as we could exhaust this
-        sudo sysctl -w net.ipv4.ip_local_port_range="22768 61999"
-        # Increase our open file descriptor limit as we could hit this
-        ulimit -n 65536
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
-        innodb_buffer_pool_dump_at_shutdown=OFF
-        innodb_buffer_pool_in_core_file=OFF
-        innodb_buffer_pool_load_at_startup=OFF
-        innodb_buffer_pool_size=64M
-        innodb_doublewrite=OFF
-        innodb_flush_log_at_trx_commit=0
-        innodb_flush_method=O_DIRECT
-        innodb_numa_interleave=ON
-        innodb_adaptive_hash_index=OFF
-        sync_binlog=0
-        sync_relay_log=0
-        performance_schema=OFF
-        slow-query-log=OFF
-        EOF
-        
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vtgate_general_heavy
+          # Increase our local ephemeral port range as we could exhaust this
+          sudo sysctl -w net.ipv4.ip_local_port_range="22768 61999"
+          # Increase our open file descriptor limit as we could hit this
+          ulimit -n 65536
+          cat <<-EOF>>./config/mycnf/mysql80.cnf
+          innodb_buffer_pool_dump_at_shutdown=OFF
+          innodb_buffer_pool_in_core_file=OFF
+          innodb_buffer_pool_load_at_startup=OFF
+          innodb_buffer_pool_size=64M
+          innodb_doublewrite=OFF
+          innodb_flush_log_at_trx_commit=0
+          innodb_flush_method=O_DIRECT
+          innodb_numa_interleave=ON
+          innodb_adaptive_hash_index=OFF
+          sync_binlog=0
+          sync_relay_log=0
+          performance_schema=OFF
+          slow-query-log=OFF
+          EOF
+          
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard vtgate_general_heavy

--- a/.github/workflows/cluster_endtoend_vtgate_godriver.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_godriver.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vtgate_godriver
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard vtgate_godriver

--- a/.github/workflows/cluster_endtoend_vtgate_partial_keyspace.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_partial_keyspace.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vtgate_partial_keyspace -partial-keyspace=true 
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard vtgate_partial_keyspace -partial-keyspace=true 

--- a/.github/workflows/cluster_endtoend_vtgate_queries.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_queries.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vtgate_queries
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard vtgate_queries

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vtgate_readafterwrite
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard vtgate_readafterwrite

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vtgate_reservedconn
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard vtgate_reservedconn

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vtgate_schema
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard vtgate_schema

--- a/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vtgate_schema_tracker
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard vtgate_schema_tracker

--- a/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vtgate_tablet_healthcheck_cache
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard vtgate_tablet_healthcheck_cache

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vtgate_topo
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard vtgate_topo

--- a/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
@@ -95,14 +95,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vtgate_topo_consul
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard vtgate_topo_consul

--- a/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vtgate_topo_etcd
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard vtgate_topo_etcd

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vtgate_transaction
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard vtgate_transaction

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vtgate_unsharded
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard vtgate_unsharded

--- a/.github/workflows/cluster_endtoend_vtgate_vindex_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex_heavy.yml
@@ -90,34 +90,38 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # Increase our local ephemeral port range as we could exhaust this
-        sudo sysctl -w net.ipv4.ip_local_port_range="22768 61999"
-        # Increase our open file descriptor limit as we could hit this
-        ulimit -n 65536
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
-        innodb_buffer_pool_dump_at_shutdown=OFF
-        innodb_buffer_pool_in_core_file=OFF
-        innodb_buffer_pool_load_at_startup=OFF
-        innodb_buffer_pool_size=64M
-        innodb_doublewrite=OFF
-        innodb_flush_log_at_trx_commit=0
-        innodb_flush_method=O_DIRECT
-        innodb_numa_interleave=ON
-        innodb_adaptive_hash_index=OFF
-        sync_binlog=0
-        sync_relay_log=0
-        performance_schema=OFF
-        slow-query-log=OFF
-        EOF
-        
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vtgate_vindex_heavy
+          # Increase our local ephemeral port range as we could exhaust this
+          sudo sysctl -w net.ipv4.ip_local_port_range="22768 61999"
+          # Increase our open file descriptor limit as we could hit this
+          ulimit -n 65536
+          cat <<-EOF>>./config/mycnf/mysql80.cnf
+          innodb_buffer_pool_dump_at_shutdown=OFF
+          innodb_buffer_pool_in_core_file=OFF
+          innodb_buffer_pool_load_at_startup=OFF
+          innodb_buffer_pool_size=64M
+          innodb_doublewrite=OFF
+          innodb_flush_log_at_trx_commit=0
+          innodb_flush_method=O_DIRECT
+          innodb_numa_interleave=ON
+          innodb_adaptive_hash_index=OFF
+          sync_binlog=0
+          sync_relay_log=0
+          performance_schema=OFF
+          slow-query-log=OFF
+          EOF
+          
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard vtgate_vindex_heavy

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vtgate_vschema
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard vtgate_vschema

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vtorc
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard vtorc

--- a/.github/workflows/cluster_endtoend_vttablet_prscomplex.yml
+++ b/.github/workflows/cluster_endtoend_vttablet_prscomplex.yml
@@ -90,14 +90,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vttablet_prscomplex
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard vttablet_prscomplex

--- a/.github/workflows/cluster_endtoend_xb_backup.yml
+++ b/.github/workflows/cluster_endtoend_xb_backup.yml
@@ -93,14 +93,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard xb_backup
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard xb_backup

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -93,14 +93,18 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard xb_recovery
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker=false -follow -shard xb_recovery

--- a/.github/workflows/docker_test_cluster_10.yml
+++ b/.github/workflows/docker_test_cluster_10.yml
@@ -57,5 +57,10 @@ jobs:
 
     - name: Run tests which require docker - 1
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      run: |
-        go run test.go -docker=true --follow -shard 10 -bootstrap-version 14.1
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        retry_on: error
+        command: |
+          go run test.go -docker=true --follow -shard 10 -bootstrap-version 14.1

--- a/.github/workflows/docker_test_cluster_25.yml
+++ b/.github/workflows/docker_test_cluster_25.yml
@@ -56,5 +56,10 @@ jobs:
 
     - name: Run tests which require docker - 2
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      run: |
-        go run test.go -docker=true --follow -shard 25
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        retry_on: error
+        command: |
+          go run test.go -docker=true --follow -shard 25

--- a/.github/workflows/e2e_race.yml
+++ b/.github/workflows/e2e_race.yml
@@ -78,6 +78,10 @@ jobs:
 
     - name: e2e_race
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 30
-      run: |
-        make e2e_test_race
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        retry_on: error
+        command: |
+          make e2e_test_race

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -75,6 +75,10 @@ jobs:
 
     - name: endtoend
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 30
-      run: |
-        eatmydata -- tools/e2e_test_runner.sh
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        retry_on: error
+        command: |
+          eatmydata -- tools/e2e_test_runner.sh

--- a/.github/workflows/local_example.yml
+++ b/.github/workflows/local_example.yml
@@ -98,10 +98,14 @@ jobs:
 
     - name: local_example
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.examples == 'true'
-      timeout-minutes: 30
-      run: |
-        export TOPO=${{matrix.topo}}
-        if [ ${{matrix.os}} = "macos-latest" ]; then
-          export PATH="/usr/local/opt/mysql@5.7/bin:$PATH"
-        fi
-        eatmydata -- go run test.go -print-log -follow -retry=1 local_example
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        retry_on: error
+        command: |
+          export TOPO=${{matrix.topo}}
+          if [ ${{matrix.os}} = "macos-latest" ]; then
+            export PATH="/usr/local/opt/mysql@5.7/bin:$PATH"
+          fi
+          eatmydata -- go run test.go -print-log -follow -retry=1 local_example

--- a/.github/workflows/region_example.yml
+++ b/.github/workflows/region_example.yml
@@ -98,11 +98,15 @@ jobs:
 
     - name: region_example
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.examples == 'true'
-      timeout-minutes: 30
-      run: |
-        export TOPO=${{matrix.topo}}
-        if [ ${{matrix.os}} = "macos-latest" ]; then
-          export PATH="/usr/local/opt/mysql@5.7/bin:$PATH"
-        fi
-        sed -i 's/user\/my-vitess/runner\/work\/vitess\/vitess/g' examples/region_sharding/main_vschema_sharded.json #set correct path to countries.json
-        eatmydata -- go run test.go -print-log -follow -retry=1 region_example
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        retry_on: error
+        command: |
+          export TOPO=${{matrix.topo}}
+          if [ ${{matrix.os}} = "macos-latest" ]; then
+            export PATH="/usr/local/opt/mysql@5.7/bin:$PATH"
+          fi
+          sed -i 's/user\/my-vitess/runner\/work\/vitess\/vitess/g' examples/region_sharding/main_vschema_sharded.json #set correct path to countries.json
+          eatmydata -- go run test.go -print-log -follow -retry=1 region_example

--- a/.github/workflows/unit_test_mysql80.yml
+++ b/.github/workflows/unit_test_mysql80.yml
@@ -109,6 +109,10 @@ jobs:
 
     - name: Run test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.unit_tests == 'true'
-      timeout-minutes: 30
-      run: |
-        eatmydata -- make unit_test
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        retry_on: error
+        command: |
+          eatmydata -- make unit_test

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -162,12 +162,17 @@ jobs:
     # Run test with VTTablet at version N-1 and VTBackup at version N
     - name: Run backups tests (vttablet=N-1, vtbackup=N)
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      run: |
-        rm -rf /tmp/vtdataroot
-        mkdir -p /tmp/vtdataroot
-        set -x
-        source build.env
-        eatmydata -- go run test.go -skip-build -docker=false -print-log -follow -tag upgrade_downgrade_backups
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        retry_on: error
+        command: |
+          rm -rf /tmp/vtdataroot
+          mkdir -p /tmp/vtdataroot
+          set -x
+          source build.env
+          eatmydata -- go run test.go -skip-build -docker=false -print-log -follow -tag upgrade_downgrade_backups
 
     # Swap binaries again, use current version's VTTablet, and last release's VTBackup
     - name: Use current version VTTablet, and other version VTBackup
@@ -184,9 +189,14 @@ jobs:
     # Run test again with VTTablet at version N, and VTBackup at version N-1
     - name: Run backups tests (vttablet=N, vtbackup=N-1)
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      run: |
-        rm -rf /tmp/vtdataroot
-        mkdir -p /tmp/vtdataroot
-        set -x
-        source build.env
-        eatmydata -- go run test.go -skip-build -keep-data=false -docker=false -print-log -follow -tag upgrade_downgrade_backups
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        retry_on: error
+        command: |
+          rm -rf /tmp/vtdataroot
+          mkdir -p /tmp/vtdataroot
+          set -x
+          source build.env
+          eatmydata -- go run test.go -skip-build -keep-data=false -docker=false -print-log -follow -tag upgrade_downgrade_backups

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
@@ -165,12 +165,17 @@ jobs:
     # Run test with VTTablet at version N+1 and VTBackup at version N
     - name: Run backups tests (vttablet=N+1, vtbackup=N)
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      run: |
-        rm -rf /tmp/vtdataroot
-        mkdir -p /tmp/vtdataroot
-        set -x
-        source build.env
-        eatmydata -- go run test.go -skip-build -docker=false -print-log -follow -tag upgrade_downgrade_backups
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        retry_on: error
+        command: |
+          rm -rf /tmp/vtdataroot
+          mkdir -p /tmp/vtdataroot
+          set -x
+          source build.env
+          eatmydata -- go run test.go -skip-build -docker=false -print-log -follow -tag upgrade_downgrade_backups
 
     # Swap binaries again, use current version's VTTablet, and next release's VTBackup
     - name: Use current version VTTablet, and other version VTBackup
@@ -187,9 +192,14 @@ jobs:
     # Run test again with VTTablet at version N, and VTBackup at version N+1
     - name: Run backups tests (vttablet=N, vtbackup=N+1)
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      run: |
-        rm -rf /tmp/vtdataroot
-        mkdir -p /tmp/vtdataroot
-        set -x
-        source build.env
-        eatmydata -- go run test.go -skip-build -keep-data=false -docker=false -print-log -follow -tag upgrade_downgrade_backups
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        retry_on: error
+        command: |
+          rm -rf /tmp/vtdataroot
+          mkdir -p /tmp/vtdataroot
+          set -x
+          source build.env
+          eatmydata -- go run test.go -skip-build -keep-data=false -docker=false -print-log -follow -tag upgrade_downgrade_backups

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
@@ -190,12 +190,17 @@ jobs:
     # Running a test with vtgate at version n-1 and vttablet at version n
     - name: Run query serving tests (vtgate=N-1, vttablet=N)
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      run: |
-        rm -rf /tmp/vtdataroot
-        mkdir -p /tmp/vtdataroot
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        retry_on: error
+        command: |
+          rm -rf /tmp/vtdataroot
+          mkdir -p /tmp/vtdataroot
 
-        source build.env
-        eatmydata -- go run test.go -skip-build -keep-data=false -docker=false -print-log -follow -tag upgrade_downgrade_query_serving_queries
+          source build.env
+          eatmydata -- go run test.go -skip-build -keep-data=false -docker=false -print-log -follow -tag upgrade_downgrade_query_serving_queries
 
     # Swap the binaries again. This time, vtgate will be at version n, and vttablet will be at version n-1
     - name: Use current version VTGate, and other version VTTablet
@@ -212,9 +217,14 @@ jobs:
     # Running a test with vtgate at version n and vttablet at version n-1
     - name: Run query serving tests (vtgate=N, vttablet=N-1)
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      run: |
-        rm -rf /tmp/vtdataroot
-        mkdir -p /tmp/vtdataroot
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        retry_on: error
+        command: |
+          rm -rf /tmp/vtdataroot
+          mkdir -p /tmp/vtdataroot
 
-        source build.env
-        eatmydata -- go run test.go -skip-build -keep-data=false -docker=false -print-log -follow -tag upgrade_downgrade_query_serving_queries
+          source build.env
+          eatmydata -- go run test.go -skip-build -keep-data=false -docker=false -print-log -follow -tag upgrade_downgrade_query_serving_queries

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
@@ -173,12 +173,17 @@ jobs:
     # Running a test with vtgate and vttablet using version n
     - name: Run query serving tests (vtgate=N, vttablet=N)
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      run: |
-        rm -rf /tmp/vtdataroot
-        mkdir -p /tmp/vtdataroot
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        retry_on: error
+        command: |
+          rm -rf /tmp/vtdataroot
+          mkdir -p /tmp/vtdataroot
 
-        source build.env
-        eatmydata -- go run test.go -skip-build -keep-data=false -docker=false -print-log -follow -tag upgrade_downgrade_query_serving_queries
+          source build.env
+          eatmydata -- go run test.go -skip-build -keep-data=false -docker=false -print-log -follow -tag upgrade_downgrade_query_serving_queries
 
     # Swap the binaries in the bin. Use vtgate version n+1 and keep vttablet at version n
     - name: Use next release's VTGate
@@ -215,9 +220,14 @@ jobs:
     # Running a test with vtgate at version n and vttablet at version n+1
     - name: Run query serving tests (vtgate=N, vttablet=N+1)
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      run: |
-        rm -rf /tmp/vtdataroot
-        mkdir -p /tmp/vtdataroot
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        retry_on: error
+        command: |
+          rm -rf /tmp/vtdataroot
+          mkdir -p /tmp/vtdataroot
 
-        source build.env
-        eatmydata -- go run test.go -skip-build -keep-data=false -docker=false -print-log -follow -tag upgrade_downgrade_query_serving_queries
+          source build.env
+          eatmydata -- go run test.go -skip-build -keep-data=false -docker=false -print-log -follow -tag upgrade_downgrade_query_serving_queries

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
@@ -170,12 +170,17 @@ jobs:
     # Running a test with vtgate and vttablet using version n
     - name: Run query serving tests (vtgate=N, vttablet=N)
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      run: |
-        rm -rf /tmp/vtdataroot
-        mkdir -p /tmp/vtdataroot
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        retry_on: error
+        command: |
+          rm -rf /tmp/vtdataroot
+          mkdir -p /tmp/vtdataroot
 
-        source build.env
-        eatmydata -- go run test.go -skip-build -keep-data=false -docker=false -print-log -follow -tag upgrade_downgrade_query_serving_schema
+          source build.env
+          eatmydata -- go run test.go -skip-build -keep-data=false -docker=false -print-log -follow -tag upgrade_downgrade_query_serving_schema
 
     # Swap the binaries in the bin. Use vtgate version n-1 and keep vttablet at version n
     - name: Use last release's VTGate
@@ -212,9 +217,14 @@ jobs:
     # Running a test with vtgate at version n and vttablet at version n-1
     - name: Run query serving tests (vtgate=N, vttablet=N-1)
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      run: |
-        rm -rf /tmp/vtdataroot
-        mkdir -p /tmp/vtdataroot
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        retry_on: error
+        command: |
+          rm -rf /tmp/vtdataroot
+          mkdir -p /tmp/vtdataroot
 
-        source build.env
-        eatmydata -- go run test.go -skip-build -keep-data=false -docker=false -print-log -follow -tag upgrade_downgrade_query_serving_schema
+          source build.env
+          eatmydata -- go run test.go -skip-build -keep-data=false -docker=false -print-log -follow -tag upgrade_downgrade_query_serving_schema

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
@@ -172,12 +172,17 @@ jobs:
     # Running a test with vtgate and vttablet using version n
     - name: Run query serving tests (vtgate=N, vttablet=N)
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      run: |
-        rm -rf /tmp/vtdataroot
-        mkdir -p /tmp/vtdataroot
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        retry_on: error
+        command: |
+          rm -rf /tmp/vtdataroot
+          mkdir -p /tmp/vtdataroot
 
-        source build.env
-        eatmydata -- go run test.go -skip-build -keep-data=false -docker=false -print-log -follow -tag upgrade_downgrade_query_serving_schema
+          source build.env
+          eatmydata -- go run test.go -skip-build -keep-data=false -docker=false -print-log -follow -tag upgrade_downgrade_query_serving_schema
 
     # Swap the binaries in the bin. Use vtgate version n+1 and keep vttablet at version n
     - name: Use next release's VTGate
@@ -192,12 +197,17 @@ jobs:
     # Running a test with vtgate at version n+1 and vttablet at version n
     - name: Run query serving tests (vtgate=N+1, vttablet=N)
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      run: |
-        rm -rf /tmp/vtdataroot
-        mkdir -p /tmp/vtdataroot
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        retry_on: error
+        command: |
+          rm -rf /tmp/vtdataroot
+          mkdir -p /tmp/vtdataroot
 
-        source build.env
-        eatmydata -- go run test.go -skip-build -keep-data=false -docker=false -print-log -follow -tag upgrade_downgrade_query_serving_schema
+          source build.env
+          eatmydata -- go run test.go -skip-build -keep-data=false -docker=false -print-log -follow -tag upgrade_downgrade_query_serving_schema
 
     # Swap the binaries again. This time, vtgate will be at version n, and vttablet will be at version n+1
     - name: Use current version VTGate, and other version VTTablet
@@ -214,9 +224,14 @@ jobs:
     # Running a test with vtgate at version n and vttablet at version n+1
     - name: Run query serving tests (vtgate=N, vttablet=N+1)
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      run: |
-        rm -rf /tmp/vtdataroot
-        mkdir -p /tmp/vtdataroot
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        retry_on: error
+        command: |
+          rm -rf /tmp/vtdataroot
+          mkdir -p /tmp/vtdataroot
 
-        source build.env
-        eatmydata -- go run test.go -skip-build -keep-data=false -docker=false -print-log -follow -tag upgrade_downgrade_query_serving_schema
+          source build.env
+          eatmydata -- go run test.go -skip-build -keep-data=false -docker=false -print-log -follow -tag upgrade_downgrade_query_serving_schema

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
@@ -187,9 +187,14 @@ jobs:
     # Running a test with vtctl at version n+1 and vttablet at version n
     - name: Run reparent tests (vtctl=N+1, vttablet=N)
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      run: |
-        rm -rf /tmp/vtdataroot
-        mkdir -p /tmp/vtdataroot
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        retry_on: error
+        command: |
+          rm -rf /tmp/vtdataroot
+          mkdir -p /tmp/vtdataroot
 
-        source build.env
-        eatmydata -- go run test.go -skip-build -keep-data=false -docker=false -print-log -follow -tag upgrade_downgrade_reparent
+          source build.env
+          eatmydata -- go run test.go -skip-build -keep-data=false -docker=false -print-log -follow -tag upgrade_downgrade_reparent

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
@@ -184,9 +184,14 @@ jobs:
     # Running a test with vtctl at version n and vttablet at version n+1
     - name: Run reparent tests (vtctl=N, vttablet=N+1)
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      run: |
-        rm -rf /tmp/vtdataroot
-        mkdir -p /tmp/vtdataroot
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        retry_on: error
+        command: |
+          rm -rf /tmp/vtdataroot
+          mkdir -p /tmp/vtdataroot
 
-        source build.env
-        eatmydata -- go run test.go -skip-build -keep-data=false -docker=false -print-log -follow -tag upgrade_downgrade_reparent
+          source build.env
+          eatmydata -- go run test.go -skip-build -keep-data=false -docker=false -print-log -follow -tag upgrade_downgrade_reparent

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -184,9 +184,14 @@ jobs:
     # Running a test with vtctl at version n-1 and vttablet at version n
     - name: Run reparent tests (vtctl=N-1, vttablet=N)
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      run: |
-        rm -rf /tmp/vtdataroot
-        mkdir -p /tmp/vtdataroot
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        retry_on: error
+        command: |
+          rm -rf /tmp/vtdataroot
+          mkdir -p /tmp/vtdataroot
 
-        source build.env
-        eatmydata -- go run test.go -skip-build -keep-data=false -docker=false -print-log -follow -tag upgrade_downgrade_reparent
+          source build.env
+          eatmydata -- go run test.go -skip-build -keep-data=false -docker=false -print-log -follow -tag upgrade_downgrade_reparent

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -181,9 +181,14 @@ jobs:
     # Running a test with vtctl at version n and vttablet at version n-1
     - name: Run reparent tests (vtctl=N, vttablet=N-1)
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      run: |
-        rm -rf /tmp/vtdataroot
-        mkdir -p /tmp/vtdataroot
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        retry_on: error
+        command: |
+          rm -rf /tmp/vtdataroot
+          mkdir -p /tmp/vtdataroot
 
-        source build.env
-        eatmydata -- go run test.go -skip-build -keep-data=false -docker=false -print-log -follow -tag upgrade_downgrade_reparent
+          source build.env
+          eatmydata -- go run test.go -skip-build -keep-data=false -docker=false -print-log -follow -tag upgrade_downgrade_reparent

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -119,36 +119,40 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 45
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        retry_on: error
+        command: |
+          # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+          # which musn't be more than 107 characters long.
+          export VTDATAROOT="/tmp/"
+          source build.env
 
-        set -x
+          set -x
 
-        {{if .LimitResourceUsage}}
-        # Increase our local ephemeral port range as we could exhaust this
-        sudo sysctl -w net.ipv4.ip_local_port_range="22768 61999"
-        # Increase our open file descriptor limit as we could hit this
-        ulimit -n 65536
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
-        innodb_buffer_pool_dump_at_shutdown=OFF
-        innodb_buffer_pool_in_core_file=OFF
-        innodb_buffer_pool_load_at_startup=OFF
-        innodb_buffer_pool_size=64M
-        innodb_doublewrite=OFF
-        innodb_flush_log_at_trx_commit=0
-        innodb_flush_method=O_DIRECT
-        innodb_numa_interleave=ON
-        innodb_adaptive_hash_index=OFF
-        sync_binlog=0
-        sync_relay_log=0
-        performance_schema=OFF
-        slow-query-log=OFF
-        EOF
-        {{end}}
+          {{if .LimitResourceUsage}}
+          # Increase our local ephemeral port range as we could exhaust this
+          sudo sysctl -w net.ipv4.ip_local_port_range="22768 61999"
+          # Increase our open file descriptor limit as we could hit this
+          ulimit -n 65536
+          cat <<-EOF>>./config/mycnf/mysql80.cnf
+          innodb_buffer_pool_dump_at_shutdown=OFF
+          innodb_buffer_pool_in_core_file=OFF
+          innodb_buffer_pool_load_at_startup=OFF
+          innodb_buffer_pool_size=64M
+          innodb_doublewrite=OFF
+          innodb_flush_log_at_trx_commit=0
+          innodb_flush_method=O_DIRECT
+          innodb_numa_interleave=ON
+          innodb_adaptive_hash_index=OFF
+          sync_binlog=0
+          sync_relay_log=0
+          performance_schema=OFF
+          slow-query-log=OFF
+          EOF
+          {{end}}
 
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker={{if .Docker}}true -flavor={{.Platform}}{{else}}false{{end}} -follow -shard {{.Shard}}{{if .PartialKeyspace}} -partial-keyspace=true {{end}}
+          # run the tests however you normally do, then produce a JUnit XML file
+          eatmydata -- go run test.go -docker={{if .Docker}}true -flavor={{.Platform}}{{else}}false{{end}} -follow -shard {{.Shard}}{{if .PartialKeyspace}} -partial-keyspace=true {{end}}

--- a/test/templates/cluster_endtoend_test_docker.tpl
+++ b/test/templates/cluster_endtoend_test_docker.tpl
@@ -55,6 +55,10 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 30
-      run: |
-        go run test.go -docker=true --follow -shard {{.Shard}}
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        retry_on: error
+        command: |
+          go run test.go -docker=true --follow -shard {{.Shard}}

--- a/test/templates/cluster_endtoend_test_self_hosted.tpl
+++ b/test/templates/cluster_endtoend_test_self_hosted.tpl
@@ -52,8 +52,12 @@ jobs:
 
       - name: Run test
         if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-        timeout-minutes: 30
-        run: docker run --name "{{.ImageName}}_$GITHUB_SHA" {{.ImageName}}:$GITHUB_SHA /bin/bash -c 'source build.env && go run test.go -keep-data=true -docker=false -print-log -follow -shard {{.Shard}} -- -- --keep-data=true'
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          retry_on: error
+          command: docker run --name "{{.ImageName}}_$GITHUB_SHA" {{.ImageName}}:$GITHUB_SHA /bin/bash -c 'source build.env && go run test.go -keep-data=true -docker=false -print-log -follow -shard {{.Shard}} -- -- --keep-data=true'
 
       - name: Print Volume Used
         if: always() && steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'

--- a/test/templates/unit_test.tpl
+++ b/test/templates/unit_test.tpl
@@ -137,6 +137,10 @@ jobs:
 
     - name: Run test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.unit_tests == 'true'
-      timeout-minutes: 30
-      run: |
-        eatmydata -- make unit_test
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        retry_on: error
+        command: |
+          eatmydata -- make unit_test

--- a/test/templates/unit_test_self_hosted.tpl
+++ b/test/templates/unit_test_self_hosted.tpl
@@ -50,8 +50,13 @@ jobs:
 
       - name: Run test
         if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.unit_tests == 'true'
-        timeout-minutes: 30
-        run: docker run --name "{{.ImageName}}_$GITHUB_SHA" {{.ImageName}}:$GITHUB_SHA /bin/bash -c 'make unit_test'
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          retry_on: error
+          command: |
+            docker run --name "{{.ImageName}}_$GITHUB_SHA" {{.ImageName}}:$GITHUB_SHA /bin/bash -c 'make unit_test'
 
       - name: Print Volume Used
         if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.unit_tests == 'true'


### PR DESCRIPTION
## Description

This PR adds the same retries we added to v14 to this release using the GitHub action: `nick-fields/retry@v2`

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
