### PR TITLE
`slack-15.0`: backport vitessio/vitess#15897

### DIFF
--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -168,11 +168,6 @@ var (
 	warnings *stats.CountersWithSingleLabel
 
 	vstreamSkewDelayCount *stats.Counter
-
-	sqlTextCounts = stats.NewCountersWithMultiLabels(
-		"VtgateSQLTextCounts",
-		"Vtgate API query SQL text counts",
-		[]string{"Operation", "Keyspace", "DbType"})
 )
 
 // VTGate is the rpc interface to vtgate. Only one instance
@@ -309,6 +304,10 @@ func Init(
 		rowsAffected: stats.NewCountersWithMultiLabels(
 			"VtgateApiRowsAffected",
 			"Rows affected by a write (DML) operation through the VTgate API",
+			[]string{"Operation", "Keyspace", "DbType"}),
+		sqlTextCount: stats.NewCountersWithMultiLabels(
+			"VtgateSQLTextCounts",
+			"Vtgate API query SQL text counts",
 			[]string{"Operation", "Keyspace", "DbType"}),
 
 		logExecute:       logutil.NewThrottledLogger("Execute", 5*time.Second),

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -305,7 +305,7 @@ func Init(
 			"VtgateApiRowsAffected",
 			"Rows affected by a write (DML) operation through the VTgate API",
 			[]string{"Operation", "Keyspace", "DbType"}),
-		sqlTextCount: stats.NewCountersWithMultiLabels(
+		sqlTextCounts: stats.NewCountersWithMultiLabels(
 			"VtgateSQLTextCounts",
 			"Vtgate API query SQL text counts",
 			[]string{"Operation", "Keyspace", "DbType"}),

--- a/go/vt/vttablet/tabletserver/query_engine_test.go
+++ b/go/vt/vttablet/tabletserver/query_engine_test.go
@@ -628,6 +628,7 @@ func TestAddQueryStats(t *testing.T) {
 		}, {
 			name:                          "select into query",
 			plan:                          fakeSelectPlan,
+			tableName:                     "A",
 			queryCount:                    1,
 			duration:                      10,
 			rowsAffected:                  15,

--- a/go/vt/vttablet/tabletserver/query_engine_test.go
+++ b/go/vt/vttablet/tabletserver/query_engine_test.go
@@ -573,9 +573,21 @@ func TestPlanCachePollution(t *testing.T) {
 }
 
 func TestAddQueryStats(t *testing.T) {
+	fakeSelectPlan := &TabletPlan{
+		Plan: &planbuilder.Plan{
+			PlanID:    planbuilder.PlanSelect,
+			FullQuery: &sqlparser.ParsedQuery{Query: `select * from something where something=123`}, // 43 length
+		},
+	}
+	fakeInsertPlan := &TabletPlan{
+		Plan: &planbuilder.Plan{
+			PlanID:    planbuilder.PlanInsert,
+			FullQuery: &sqlparser.ParsedQuery{Query: `insert into something (id, msg) values(123, 'hello world!')`}, // 59 length
+		},
+	}
 	testcases := []struct {
 		name                          string
-		planType                      planbuilder.PlanType
+		plan                          *TabletPlan
 		tableName                     string
 		queryCount                    int64
 		duration                      time.Duration
@@ -590,12 +602,13 @@ func TestAddQueryStats(t *testing.T) {
 		expectedQueryTimes            string
 		expectedQueryRowsAffected     string
 		expectedQueryRowsReturned     string
+		expectedQuerySQLTextCounts    string
 		expectedQueryErrorCounts      string
 		expectedQueryRowCounts        string
 	}{
 		{
 			name:                          "select query",
-			planType:                      planbuilder.PlanSelect,
+			plan:                          fakeSelectPlan,
 			tableName:                     "A",
 			queryCount:                    1,
 			duration:                      10,
@@ -609,12 +622,12 @@ func TestAddQueryStats(t *testing.T) {
 			expectedQueryTimes:            `{"A.Select": 10}`,
 			expectedQueryRowsAffected:     `{}`,
 			expectedQueryRowsReturned:     `{"A.Select": 15}`,
+			expectedQuerySQLTextCounts:    `{"A.Select": 43}`,
 			expectedQueryRowCounts:        `{"A.Select": 0}`,
 			expectedQueryErrorCounts:      `{"A.Select": 0}`,
 		}, {
 			name:                          "select into query",
-			planType:                      planbuilder.PlanSelect,
-			tableName:                     "A",
+			plan:                          fakeSelectPlan,
 			queryCount:                    1,
 			duration:                      10,
 			rowsAffected:                  15,
@@ -627,11 +640,12 @@ func TestAddQueryStats(t *testing.T) {
 			expectedQueryTimes:            `{"A.Select": 10}`,
 			expectedQueryRowsAffected:     `{"A.Select": 15}`,
 			expectedQueryRowsReturned:     `{"A.Select": 0}`,
+			expectedQuerySQLTextCounts:    `{"A.Select": 43}`,
 			expectedQueryRowCounts:        `{"A.Select": 15}`,
 			expectedQueryErrorCounts:      `{"A.Select": 0}`,
 		}, {
 			name:                          "error",
-			planType:                      planbuilder.PlanSelect,
+			plan:                          fakeSelectPlan,
 			tableName:                     "A",
 			queryCount:                    1,
 			duration:                      10,
@@ -645,11 +659,12 @@ func TestAddQueryStats(t *testing.T) {
 			expectedQueryTimes:            `{"A.Select": 10}`,
 			expectedQueryRowsAffected:     `{}`,
 			expectedQueryRowsReturned:     `{"A.Select": 0}`,
+			expectedQuerySQLTextCounts:    `{"A.Select": 43}`,
 			expectedQueryRowCounts:        `{"A.Select": 0}`,
 			expectedQueryErrorCounts:      `{"A.Select": 1}`,
 		}, {
 			name:                          "insert query",
-			planType:                      planbuilder.PlanInsert,
+			plan:                          fakeInsertPlan,
 			tableName:                     "A",
 			queryCount:                    1,
 			duration:                      10,
@@ -663,11 +678,12 @@ func TestAddQueryStats(t *testing.T) {
 			expectedQueryTimes:            `{"A.Insert": 10}`,
 			expectedQueryRowsAffected:     `{"A.Insert": 15}`,
 			expectedQueryRowsReturned:     `{}`,
+			expectedQuerySQLTextCounts:    `{"A.Insert": 59}`,
 			expectedQueryRowCounts:        `{"A.Insert": 15}`,
 			expectedQueryErrorCounts:      `{"A.Insert": 0}`,
 		}, {
 			name:                          "select query with per workload metrics",
-			planType:                      planbuilder.PlanSelect,
+			plan:                          fakeSelectPlan,
 			tableName:                     "A",
 			queryCount:                    1,
 			duration:                      10,
@@ -681,11 +697,12 @@ func TestAddQueryStats(t *testing.T) {
 			expectedQueryTimes:            `{"A.Select.some-workload": 10}`,
 			expectedQueryRowsAffected:     `{}`,
 			expectedQueryRowsReturned:     `{"A.Select.some-workload": 15}`,
+			expectedQuerySQLTextCounts:    `{"A.Select.some-workload": 43}`,
 			expectedQueryRowCounts:        `{"A.Select.some-workload": 0}`,
 			expectedQueryErrorCounts:      `{"A.Select.some-workload": 0}`,
 		}, {
 			name:                          "select into query with per workload metrics",
-			planType:                      planbuilder.PlanSelect,
+			plan:                          fakeSelectPlan,
 			tableName:                     "A",
 			queryCount:                    1,
 			duration:                      10,
@@ -699,11 +716,12 @@ func TestAddQueryStats(t *testing.T) {
 			expectedQueryTimes:            `{"A.Select.some-workload": 10}`,
 			expectedQueryRowsAffected:     `{"A.Select.some-workload": 15}`,
 			expectedQueryRowsReturned:     `{"A.Select.some-workload": 0}`,
+			expectedQuerySQLTextCounts:    `{"A.Select.some-workload": 43}`,
 			expectedQueryRowCounts:        `{"A.Select.some-workload": 15}`,
 			expectedQueryErrorCounts:      `{"A.Select.some-workload": 0}`,
 		}, {
 			name:                          "error with per workload metrics",
-			planType:                      planbuilder.PlanSelect,
+			plan:                          fakeSelectPlan,
 			tableName:                     "A",
 			queryCount:                    1,
 			duration:                      10,
@@ -717,11 +735,12 @@ func TestAddQueryStats(t *testing.T) {
 			expectedQueryTimes:            `{"A.Select.some-workload": 10}`,
 			expectedQueryRowsAffected:     `{}`,
 			expectedQueryRowsReturned:     `{"A.Select.some-workload": 0}`,
+			expectedQuerySQLTextCounts:    `{"A.Select.some-workload": 43}`,
 			expectedQueryRowCounts:        `{"A.Select.some-workload": 0}`,
 			expectedQueryErrorCounts:      `{"A.Select.some-workload": 1}`,
 		}, {
 			name:                          "insert query with per workload metrics",
-			planType:                      planbuilder.PlanInsert,
+			plan:                          fakeInsertPlan,
 			tableName:                     "A",
 			queryCount:                    1,
 			duration:                      10,
@@ -735,6 +754,7 @@ func TestAddQueryStats(t *testing.T) {
 			expectedQueryTimes:            `{"A.Insert.some-workload": 10}`,
 			expectedQueryRowsAffected:     `{"A.Insert.some-workload": 15}`,
 			expectedQueryRowsReturned:     `{}`,
+			expectedQuerySQLTextCounts:    `{"A.Insert.some-workload": 59}`,
 			expectedQueryRowCounts:        `{"A.Insert.some-workload": 15}`,
 			expectedQueryErrorCounts:      `{"A.Insert.some-workload": 0}`,
 		},
@@ -749,12 +769,13 @@ func TestAddQueryStats(t *testing.T) {
 			env := tabletenv.NewEnv(config, "TestAddQueryStats_"+testcase.name)
 			se := schema.NewEngine(env)
 			qe := NewQueryEngine(env, se)
-			qe.AddStats(testcase.planType, testcase.tableName, testcase.workload, testcase.queryCount, testcase.duration, testcase.mysqlTime, testcase.rowsAffected, testcase.rowsReturned, testcase.errorCount)
+			qe.AddStats(testcase.plan, testcase.tableName, testcase.workload, testcase.queryCount, testcase.duration, testcase.mysqlTime, testcase.rowsAffected, testcase.rowsReturned, testcase.errorCount)
 			assert.Equal(t, testcase.expectedQueryCounts, qe.queryCounts.String())
 			assert.Equal(t, testcase.expectedQueryTimes, qe.queryTimes.String())
 			assert.Equal(t, testcase.expectedQueryRowsAffected, qe.queryRowsAffected.String())
 			assert.Equal(t, testcase.expectedQueryRowsReturned, qe.queryRowsReturned.String())
 			assert.Equal(t, testcase.expectedQueryRowCounts, qe.queryRowCounts.String())
+			assert.Equal(t, testcase.expectedQuerySQLTextCounts, qe.querySQLTextCounts.String())
 			assert.Equal(t, testcase.expectedQueryErrorCounts, qe.queryErrorCounts.String())
 		})
 	}

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -121,11 +121,11 @@ func (qre *QueryExecutor) Execute() (reply *sqltypes.Result, err error) {
 		}
 
 		if reply == nil {
-			qre.tsv.qe.AddStats(qre.plan.PlanID, tableName, qre.options.GetWorkloadName(), 1, duration, mysqlTime, 0, 0, 1)
+			qre.tsv.qe.AddStats(qre.plan, tableName, qre.options.GetWorkloadName(), 1, duration, mysqlTime, 0, 0, 1)
 			qre.plan.AddStats(1, duration, mysqlTime, 0, 0, 1)
 			return
 		}
-		qre.tsv.qe.AddStats(qre.plan.PlanID, tableName, qre.options.GetWorkloadName(), 1, duration, mysqlTime, int64(reply.RowsAffected), int64(len(reply.Rows)), 0)
+		qre.tsv.qe.AddStats(qre.plan, tableName, qre.options.GetWorkloadName(), 1, duration, mysqlTime, int64(reply.RowsAffected), int64(len(reply.Rows)), 0)
 		qre.plan.AddStats(1, duration, mysqlTime, reply.RowsAffected, uint64(len(reply.Rows)), 0)
 		qre.logStats.RowsAffected = int(reply.RowsAffected)
 		qre.logStats.Rows = reply.Rows


### PR DESCRIPTION
## Description

Backporting [this approved-but-unmerged upstream PR](https://github.com/vitessio/vitess/pull/15897) so we can provide the output upstream requested

This provides us SQL text stats requested internally

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
