### PR TITLE
`slack-15.0`: use latest-stable `go1.21.10`

### DIFF
--- a/.github/workflows/assign_milestone.yml
+++ b/.github/workflows/assign_milestone.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.21.8
+          go-version: 1.21.10
 
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/check_make_vtadmin_authz_testgen.yml
+++ b/.github/workflows/check_make_vtadmin_authz_testgen.yml
@@ -41,7 +41,7 @@ jobs:
       uses: actions/setup-go@v3
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.vtadmin_changes == 'true'
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/check_make_vtadmin_web_proto.yml
+++ b/.github/workflows/check_make_vtadmin_web_proto.yml
@@ -40,7 +40,7 @@ jobs:
       uses: actions/setup-go@v3
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.proto_changes == 'true'
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup Node
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.proto_changes == 'true'

--- a/.github/workflows/cluster_endtoend_12.yml
+++ b/.github/workflows/cluster_endtoend_12.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_18.yml
+++ b/.github/workflows/cluster_endtoend_18.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
+++ b/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_mysql80.yml
+++ b/.github/workflows/cluster_endtoend_mysql80.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_mysql_server_vault.yml
+++ b/.github/workflows/cluster_endtoend_mysql_server_vault.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_topo_connection_cache.yml
+++ b/.github/workflows/cluster_endtoend_topo_connection_cache.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_vreplication_migrate_vdiff2_convert_tz.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate_vdiff2_convert_tz.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_vstream_failover.yml
+++ b/.github/workflows/cluster_endtoend_vstream_failover.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
+++ b/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_vtbackup_transform.yml
+++ b/.github/workflows/cluster_endtoend_vtbackup_transform.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_vtgate_general_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_general_heavy.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_vtgate_godriver.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_godriver.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_vtgate_partial_keyspace.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_partial_keyspace.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_vtgate_queries.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_queries.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_vtgate_vindex_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex_heavy.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_vttablet_prscomplex.yml
+++ b/.github/workflows/cluster_endtoend_vttablet_prscomplex.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_xb_backup.yml
+++ b/.github/workflows/cluster_endtoend_xb_backup.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -51,7 +51,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.21.8
+          go-version: 1.21.10
 
       - name: Get base dependencies
         run: |

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup node
       uses: actions/setup-node@v3

--- a/.github/workflows/docker_test_cluster_10.yml
+++ b/.github/workflows/docker_test_cluster_10.yml
@@ -47,7 +47,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/docker_test_cluster_25.yml
+++ b/.github/workflows/docker_test_cluster_25.yml
@@ -47,7 +47,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/e2e_race.yml
+++ b/.github/workflows/e2e_race.yml
@@ -45,7 +45,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -45,7 +45,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/local_example.yml
+++ b/.github/workflows/local_example.yml
@@ -50,7 +50,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.examples == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/region_example.yml
+++ b/.github/workflows/region_example.yml
@@ -50,7 +50,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.examples == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/sonar_analysis.yml
+++ b/.github/workflows/sonar_analysis.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.21.8
+          go-version: 1.21.10
 
       - name: Tune the OS
         run: |

--- a/.github/workflows/static_checks_etc.yml
+++ b/.github/workflows/static_checks_etc.yml
@@ -94,7 +94,7 @@ jobs:
         if: steps.skip-workflow.outputs.skip-workflow == 'false' && (steps.changes.outputs.go_files == 'true' || steps.changes.outputs.parser_changes == 'true' || steps.changes.outputs.proto_changes == 'true')
         uses: actions/setup-go@v3
         with:
-          go-version: 1.21.8
+          go-version: 1.21.10
 
       - name: Setup github.com/slackhq/vitess-additions access token
         run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/unit_race.yml
+++ b/.github/workflows/unit_race.yml
@@ -49,7 +49,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.unit_tests == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/unit_test_mysql80.yml
+++ b/.github/workflows/unit_test_mysql80.yml
@@ -50,7 +50,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.unit_tests == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/update_golang_version.yml
+++ b/.github/workflows/update_golang_version.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.21.8
+          go-version: 1.21.10
 
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -77,7 +77,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
@@ -80,7 +80,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -79,7 +79,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
@@ -82,7 +82,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
@@ -79,7 +79,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
@@ -82,7 +82,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
@@ -79,7 +79,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
@@ -81,7 +81,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
@@ -82,7 +82,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
@@ -82,7 +82,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -79,7 +79,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -79,7 +79,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/docker/bootstrap/Dockerfile.common
+++ b/docker/bootstrap/Dockerfile.common
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 golang:1.21.8-bullseye
+FROM --platform=linux/amd64 golang:1.21.10-bullseye
 
 # Install Vitess build dependencies
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -49,7 +49,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/test/templates/cluster_endtoend_test_docker.tpl
+++ b/test/templates/cluster_endtoend_test_docker.tpl
@@ -46,7 +46,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/test/templates/cluster_endtoend_test_mysql57.tpl
+++ b/test/templates/cluster_endtoend_test_mysql57.tpl
@@ -56,7 +56,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/

--- a/test/templates/unit_test.tpl
+++ b/test/templates/unit_test.tpl
@@ -48,7 +48,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.unit_tests == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.8
+        go-version: 1.21.10
 
     - name: Setup github.com/slackhq/vitess-additions access token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/


### PR DESCRIPTION
## Description

This PR updates the go runtime to latest-stable `go1.21.10`

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
