### PR TITLE
`slack-15.0`: fix private repo git config in docker build

### DIFF
--- a/docker/base/Dockerfile.mariadb
+++ b/docker/base/Dockerfile.mariadb
@@ -15,9 +15,16 @@ ARG BUILD_GIT_BRANCH
 # Allows docker builds to set the BUILD_GIT_REV
 ARG BUILD_GIT_REV
 
+# Allows private repo go dependencies
+ARG GH_ACCESS_TOKEN
+
 # Re-copy sources from working tree
 USER root
 COPY . /vt/src/vitess.io/vitess
+
+# Allow checkout of github.com/slackhq/vitess-addons (private repo)
+ENV GOPRIVATE=github.com/slackhq/vitess-addons
+RUN git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
 
 # Build Vitess
 RUN make build

--- a/docker/base/Dockerfile.mariadb103
+++ b/docker/base/Dockerfile.mariadb103
@@ -15,9 +15,16 @@ ARG BUILD_GIT_BRANCH
 # Allows docker builds to set the BUILD_GIT_REV
 ARG BUILD_GIT_REV
 
+# Allows private repo go dependencies
+ARG GH_ACCESS_TOKEN
+
 # Re-copy sources from working tree
 USER root
 COPY . /vt/src/vitess.io/vitess
+
+# Allow checkout of github.com/slackhq/vitess-addons (private repo)
+ENV GOPRIVATE=github.com/slackhq/vitess-addons
+RUN git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
 
 # Build Vitess
 RUN make build

--- a/docker/base/Dockerfile.mysql80
+++ b/docker/base/Dockerfile.mysql80
@@ -15,9 +15,16 @@ ARG BUILD_GIT_BRANCH
 # Allows docker builds to set the BUILD_GIT_REV
 ARG BUILD_GIT_REV
 
+# Allows private repo go dependencies
+ARG GH_ACCESS_TOKEN
+
 # Re-copy sources from working tree
 USER root
 COPY . /vt/src/vitess.io/vitess
+
+# Allow checkout of github.com/slackhq/vitess-addons (private repo)
+ENV GOPRIVATE=github.com/slackhq/vitess-addons
+RUN git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
 
 # Build Vitess
 RUN make build

--- a/docker/base/Dockerfile.percona57
+++ b/docker/base/Dockerfile.percona57
@@ -29,9 +29,16 @@ ARG BUILD_GIT_BRANCH
 # Allows docker builds to set the BUILD_GIT_REV
 ARG BUILD_GIT_REV
 
+# Allows private repo go dependencies
+ARG GH_ACCESS_TOKEN
+
 # Re-copy sources from working tree
 USER root
 COPY . /vt/src/vitess.io/vitess
+
+# Allow checkout of github.com/slackhq/vitess-addons (private repo)
+ENV GOPRIVATE=github.com/slackhq/vitess-addons
+RUN git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
 
 # Build Vitess
 RUN make build

--- a/docker/base/Dockerfile.percona80
+++ b/docker/base/Dockerfile.percona80
@@ -29,9 +29,16 @@ ARG BUILD_GIT_BRANCH
 # Allows docker builds to set the BUILD_GIT_REV
 ARG BUILD_GIT_REV
 
+# Allows private repo go dependencies
+ARG GH_ACCESS_TOKEN
+
 # Re-copy sources from working tree
 USER root
 COPY . /vt/src/vitess.io/vitess
+
+# Allow checkout of github.com/slackhq/vitess-addons (private repo)
+ENV GOPRIVATE=github.com/slackhq/vitess-addons
+RUN git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
 
 # Fix permissions
 RUN chown -R vitess:vitess /vt


### PR DESCRIPTION
## Description

This PR should fix access issues in our Jenkins build due to using a Durability Policy in a private repo, and the Docker build being unprepared for this:
```
2024.05.22 19:42:46 #8 4.691 go: downloading github.com/mattn/go-colorable v0.1.6
2024.05.22 19:42:46 #8 4.694 go: downloading github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0
2024.05.22 19:42:46 #8 4.741 go: downloading github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
2024.05.22 19:42:46 #8 4.741 go: downloading github.com/hashicorp/go-immutable-radix v1.1.0
2024.05.22 19:42:46 #8 4.805 go: downloading github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
2024.05.22 19:42:47 #8 5.671 go/vt/vtctl/reparentutil/slack_cross_cell_shim.go:3:8: reading github.com/slackhq/vitess-addons/go.mod at revision v0.15.3: git ls-remote -q origin in /go/pkg/mod/cache/vcs/deddcb84177463a570ad3cac1ad9ff1e94bf4f985fbe6cc27416617e75330028: exit status 128:
2024.05.22 19:42:47 #8 5.671 	fatal: could not read Username for 'https://github.com/': terminal prompts disabled
2024.05.22 19:42:47 #8 5.671 Confirm the import path was entered correctly.
2024.05.22 19:42:47 #8 5.671 If this is a private repository, see https://golang.org/doc/faq#git_https for additional information.
2024.05.22 19:42:47 #8 5.674 make: *** [Makefile:85: build] Error 1
2024.05.22 19:42:48 #8 ERROR: process "/bin/sh -c make build" did not complete successfully: exit code: 2
2024.05.22 19:42:48 ------
```

This issue was introduced in https://github.com/slackhq/vitess/pull/266 where I should have updated these Dockerfiles 🤦 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
