### PR TITLE
fix spurious errors when closing inactive connections

### DIFF
--- a/go/vt/vtgateproxy/mysql_server.go
+++ b/go/vt/vtgateproxy/mysql_server.go
@@ -99,17 +99,7 @@ func (ph *proxyHandler) NewConnection(c *mysql.Conn) {
 
 func (ph *proxyHandler) ComResetConnection(c *mysql.Conn) {
 	ctx := context.Background()
-	session, err := ph.getSession(ctx, c)
-	if err != nil {
-		return
-	}
-	if session.SessionPb().InTransaction {
-		defer atomic.AddInt32(&busyConnections, -1)
-	}
-	err = ph.proxy.CloseSession(ctx, session)
-	if err != nil {
-		log.Errorf("Error happened in transaction rollback: %v", err)
-	}
+	ph.closeSession(ctx, c)
 }
 
 func (ph *proxyHandler) ConnectionClosed(c *mysql.Conn) {
@@ -127,14 +117,7 @@ func (ph *proxyHandler) ConnectionClosed(c *mysql.Conn) {
 	} else {
 		ctx = context.Background()
 	}
-	session, err := ph.getSession(ctx, c)
-	if err != nil {
-		return
-	}
-	if session.SessionPb().InTransaction {
-		defer atomic.AddInt32(&busyConnections, -1)
-	}
-	_ = ph.proxy.CloseSession(ctx, session)
+	ph.closeSession(ctx, c)
 }
 
 // Regexp to extract parent span id over the sql query
@@ -375,6 +358,23 @@ func (ph *proxyHandler) getSession(ctx context.Context, c *mysql.Conn) (*vtgatec
 	}
 
 	return session, nil
+}
+
+func (ph *proxyHandler) closeSession(ctx context.Context, c *mysql.Conn) {
+	session, _ := c.ClientData.(*vtgateconn.VTGateSession)
+	if session == nil {
+		return // no active session
+	}
+
+	if session.SessionPb().InTransaction {
+		defer atomic.AddInt32(&busyConnections, -1)
+	}
+	err := ph.proxy.CloseSession(ctx, session)
+	if err != nil {
+		log.Errorf("Error happened in transaction rollback: %v", err)
+	}
+
+	c.ClientData = nil
 }
 
 var mysqlListener *mysql.Listener


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
When a connection is closed or reset before it is properly established, the existing ::getSession will log a spurious error since the connection has no attributes to extract for the pool type.

Fix this by refactoring so that when closing a connection we only act on the session object if one already existed, i.e. the conn was used before.


<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
