### PR TITLE
rework tabletbalancer interface to avoid unnecessary sort

### DIFF
--- a/go/vt/vtgate/balancer/balancer_test.go
+++ b/go/vt/vtgate/balancer/balancer_test.go
@@ -268,6 +268,22 @@ func TestBalancedPick(t *testing.T) {
 
 			[]string{"a", "b", "c", "d"},
 		},
+		{
+			"one target same cell",
+			[]*discovery.TabletHealth{
+				createTestTablet("a"),
+			},
+
+			[]string{"a"},
+		},
+		{
+			"one target other cell",
+			[]*discovery.TabletHealth{
+				createTestTablet("a"),
+			},
+
+			[]string{"b", "c", "d"},
+		},
 	}
 
 	target := &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA}


### PR DESCRIPTION
## Description
Rework the tabletbalancer interface to avoid an unnecessary sort.

There's actually no need in the tabletgateway to ever sort the full list of potential tablet candidates, because each query attempt only goes to a single tablet, and then if that fails, the withRetry loop records which tablet failed and then re-enters the loop to try again.

Therefore, refactor the balancer to replace ShuffleTablets with a simple Pick interface that just returns the best tablet to route to.

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->


<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
