### PR TITLE
`slack-15.0`: backport required Transaction Throttler PRs, pt. 4

### DIFF
--- a/go/mysql/sql_error.go
+++ b/go/mysql/sql_error.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
@@ -135,7 +136,11 @@ func mapToSQLErrorFromErrorCode(err error, msg string) *SQLError {
 		ss = SSAccessDeniedError
 	case vtrpcpb.Code_RESOURCE_EXHAUSTED:
 		num = demuxResourceExhaustedErrors(err.Error())
-		ss = SSClientError
+		// 1041 ER_OUT_OF_RESOURCES has SQLSTATE HYOOO as per https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html#error_er_out_of_resources,
+		// so don't override it here in that case.
+		if num != EROutOfResources {
+			ss = SSClientError
+		}
 	case vtrpcpb.Code_UNIMPLEMENTED:
 		num = ERNotSupportedYet
 		ss = SSClientError
@@ -223,6 +228,8 @@ func demuxResourceExhaustedErrors(msg string) int {
 	switch {
 	case isGRPCOverflowRE.Match([]byte(msg)):
 		return ERNetPacketTooLarge
+	case strings.Contains(msg, "Transaction throttled"):
+		return EROutOfResources
 	default:
 		return ERTooManyUserConnections
 	}

--- a/go/mysql/sql_error_test.go
+++ b/go/mysql/sql_error_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDumuxResourceExhaustedErrors(t *testing.T) {
+func TestDemuxResourceExhaustedErrors(t *testing.T) {
 	type testCase struct {
 		msg  string
 		want int
@@ -42,6 +42,7 @@ func TestDumuxResourceExhaustedErrors(t *testing.T) {
 		// This should be explicitly handled by returning ERNetPacketTooLarge from the execturo directly
 		// and therefore shouldn't need to be teased out of another error.
 		{"in-memory row count exceeded allowed limit of 13", ERTooManyUserConnections},
+		{"rpc error: code = ResourceExhausted desc = Transaction throttled", EROutOfResources},
 	}
 
 	for _, c := range cases {
@@ -150,6 +151,11 @@ func TestNewSQLErrorFromError(t *testing.T) {
 			err: vterrors.NewErrorf(vtrpc.Code_FAILED_PRECONDITION, vterrors.NoDB, "no db selected"),
 			num: ERNoDb,
 			ss:  SSNoDB,
+		},
+		{
+			err: vterrors.Errorf(vtrpc.Code_RESOURCE_EXHAUSTED, "vttablet: rpc error: code = ResourceExhausted desc = Transaction throttled"),
+			num: EROutOfResources,
+			ss:  SSUnknownSQLState,
 		},
 	}
 

--- a/go/vt/throttler/max_replication_lag_module.go
+++ b/go/vt/throttler/max_replication_lag_module.go
@@ -381,7 +381,6 @@ logResult:
 		r.Reason += clearReason
 	}
 
-	log.Infof("%v", r)
 	m.results.add(r)
 }
 

--- a/go/vt/throttler/max_replication_lag_module.go
+++ b/go/vt/throttler/max_replication_lag_module.go
@@ -301,6 +301,12 @@ func (m *MaxReplicationLagModule) recalculateRate(lagRecordNow replicationLagRec
 	if lagRecordNow.isZero() {
 		panic("rate recalculation was triggered with a zero replication lag record")
 	}
+
+	// Protect against nil stats
+	if lagRecordNow.Stats == nil {
+		return
+	}
+
 	now := lagRecordNow.time
 	lagNow := lagRecordNow.lag()
 


### PR DESCRIPTION
## Description

Backports:
1. https://github.com/vitessio/vitess/pull/12620
2. https://github.com/vitessio/vitess/pull/12949
3. https://github.com/vitessio/vitess/pull/14875

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
