### PR TITLE
vtgateproxy: include vtgate hostname in debug page

### DIFF
--- a/go/vt/vtgateproxy/discovery.go
+++ b/go/vt/vtgateproxy/discovery.go
@@ -88,6 +88,7 @@ type JSONGateResolverBuilder struct {
 }
 
 type targetHost struct {
+	Hostname string
 	Addr     string
 	PoolType string
 	Affinity string
@@ -244,6 +245,7 @@ func (b *JSONGateResolverBuilder) parse() (bool, error) {
 
 	var targets = map[string][]targetHost{}
 	for _, host := range hosts {
+		hostname, hasHostname := host["host"]
 		address, hasAddress := host[b.addressField]
 		port, hasPort := host[b.portField]
 		poolType, hasPoolType := host[b.poolTypeField]
@@ -255,6 +257,10 @@ func (b *JSONGateResolverBuilder) parse() (bool, error) {
 
 		if !hasPort {
 			return false, fmt.Errorf("error parsing JSON discovery file %s: port field %s not present", b.jsonPath, b.portField)
+		}
+
+		if !hasHostname {
+			hostname = address
 		}
 
 		if b.poolTypeField != "" && !hasPoolType {
@@ -283,7 +289,7 @@ func (b *JSONGateResolverBuilder) parse() (bool, error) {
 			return false, fmt.Errorf("error parsing JSON discovery file %s: port field %s has invalid value %v", b.jsonPath, b.portField, port)
 		}
 
-		target := targetHost{fmt.Sprintf("%s:%s", address, port), poolType.(string), affinity.(string)}
+		target := targetHost{hostname.(string), fmt.Sprintf("%s:%s", address, port), poolType.(string), affinity.(string)}
 		targets[target.PoolType] = append(targets[target.PoolType], target)
 	}
 
@@ -423,10 +429,11 @@ const (
 </style>
 <table>
 {{range $i, $p := .Pools}}  <tr>
-    <th colspan="2">{{$p}}</th>
+    <th colspan="3">{{$p}}</th>
   </tr>
 {{range index $.Targets $p}}  <tr>
-    <td>{{.Addr}}</td>
+	<td>{{.Hostname}}</td>
+	<td>{{.Addr}}</td>
     <td>{{.Affinity}}</td>
   </tr>{{end}}
 {{end}}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
Minor improvement to the debug page to include the hostname for easier ... debugging.

![image](https://github.com/slackhq/vitess/assets/3308504/7fedaaa6-49cc-4a2d-b8f0-51a735467827)


<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
