### PR TITLE
add firstready balancer

### DIFF
--- a/go/vt/vtgateproxy/firstready_balancer.go
+++ b/go/vt/vtgateproxy/firstready_balancer.go
@@ -1,0 +1,80 @@
+package vtgateproxy
+
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// The firstready balancer implements the GRPC load balancer abstraction by
+// routing all queries to the first available target in the list returned from
+// discovery.
+//
+// Similar to the builtin "round_robin" balancer, the base functionality takes care
+// of establishing subconns to all targets in the list and keeping them in the "ready"
+// state, so all we have to do is pick the first available one from the set.
+//
+// This is in contrast to the `pick_first` balancer which only establishes the subconn
+// to a single target at a time and is therefore subject to undesirable behaviors if,
+// for example, the first host in the set is unreachable for some time, but not declared
+// down.
+// https://github.com/grpc/grpc-go/blob/master/pickfirst.go
+
+import (
+	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/balancer/base"
+	"google.golang.org/grpc/grpclog"
+)
+
+// Name is the name of first_ready balancer.
+const Name = "first_ready"
+
+var logger = grpclog.Component("firstready")
+
+// newBuilder creates a new roundrobin balancer builder.
+func newBuilder() balancer.Builder {
+	return base.NewBalancerBuilder(Name, &frPickerBuilder{}, base.Config{HealthCheck: true})
+}
+
+func init() {
+	balancer.Register(newBuilder())
+}
+
+type frPickerBuilder struct{}
+
+func (*frPickerBuilder) Build(info base.PickerBuildInfo) balancer.Picker {
+	logger.Infof("firstreadyPicker: Build called with info: %v", info)
+	if len(info.ReadySCs) == 0 {
+		return base.NewErrPicker(balancer.ErrNoSubConnAvailable)
+	}
+
+	var subConn balancer.SubConn
+	for sc := range info.ReadySCs {
+		subConn = sc
+		break
+	}
+	return &frPicker{
+		subConn: subConn,
+	}
+}
+
+type frPicker struct {
+	// subConn is the first ready subconn when this picker was
+	// created. The slice is immutable. Each Get() will do a round robin
+	// selection from it and return the selected SubConn.
+	subConn balancer.SubConn
+}
+
+func (p *frPicker) Pick(balancer.PickInfo) (balancer.PickResult, error) {
+	return balancer.PickResult{SubConn: p.subConn}, nil
+}

--- a/go/vt/vtgateproxy/firstready_balancer.go
+++ b/go/vt/vtgateproxy/firstready_balancer.go
@@ -31,9 +31,12 @@ limitations under the License.
 // https://github.com/grpc/grpc-go/blob/master/pickfirst.go
 
 import (
+	"sync"
+
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/balancer/base"
 	"google.golang.org/grpc/grpclog"
+	"vitess.io/vitess/go/vt/log"
 )
 
 // Name is the name of first_ready balancer.
@@ -41,7 +44,7 @@ const Name = "first_ready"
 
 var logger = grpclog.Component("firstready")
 
-// newBuilder creates a new roundrobin balancer builder.
+// newBuilder creates a new first_ready balancer builder.
 func newBuilder() balancer.Builder {
 	return base.NewBalancerBuilder(Name, &frPickerBuilder{}, base.Config{HealthCheck: true})
 }
@@ -50,31 +53,52 @@ func init() {
 	balancer.Register(newBuilder())
 }
 
-type frPickerBuilder struct{}
+// frPickerBuilder implements both the Builder and the Picker interfaces.
+//
+// Once a conn is chosen and is in the ready state, it will remain as the
+// active subconn even if other connections become available.
+type frPickerBuilder struct {
+	mu          sync.Mutex
+	currentConn balancer.SubConn
+}
 
