### PR TITLE
Vtgateproxy firstready balancer fail fast

### DIFF
--- a/go/vt/vtgateproxy/firstready_balancer.go
+++ b/go/vt/vtgateproxy/firstready_balancer.go
@@ -31,6 +31,7 @@ limitations under the License.
 // https://github.com/grpc/grpc-go/blob/master/pickfirst.go
 
 import (
+	"errors"
 	"sync"
 
 	"google.golang.org/grpc/balancer"
@@ -60,7 +61,7 @@ func (f *frPickerBuilder) Build(info base.PickerBuildInfo) balancer.Picker {
 	log.V(100).Infof("first_ready: Build called with info: %v", info)
 
 	if len(info.ReadySCs) == 0 {
-		return base.NewErrPicker(balancer.ErrNoSubConnAvailable)
+		return base.NewErrPicker(errors.New("no available connections"))
 	}
 
 	f.mu.Lock()

--- a/go/vt/vtgateproxy/vtgateproxy.go
+++ b/go/vt/vtgateproxy/vtgateproxy.go
@@ -218,7 +218,7 @@ func Init() {
 		return append(opts, grpc.WithDefaultServiceConfig(fmt.Sprintf(`{"loadBalancingConfig": [{"%s":{}}]}`, *balancerType))), nil
 	})
 
-	RegisterJSONGateResolver(
+	_, err := RegisterJSONGateResolver(
 		*vtgateHostsFile,
 		*addressField,
 		*portField,
@@ -226,4 +226,8 @@ func Init() {
 		*affinityField,
 		*affinityValue,
 	)
+
+	if err != nil {
+		log.Fatalf("error initializing resolver: %v", err)
+	}
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

Minor tweaks to fail fast

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
