### PR TITLE
`slack-15.0`: fix crash in `vtbench`

### DIFF
--- a/go/cmd/vtbench/vtbench.go
+++ b/go/cmd/vtbench/vtbench.go
@@ -103,10 +103,7 @@ func initFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&sql, "sql", sql, "SQL statement to execute")
 	fs.IntVar(&threads, "threads", threads, "Number of parallel threads to run")
 	fs.IntVar(&count, "count", count, "Number of queries per thread")
-
 	grpccommon.RegisterFlags(fs)
-	log.RegisterFlags(fs)
-	logutil.RegisterFlags(fs)
 	acl.RegisterFlags(fs)
 	servenv.RegisterMySQLServerFlags(fs)
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR fixes a crash in v15's `vtbench`, reproduction:
```bash
tvaillancourt@tvailla-ltmxctu vitess % git checkout slack-15.0
Switched to branch 'slack-15.0'
Your branch is up to date with 'origin/slack-15.0'.
tvaillancourt@tvailla-ltmxctu vitess % make build
Thu Jul 11 18:07:08 CEST 2024: Building source tree
tvaillancourt@tvailla-ltmxctu vitess % ./bin/vtbench                                             
vtbench flag redefined: log_rotate_max_size
panic: vtbench flag redefined: log_rotate_max_size

goroutine 1 [running]:
github.com/spf13/pflag.(*FlagSet).AddFlag(0xc00012c000, 0xc0001317c0)
	github.com/spf13/pflag@v1.0.5/flag.go:848 +0x5fc
github.com/spf13/pflag.(*FlagSet).VarPF(0xc00012c000, {0x604d378, 0x6611ab8}, {0x5a8f4e2, 0x13}, {0x0, 0x0}, {0x5ab2c9f, 0x36})
	github.com/spf13/pflag@v1.0.5/flag.go:831 +0x105
github.com/spf13/pflag.(*FlagSet).VarP(...)
	github.com/spf13/pflag@v1.0.5/flag.go:837
github.com/spf13/pflag.(*FlagSet).Uint64Var(...)
	github.com/spf13/pflag@v1.0.5/uint64.go:45
vitess.io/vitess/go/vt/log.RegisterFlags(0xc00012c000?)
	vitess.io/vitess/go/vt/log/log.go:81 +0x45
main.initFlags(0xc00012c000)
	vitess.io/vitess/go/cmd/vtbench/vtbench.go:108 +0x265
main.main.func1(0xc00012c000)
	vitess.io/vitess/go/cmd/vtbench/vtbench.go:119 +0x87
vitess.io/vitess/go/vt/servenv.GetFlagSetFor({0x5a81df2, 0x7})
	vitess.io/vitess/go/vt/servenv/servenv.go:347 +0xa6
vitess.io/vitess/go/vt/servenv.ParseFlags({0x5a81df2, 0x7})
	vitess.io/vitess/go/vt/servenv/servenv.go:316 +0x2c
main.main()
	vitess.io/vitess/go/cmd/vtbench/vtbench.go:123 +0x57
```

With the fix ✅:
```bash
tvaillancourt@tvailla-ltmxctu vitess % ./bin/vtbench                            
F0711 18:09:30.063976    6027 vtbench.go:149] vtbench requires either host/port or unix_socket
```

This is a one-time patch that is not needed in our next release

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
