### PR TITLE
`slack-vitess-r15.0.5`: close topoServer after use in `vttest`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -117,6 +117,7 @@ require (
 
 require (
 	github.com/bndr/gotabulate v1.1.2
+	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/go-version v1.6.0
 	github.com/planetscale/log v0.0.0-20221118170849-fb599bc35c50
 	github.com/slok/noglog v0.2.0
@@ -147,7 +148,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
-	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
 	github.com/hashicorp/go-hclog v0.12.0 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/hashicorp/golang-lru v0.5.1 // indirect

--- a/go/flags/endtoend/vtbackup.txt
+++ b/go/flags/endtoend/vtbackup.txt
@@ -155,7 +155,7 @@ Usage of vtbackup:
       --topo_consul_lock_delay duration                 LockDelay for consul session. (default 15s)
       --topo_consul_lock_session_checks string          List of checks for consul session. (default "serfHealth")
       --topo_consul_lock_session_ttl string             TTL for consul session.
-      --topo_consul_max_conns_per_host int              Maximum number of consul connections per host.
+      --topo_consul_max_conns_per_host int              Maximum number of consul connections per host. (default 250)
       --topo_consul_max_idle_conns int                  Maximum number of idle consul connections. (default 100)
       --topo_consul_watch_poll_duration duration        time of the long poll for watch queries. (default 30s)
       --topo_etcd_lease_ttl int                         Lease TTL for locks and leader election. The client will use KeepAlive to keep the lease going. (default 30)

--- a/go/flags/endtoend/vtctld.txt
+++ b/go/flags/endtoend/vtctld.txt
@@ -124,7 +124,7 @@ Usage of vtctld:
       --topo_consul_lock_delay duration                                  LockDelay for consul session. (default 15s)
       --topo_consul_lock_session_checks string                           List of checks for consul session. (default "serfHealth")
       --topo_consul_lock_session_ttl string                              TTL for consul session.
-      --topo_consul_max_conns_per_host int                               Maximum number of consul connections per host.
+      --topo_consul_max_conns_per_host int                               Maximum number of consul connections per host. (default 250)
       --topo_consul_max_idle_conns int                                   Maximum number of idle consul connections. (default 100)
       --topo_consul_watch_poll_duration duration                         time of the long poll for watch queries. (default 30s)
       --topo_etcd_lease_ttl int                                          Lease TTL for locks and leader election. The client will use KeepAlive to keep the lease going. (default 30)

--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -171,7 +171,7 @@ Usage of vtgate:
       --topo_consul_lock_delay duration                                  LockDelay for consul session. (default 15s)
       --topo_consul_lock_session_checks string                           List of checks for consul session. (default "serfHealth")
       --topo_consul_lock_session_ttl string                              TTL for consul session.
-      --topo_consul_max_conns_per_host int                               Maximum number of consul connections per host.
+      --topo_consul_max_conns_per_host int                               Maximum number of consul connections per host. (default 250)
       --topo_consul_max_idle_conns int                                   Maximum number of idle consul connections. (default 100)
       --topo_consul_watch_poll_duration duration                         time of the long poll for watch queries. (default 30s)
       --topo_etcd_lease_ttl int                                          Lease TTL for locks and leader election. The client will use KeepAlive to keep the lease going. (default 30)

--- a/go/flags/endtoend/vtgr.txt
+++ b/go/flags/endtoend/vtgr.txt
@@ -54,7 +54,7 @@ Usage of vtgr:
       --topo_consul_lock_delay duration            LockDelay for consul session. (default 15s)
       --topo_consul_lock_session_checks string     List of checks for consul session. (default "serfHealth")
       --topo_consul_lock_session_ttl string        TTL for consul session.
-      --topo_consul_max_conns_per_host int         Maximum number of consul connections per host.
+      --topo_consul_max_conns_per_host int         Maximum number of consul connections per host. (default 250)
       --topo_consul_max_idle_conns int             Maximum number of idle consul connections. (default 100)
       --topo_consul_watch_poll_duration duration   time of the long poll for watch queries. (default 30s)
       --topo_etcd_lease_ttl int                    Lease TTL for locks and leader election. The client will use KeepAlive to keep the lease going. (default 30)

--- a/go/flags/endtoend/vtorc.txt
+++ b/go/flags/endtoend/vtorc.txt
@@ -64,7 +64,7 @@ Usage of vtorc:
       --topo_consul_lock_delay duration              LockDelay for consul session. (default 15s)
       --topo_consul_lock_session_checks string       List of checks for consul session. (default "serfHealth")
       --topo_consul_lock_session_ttl string          TTL for consul session.
-      --topo_consul_max_conns_per_host int           Maximum number of consul connections per host.
+      --topo_consul_max_conns_per_host int           Maximum number of consul connections per host. (default 250)
       --topo_consul_max_idle_conns int               Maximum number of idle consul connections. (default 100)
       --topo_consul_watch_poll_duration duration     time of the long poll for watch queries. (default 30s)
       --topo_etcd_lease_ttl int                      Lease TTL for locks and leader election. The client will use KeepAlive to keep the lease going. (default 30)

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -308,7 +308,7 @@ Usage of vttablet:
       --topo_consul_lock_delay duration                                  LockDelay for consul session. (default 15s)
       --topo_consul_lock_session_checks string                           List of checks for consul session. (default "serfHealth")
       --topo_consul_lock_session_ttl string                              TTL for consul session.
-      --topo_consul_max_conns_per_host int                               Maximum number of consul connections per host.
+      --topo_consul_max_conns_per_host int                               Maximum number of consul connections per host. (default 250)
       --topo_consul_max_idle_conns int                                   Maximum number of idle consul connections. (default 100)
       --topo_consul_watch_poll_duration duration                         time of the long poll for watch queries. (default 30s)
       --topo_etcd_lease_ttl int                                          Lease TTL for locks and leader election. The client will use KeepAlive to keep the lease going. (default 30)

--- a/go/flags/endtoend/vttestserver.txt
+++ b/go/flags/endtoend/vttestserver.txt
@@ -112,7 +112,7 @@ Usage of vttestserver:
       --topo_consul_lock_delay duration                                  LockDelay for consul session. (default 15s)
       --topo_consul_lock_session_checks string                           List of checks for consul session. (default "serfHealth")
       --topo_consul_lock_session_ttl string                              TTL for consul session.
-      --topo_consul_max_conns_per_host int                               Maximum number of consul connections per host.
+      --topo_consul_max_conns_per_host int                               Maximum number of consul connections per host. (default 250)
       --topo_consul_max_idle_conns int                                   Maximum number of idle consul connections. (default 100)
       --topo_consul_watch_poll_duration duration                         time of the long poll for watch queries. (default 30s)
       --topo_zk_auth_file string                                         auth to use when connecting to the zk topo server, file contents should be <scheme>:<auth>, e.g., digest:user:pass

--- a/go/vt/topo/consultopo/server.go
+++ b/go/vt/topo/consultopo/server.go
@@ -39,7 +39,6 @@ import (
 
 var (
 	consulAuthClientStaticFile string
-	consulConfig               = api.DefaultConfig()
 	// serfHealth is the default check from consul
 	consulLockSessionChecks = "serfHealth"
 	consulLockSessionTTL    string

--- a/go/vt/topo/consultopo/server.go
+++ b/go/vt/topo/consultopo/server.go
@@ -173,6 +173,9 @@ func parseConsulLockSessionChecks(s string) []string {
 // It will nil out the global and cells fields, so any attempt to
 // re-use this server will panic.
 func (s *Server) Close() {
+	if consulConfig.Transport != nil {
+		consulConfig.Transport.CloseIdleConnections()
+	}
 	s.client = nil
 	s.kv = nil
 	s.mu.Lock()

--- a/go/vt/topo/consultopo/server.go
+++ b/go/vt/topo/consultopo/server.go
@@ -144,10 +144,10 @@ func NewServer(cell, serverAddr, root string) (*Server, error) {
 		return nil, err
 	}
 	cfg := api.DefaultConfig()
+	cfg.Address = serverAddr
 	cfg.Transport.MaxConnsPerHost = consulMaxConnsPerHost
 	cfg.Transport.MaxIdleConns = consulMaxIdleConns
 	cfg.Transport.IdleConnTimeout = consulIdleConnTimeout
-	cfg.Address = serverAddr
 	if creds != nil {
 		if creds[cell] != nil {
 			cfg.Token = creds[cell].ACLToken

--- a/go/vt/topo/consultopo/server.go
+++ b/go/vt/topo/consultopo/server.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/go-cleanhttp"
 	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/vt/log"
@@ -42,7 +43,10 @@ var (
 	// serfHealth is the default check from consul
 	consulLockSessionChecks = "serfHealth"
 	consulLockSessionTTL    string
-	consulLockDelay         = 15 * time.Second
+	consulLockDelay             = 15 * time.Second
+	consulMaxConnsPerHost   int = 250 // do not use client default of 0/unlimited
+	consulMaxIdleConns      int
+	consulIdleConnTimeout   time.Duration
 )
 
 func init() {
@@ -50,13 +54,18 @@ func init() {
 }
 
 func registerServerFlags(fs *pflag.FlagSet) {
+	// cleanhttp.DefaultPooledTransport() is used by the consul api client
+	// as an *http.Transport. We call it here just to get the default
+	// values the consul api client will inherit from it later.
+	defaultConsulPooledTransport := cleanhttp.DefaultPooledTransport()
+
 	fs.StringVar(&consulAuthClientStaticFile, "consul_auth_static_file", consulAuthClientStaticFile, "JSON File to read the topos/tokens from.")
 	fs.StringVar(&consulLockSessionChecks, "topo_consul_lock_session_checks", consulLockSessionChecks, "List of checks for consul session.")
 	fs.StringVar(&consulLockSessionTTL, "topo_consul_lock_session_ttl", consulLockSessionTTL, "TTL for consul session.")
 	fs.DurationVar(&consulLockDelay, "topo_consul_lock_delay", consulLockDelay, "LockDelay for consul session.")
-	fs.IntVar(&consulConfig.Transport.MaxConnsPerHost, "topo_consul_max_conns_per_host", consulConfig.Transport.MaxConnsPerHost, "Maximum number of consul connections per host.")
-	fs.IntVar(&consulConfig.Transport.MaxIdleConns, "topo_consul_max_idle_conns", consulConfig.Transport.MaxIdleConns, "Maximum number of idle consul connections.")
-	fs.DurationVar(&consulConfig.Transport.IdleConnTimeout, "topo_consul_idle_conn_timeout", consulConfig.Transport.IdleConnTimeout, "Maximum amount of time to pool idle connections.")
+	fs.IntVar(&consulMaxConnsPerHost, "topo_consul_max_conns_per_host", consulMaxConnsPerHost, "Maximum number of consul connections per host.")
+	fs.IntVar(&consulMaxIdleConns, "topo_consul_max_idle_conns", defaultConsulPooledTransport.MaxIdleConns, "Maximum number of idle consul connections.")
+	fs.DurationVar(&consulIdleConnTimeout, "topo_consul_idle_conn_timeout", defaultConsulPooledTransport.IdleConnTimeout, "Maximum amount of time to pool idle connections.")
 }
 
 // ClientAuthCred credential to use for consul clusters
@@ -135,7 +144,10 @@ func NewServer(cell, serverAddr, root string) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
-	cfg := consulConfig
+	cfg := api.DefaultConfig()
+	cfg.Transport.MaxConnsPerHost = consulMaxConnsPerHost
+	cfg.Transport.MaxIdleConns = consulMaxIdleConns
+	cfg.Transport.IdleConnTimeout = consulIdleConnTimeout
 	cfg.Address = serverAddr
 	if creds != nil {
 		if creds[cell] != nil {
@@ -173,9 +185,6 @@ func parseConsulLockSessionChecks(s string) []string {
 // It will nil out the global and cells fields, so any attempt to
 // re-use this server will panic.
 func (s *Server) Close() {
-	if consulConfig.Transport != nil {
-		consulConfig.Transport.CloseIdleConnections()
-	}
 	s.client = nil
 	s.kv = nil
 	s.mu.Lock()

--- a/go/vt/vttest/topoctl.go
+++ b/go/vt/vttest/topoctl.go
@@ -31,6 +31,7 @@ func (ctl *Topoctl) Setup() error {
 	if err != nil {
 		return err
 	}
+	defer topoServer.Close()
 
 	log.Infof("Creating cells if they don't exist in the provided topo server %s %s %s", ctl.TopoImplementation, ctl.TopoGlobalServerAddress, ctl.TopoGlobalRoot)
 	// Create cells if it doesn't exist to be idempotent. Should work when we share the same topo server across multiple local clusters.

--- a/tools/unit_test_race.sh
+++ b/tools/unit_test_race.sh
@@ -36,7 +36,7 @@ all_except_flaky_tests=$(echo "$packages_with_tests" | grep -vE ".+ .+_flaky_tes
 flaky_tests=$(echo "$packages_with_tests" | grep -E ".+ .+_flaky_test\.go" | cut -d" " -f1)
 
 # Run non-flaky tests.
-echo "$all_except_flaky_tests" | xargs go test -v $VT_GO_PARALLEL -race -count=1
+echo "$all_except_flaky_tests" | xargs go test $VT_GO_PARALLEL -race -count=1
 if [ $? -ne 0 ]; then
   echo "ERROR: Go unit tests failed. See above for errors."
   echo
@@ -52,7 +52,7 @@ for pkg in $flaky_tests; do
   max_attempts=3
   attempt=1
   # Set a timeout because some tests may deadlock when they flake.
-  until go test -v -timeout 2m $VT_GO_PARALLEL $pkg -race -count=1; do
+  until go test -timeout 2m $VT_GO_PARALLEL $pkg -race -count=1; do
     echo "FAILED (try $attempt/$max_attempts) in $pkg (return code $?). See above for errors."
     if [ $((++attempt)) -gt $max_attempts ]; then
       echo "ERROR: Flaky Go unit tests in package $pkg failed too often (after $max_attempts retries). Please reduce the flakiness."

--- a/tools/unit_test_race.sh
+++ b/tools/unit_test_race.sh
@@ -36,7 +36,7 @@ all_except_flaky_tests=$(echo "$packages_with_tests" | grep -vE ".+ .+_flaky_tes
 flaky_tests=$(echo "$packages_with_tests" | grep -E ".+ .+_flaky_test\.go" | cut -d" " -f1)
 
 # Run non-flaky tests.
-echo "$all_except_flaky_tests" | xargs go test $VT_GO_PARALLEL -race -count=1
+echo "$all_except_flaky_tests" | xargs go test -v $VT_GO_PARALLEL -race -count=1
 if [ $? -ne 0 ]; then
   echo "ERROR: Go unit tests failed. See above for errors."
   echo
@@ -52,7 +52,7 @@ for pkg in $flaky_tests; do
   max_attempts=3
   attempt=1
   # Set a timeout because some tests may deadlock when they flake.
-  until go test -timeout 2m $VT_GO_PARALLEL $pkg -race -count=1; do
+  until go test -v -timeout 2m $VT_GO_PARALLEL $pkg -race -count=1; do
     echo "FAILED (try $attempt/$max_attempts) in $pkg (return code $?). See above for errors."
     if [ $((++attempt)) -gt $max_attempts ]; then
       echo "ERROR: Flaky Go unit tests in package $pkg failed too often (after $max_attempts retries). Please reduce the flakiness."


### PR DESCRIPTION
## Description

This PR attempts to fix a `Unit race` CI failure due to an idle Consul-topo connection being left open

Now the topo server used by the CI is closed after use

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
