### PR TITLE
Backport upstream: do not demote a new primary after backup completion (#12856)

### DIFF
--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -24,6 +24,7 @@ import (
 	"os/exec"
 	"path"
 	"strings"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -36,6 +37,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"vitess.io/vitess/go/json2"
 	"vitess.io/vitess/go/test/endtoend/cluster"
 )
 
@@ -329,6 +331,10 @@ func TestBackup(t *testing.T, setupType int, streamMode string, stripes int, cDe
 			name:   "TestTerminatedRestore",
 			method: terminatedRestore,
 		}, //
+		{
+			name:   "DoNotDemoteNewlyPromotedPrimaryIfReparentingDuringBackup",
+			method: doNotDemoteNewlyPromotedPrimaryIfReparentingDuringBackup,
+		}, //
 	}
 
 	defer cluster.PanicHandler(t)
@@ -342,6 +348,10 @@ func TestBackup(t *testing.T, setupType int, streamMode string, stripes int, cDe
 	// Run all the backup tests
 	for _, test := range testMethods {
 		if len(runSpecific) > 0 && !isRegistered(test.name, runSpecific) {
+			continue
+		}
+		// don't run this one unless specified
+		if len(runSpecific) == 0 && test.name == "DoNotDemoteNewlyPromotedPrimaryIfReparentingDuringBackup" {
 			continue
 		}
 		if retVal := t.Run(test.name, test.method); !retVal {
@@ -747,6 +757,60 @@ func terminatedRestore(t *testing.T) {
 
 	cluster.VerifyRowsInTablet(t, primary, keyspaceName, 3)
 	stopAllTablets()
+}
+
+func checkTabletType(t *testing.T, alias string, tabletType topodata.TabletType) {
+	// for loop for 15 seconds to check if tablet type is correct
+	for i := 0; i < 15; i++ {
+		output, err := localCluster.VtctldClientProcess.ExecuteCommandWithOutput("GetTablet", alias)
+		require.Nil(t, err)
+		var tabletPB topodata.Tablet
+		err = json2.Unmarshal([]byte(output), &tabletPB)
+		require.NoError(t, err)
+		if tabletType == tabletPB.Type {
+			return
+		}
+		time.Sleep(1 * time.Second)
+	}
+	require.Failf(t, "checkTabletType failed.", "Tablet type is not correct. Expected: %v", tabletType)
+}
+
+func doNotDemoteNewlyPromotedPrimaryIfReparentingDuringBackup(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Start the backup on a replica
+	go func() {
+		defer wg.Done()
+		// ensure this is a primary first
+		checkTabletType(t, primary.Alias, topodata.TabletType_PRIMARY)
+
+		// now backup
+		err := localCluster.VtctlclientProcess.ExecuteCommand("Backup", replica1.Alias)
+		require.Nil(t, err)
+	}()
+
+	// Perform a graceful reparent operation
+	go func() {
+		defer wg.Done()
+		// ensure this is a primary first
+		checkTabletType(t, primary.Alias, topodata.TabletType_PRIMARY)
+
+		// now reparent
+		_, err := localCluster.VtctlclientProcess.ExecuteCommandWithOutput(
+			"PlannedReparentShard", "--",
+			"--keyspace_shard", fmt.Sprintf("%s/%s", keyspaceName, shardName),
+			"--new_primary", replica1.Alias)
+		require.Nil(t, err)
+
+		// check that we reparented
+		checkTabletType(t, replica1.Alias, topodata.TabletType_PRIMARY)
+	}()
+
+	wg.Wait()
+
+	// check that this is still a primary
+	checkTabletType(t, replica1.Alias, topodata.TabletType_PRIMARY)
 }
 
 // test_backup will:

--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -762,7 +762,7 @@ func terminatedRestore(t *testing.T) {
 func checkTabletType(t *testing.T, alias string, tabletType topodata.TabletType) {
 	// for loop for 15 seconds to check if tablet type is correct
 	for i := 0; i < 15; i++ {
-		output, err := localCluster.VtctldClientProcess.ExecuteCommandWithOutput("GetTablet", alias)
+		output, err := localCluster.VtctlclientProcess.ExecuteCommandWithOutput("GetTablet", alias)
 		require.Nil(t, err)
 		var tabletPB topodata.Tablet
 		err = json2.Unmarshal([]byte(output), &tabletPB)

--- a/go/test/endtoend/backup/xtrabackup/xtrabackup_test.go
+++ b/go/test/endtoend/backup/xtrabackup/xtrabackup_test.go
@@ -41,6 +41,34 @@ func TestXtrabackWithZstdCompression(t *testing.T) {
 	backup.TestBackup(t, backup.XtraBackup, "tar", 0, cDetails, []string{"TestReplicaBackup"})
 }
 
+func TestXtrabackupWithExternalZstdCompression(t *testing.T) {
+	defer setDefaultCompressionFlag()
+	cDetails := &backup.CompressionDetails{
+		CompressorEngineName:    "external",
+		ExternalCompressorCmd:   "zstd",
+		ExternalCompressorExt:   ".zst",
+		ExternalDecompressorCmd: "zstd -d",
+	}
+
+	backup.TestBackup(t, backup.XtraBackup, "tar", 0, cDetails, []string{"TestReplicaBackup"})
+}
+
+func TestXtrabackupWithExternalZstdCompressionAndManifestedDecompressor(t *testing.T) {
+	defer setDefaultCompressionFlag()
+	cDetails := &backup.CompressionDetails{
+		CompressorEngineName:    "external",
+		ExternalCompressorCmd:   "zstd",
+		ExternalCompressorExt:   ".zst",
+		ExternalDecompressorCmd: "zstd -d",
+	}
+
+	backup.TestBackup(t, backup.XtraBackup, "tar", 0, cDetails, []string{"TestReplicaBackup"})
+}
+
+func TestDoNotDemoteNewlyPromotedPrimaryIfReparentingDuringBackup(t *testing.T) {
+	backup.TestBackup(t, backup.XtraBackup, "xbstream", 0, nil, []string{"DoNotDemoteNewlyPromotedPrimaryIfReparentingDuringBackup"})
+}
+
 func setDefaultCompressionFlag() {
 	mysqlctl.CompressionEngineName = "pgzip"
 	mysqlctl.ExternalCompressorCmd = ""

--- a/go/vt/vtctl/grpcvtctldserver/server.go
+++ b/go/vt/vtctl/grpcvtctldserver/server.go
@@ -478,20 +478,7 @@ func (s *VtctldServer) backupTablet(ctx context.Context, tablet *topodatapb.Tabl
 				logger.Errorf("failed to send stream response %+v: %v", resp, err)
 			}
 		case io.EOF:
-			// Do not do anything for primary tablets and when active reparenting is disabled
-			if mysqlctl.DisableActiveReparents || tablet.Type == topodatapb.TabletType_PRIMARY {
-				return nil
-			}
-
-			// Otherwise we find the correct primary tablet and set the replication source,
-			// since the primary could have changed while we executed the backup which can
-			// also affect whether we want to send semi sync acks or not.
-			tabletInfo, err := s.ts.GetTablet(ctx, tablet.Alias)
-			if err != nil {
-				return err
-			}
-
-			return reparentutil.SetReplicationSource(ctx, s.ts, s.tmc, tabletInfo.Tablet)
+			return nil
 		default:
 			return err
 		}


### PR DESCRIPTION
* do not demote a new primary after backup completion



* move set replication source out of vtctld and into tablet



* remove set replication source in vtctld



* fix ctx, and wip test



* add e2e test instead of unit test



* use built in methods



* omit this in test



* Update go/vt/vttablet/tabletmanager/rpc_backup.go





* move wg done to top of func



* fix method change





* try running this in isolation



* try running this in isolation, dont run with others



* add debug logging



* add debug logging



* Update go/test/endtoend/backup/vtctlbackup/backup_utils.go




* Update go/test/endtoend/backup/vtctlbackup/backup_utils.go




* run goimports



* remove dupe



* remove generated file



---------

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

backport https://github.com/vitessio/vitess/pull/12856

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
