### PR TITLE
incident patch: disable the queryservice checks in rebuildkeyspacegraph call

### DIFF
--- a/go/vt/topotools/rebuild_keyspace.go
+++ b/go/vt/topotools/rebuild_keyspace.go
@@ -78,9 +78,11 @@ func RebuildKeyspaceLocked(ctx context.Context, log logutil.Logger, ts *topo.Ser
 	//   value: topo.SrvKeyspace object being built
 	srvKeyspaceMap := make(map[string]*topodatapb.SrvKeyspace)
 	for _, cell := range cells {
-		srvKeyspace, err := ts.GetSrvKeyspace(ctx, cell, keyspace)
+		_ /*srvKeyspace*/, err := ts.GetSrvKeyspace(ctx, cell, keyspace)
 		switch {
 		case err == nil:
+			fmt.Println("Skipping");
+			/*
 			for _, partition := range srvKeyspace.GetPartitions() {
 				for _, shardTabletControl := range partition.GetShardTabletControls() {
 					if shardTabletControl.QueryServiceDisabled {
@@ -88,6 +90,7 @@ func RebuildKeyspaceLocked(ctx context.Context, log logutil.Logger, ts *topo.Ser
 					}
 				}
 			}
+			*/
 		case topo.IsErrType(err, topo.NoNode):
 			// NOOP
 		default:


### PR DESCRIPTION
I'm doing the branch build, this is just for 👀 at the diff

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