-func (*frPickerBuilder) Build(info base.PickerBuildInfo) balancer.Picker {
-	logger.Infof("firstreadyPicker: Build called with info: %v", info)
+func (f *frPickerBuilder) Build(info base.PickerBuildInfo) balancer.Picker {
+	log.V(100).Infof("firstreadyPicker: Build called with info: %v", info)
+
 	if len(info.ReadySCs) == 0 {
 		return base.NewErrPicker(balancer.ErrNoSubConnAvailable)
 	}
 
-	var subConn balancer.SubConn
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	// If we've already chosen a subconn, and it is still in the ready list, then
+	// no need to change state
+	if f.currentConn != nil {
+		log.V(100).Infof("firstreadyPicker: currentConn is active, checking if still ready")
+		for sc := range info.ReadySCs {
+			if f.currentConn == sc {
+				log.V(100).Infof("firstreadyPicker: currentConn still active - not changing")
+				return f
+			}
+		}
+	}
+
+	// Otherwise either we don't have an active conn or the conn we were using is
+	// no longer active, so pick an arbitrary new one out of the map.
+	log.V(100).Infof("firstreadyPicker: currentConn is not active, picking a new one")
 	for sc := range info.ReadySCs {
-		subConn = sc
+		f.currentConn = sc
 		break
 	}
-	return &frPicker{
-		subConn: subConn,
-	}
+
+	return f
 }
 
-type frPicker struct {
-	// subConn is the first ready subconn when this picker was
-	// created. The slice is immutable. Each Get() will do a round robin
-	// selection from it and return the selected SubConn.
-	subConn balancer.SubConn
-}
+// Pick simply returns the currently chosen conn
+func (f *frPickerBuilder) Pick(balancer.PickInfo) (balancer.PickResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 
-func (p *frPicker) Pick(balancer.PickInfo) (balancer.PickResult, error) {
-	return balancer.PickResult{SubConn: p.subConn}, nil
+	return balancer.PickResult{SubConn: f.currentConn}, nil
 }

--- a/go/vt/vtgateproxy/firstready_balancer.go
+++ b/go/vt/vtgateproxy/firstready_balancer.go
@@ -57,7 +57,7 @@ type frPickerBuilder struct {
 }
 
 func (f *frPickerBuilder) Build(info base.PickerBuildInfo) balancer.Picker {
-	log.V(100).Infof("firstreadyPicker: Build called with info: %v", info)
+	log.V(100).Infof("first_ready: Build called with info: %v", info)
 
 	if len(info.ReadySCs) == 0 {
 		return base.NewErrPicker(balancer.ErrNoSubConnAvailable)
@@ -69,10 +69,10 @@ func (f *frPickerBuilder) Build(info base.PickerBuildInfo) balancer.Picker {
 	// If we've already chosen a subconn, and it is still in the ready list, then
 	// no need to change state
 	if f.currentConn != nil {
-		log.V(100).Infof("firstreadyPicker: currentConn is active, checking if still ready")
+		log.V(100).Infof("first_ready: currentConn is active, checking if still ready")
 		for sc := range info.ReadySCs {
 			if f.currentConn == sc {
-				log.V(100).Infof("firstreadyPicker: currentConn still active - not changing")
+				log.V(100).Infof("first_ready: currentConn still active - not changing")
 				return f
 			}
 		}
@@ -80,7 +80,7 @@ func (f *frPickerBuilder) Build(info base.PickerBuildInfo) balancer.Picker {
 
 	// Otherwise either we don't have an active conn or the conn we were using is
 	// no longer active, so pick an arbitrary new one out of the map.
-	log.V(100).Infof("firstreadyPicker: currentConn is not active, picking a new one")
+	log.V(100).Infof("first_ready: currentConn is not active, picking a new one")
 	for sc := range info.ReadySCs {
 		f.currentConn = sc
 		break

--- a/go/vt/vtgateproxy/firstready_balancer.go
+++ b/go/vt/vtgateproxy/firstready_balancer.go
@@ -35,18 +35,12 @@ import (
 
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/balancer/base"
-	"google.golang.org/grpc/grpclog"
 	"vitess.io/vitess/go/vt/log"
 )
 
-// Name is the name of first_ready balancer.
-const Name = "first_ready"
-
-var logger = grpclog.Component("firstready")
-
 // newBuilder creates a new first_ready balancer builder.
 func newBuilder() balancer.Builder {
-	return base.NewBalancerBuilder(Name, &frPickerBuilder{}, base.Config{HealthCheck: true})
+	return base.NewBalancerBuilder("first_ready", &frPickerBuilder{}, base.Config{HealthCheck: true})
 }
 
 func init() {

--- a/go/vt/vtgateproxy/vtgateproxy.go
+++ b/go/vt/vtgateproxy/vtgateproxy.go
@@ -203,10 +203,18 @@ func (proxy *VTGateProxy) StreamExecute(ctx context.Context, session *vtgateconn
 }
 
 func Init() {
-	log.V(100).Infof("Registering GRPC dial options")
+	log.Infof("registering GRPC dial options: balancer type %s", *balancerType)
+
+	switch *balancerType {
+	case "round_robin":
+	case "first_ready":
+	case "pick_first":
+		break
+	default:
+		log.Fatalf("invalid balancer type %s", *balancerType)
+	}
 
 	grpcclient.RegisterGRPCDialOptions(func(opts []grpc.DialOption) ([]grpc.DialOption, error) {
-		log.Infof("registering %s load balancer", *balancerType)
 		return append(opts, grpc.WithDefaultServiceConfig(fmt.Sprintf(`{"loadBalancingConfig": [{"%s":{}}]}`, *balancerType))), nil
 	})
 


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
Implement a "first_ready" load balancer and a config to select it.

Despite how simple the code actually is, this balancer (I think!) does what (I think!) we want it to do (basically!):
* When the discovery returns N targets, the base code in the balancer will attempt to establish a SubConn to each of the targets, and will maintain that subconn with keepalives and retries.
* However when picking one of these for a given request, it always returns the first "ready" subconn.

This means that in practice, in steady state a webapp host will have one "hot" connection to a single vtgate, and will route all queries to it. At the same time it will maintain N-1 idle connections to other vtgates, and if the connection to the primary vtgate goes away or is interrupted, queries will get routed to one of the other ones as a backup.

*AZ Affinity*: Just like the case of `round_robin` if there aren't N hosts in the same AZ, then some amount of cross-AZ queries are inevitable. When using `first_ready` it can be especially bad since if the "first" ready subconn is in a different AZ then webapp will be stuck crossing AZs until discovery runs again. 

In practice I think this isn't actually a problem since we should always have at least N vtgates in each AZ.

## Testing
This seems to do what it's supposed to with some basic testing, including using iptables rules to temporarily black hole network traffic to the "selected" gate. After the keepalive timeout, the connection was marked as TRANSIENT_FAILURE and the query was routed to a different gate, so the app saw a slowdown but not a failure.


<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
