### PR TITLE
`slack-15.0`: refactor private go dep config from #367

### DIFF
--- a/build.env
+++ b/build.env
@@ -44,3 +44,8 @@ ln -sf "$PWD/misc/git/pre-commit" .git/hooks/pre-commit
 ln -sf "$PWD/misc/git/commit-msg" .git/hooks/commit-msg
 git config core.hooksPath .git/hooks
 export EXTRA_BIN=$PWD/test/bin
+
+# support private github.com/slackhq/vitess-addons repo
+if [[ -n "${GH_ACCESS_TOKEN}" ]]; then
+  git config --global url.https://${GH_ACCESS_TOKEN}@github.com/.insteadOf https://github.com/
+fi

--- a/docker/base/Dockerfile.mariadb
+++ b/docker/base/Dockerfile.mariadb
@@ -16,15 +16,12 @@ ARG BUILD_GIT_BRANCH
 ARG BUILD_GIT_REV
 
 # Allows private repo go dependencies
+ARG GOPRIVATE
 ARG GH_ACCESS_TOKEN
 
 # Re-copy sources from working tree
 USER root
 COPY . /vt/src/vitess.io/vitess
-
-# Allow checkout of github.com/slackhq/vitess-addons (private repo)
-ENV GOPRIVATE=github.com/slackhq/vitess-addons
-RUN git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
 
 # Build Vitess
 RUN make build

--- a/docker/base/Dockerfile.mariadb103
+++ b/docker/base/Dockerfile.mariadb103
@@ -16,15 +16,12 @@ ARG BUILD_GIT_BRANCH
 ARG BUILD_GIT_REV
 
 # Allows private repo go dependencies
+ARG GOPRIVATE
 ARG GH_ACCESS_TOKEN
 
 # Re-copy sources from working tree
 USER root
 COPY . /vt/src/vitess.io/vitess
-
-# Allow checkout of github.com/slackhq/vitess-addons (private repo)
-ENV GOPRIVATE=github.com/slackhq/vitess-addons
-RUN git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
 
 # Build Vitess
 RUN make build

--- a/docker/base/Dockerfile.mysql80
+++ b/docker/base/Dockerfile.mysql80
@@ -16,15 +16,12 @@ ARG BUILD_GIT_BRANCH
 ARG BUILD_GIT_REV
 
 # Allows private repo go dependencies
+ARG GOPRIVATE
 ARG GH_ACCESS_TOKEN
 
 # Re-copy sources from working tree
 USER root
 COPY . /vt/src/vitess.io/vitess
-
-# Allow checkout of github.com/slackhq/vitess-addons (private repo)
-ENV GOPRIVATE=github.com/slackhq/vitess-addons
-RUN git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
 
 # Build Vitess
 RUN make build

--- a/docker/base/Dockerfile.percona57
+++ b/docker/base/Dockerfile.percona57
@@ -30,15 +30,12 @@ ARG BUILD_GIT_BRANCH
 ARG BUILD_GIT_REV
 
 # Allows private repo go dependencies
+ARG GOPRIVATE
 ARG GH_ACCESS_TOKEN
 
 # Re-copy sources from working tree
 USER root
 COPY . /vt/src/vitess.io/vitess
-
-# Allow checkout of github.com/slackhq/vitess-addons (private repo)
-ENV GOPRIVATE=github.com/slackhq/vitess-addons
-RUN git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
 
 # Build Vitess
 RUN make build

--- a/docker/base/Dockerfile.percona80
+++ b/docker/base/Dockerfile.percona80
@@ -30,15 +30,12 @@ ARG BUILD_GIT_BRANCH
 ARG BUILD_GIT_REV
 
 # Allows private repo go dependencies
+ARG GOPRIVATE
 ARG GH_ACCESS_TOKEN
 
 # Re-copy sources from working tree
 USER root
 COPY . /vt/src/vitess.io/vitess
-
-# Allow checkout of github.com/slackhq/vitess-addons (private repo)
-ENV GOPRIVATE=github.com/slackhq/vitess-addons
-RUN git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
 
 # Fix permissions
 RUN chown -R vitess:vitess /vt


### PR DESCRIPTION
## Description

This PR refactors https://github.com/slackhq/vitess/pull/367 by moving the `git config` commands to setup private-repo access (for our custom durability policy) into `build.env`, so the logic is more general and the GitHub token is not leaked in CI output

A separate, internal PR will occur to add `GOPRIVATE` to our CI environment

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
