### PR TITLE
Allow setting grpc send and recv message sizes independently

### DIFF
--- a/go/flags/endtoend/vtbackup.txt
+++ b/go/flags/endtoend/vtbackup.txt
@@ -79,6 +79,8 @@ Usage of vtbackup:
       --grpc_keepalive_time duration                    After a duration of this time, if the client doesn't see any activity, it pings the server to see if the transport is still alive. (default 10s)
       --grpc_keepalive_timeout duration                 After having pinged for keepalive check, the client waits for a duration of Timeout and if no activity is seen even after that the connection is closed. (default 10s)
       --grpc_max_message_size int                       Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
+      --grpc_max_message_recv_size int                  Maximum allowed RPC message size when receiving. If 0, defaults to grpc_max_message_size.
+      --grpc_max_message_send_size int                  Maximum allowed RPC message size when sending. If 0, defaults to grpc_max_message_size.
       --grpc_prometheus                                 Enable gRPC monitoring with Prometheus.
   -h, --help                                            display usage and exit
       --init_db_name_override string                    (init parameter) override the name of the db used by vttablet

--- a/go/flags/endtoend/vtbackup.txt
+++ b/go/flags/endtoend/vtbackup.txt
@@ -78,9 +78,9 @@ Usage of vtbackup:
       --grpc_initial_window_size int                    gRPC initial window size
       --grpc_keepalive_time duration                    After a duration of this time, if the client doesn't see any activity, it pings the server to see if the transport is still alive. (default 10s)
       --grpc_keepalive_timeout duration                 After having pinged for keepalive check, the client waits for a duration of Timeout and if no activity is seen even after that the connection is closed. (default 10s)
-      --grpc_max_message_size int                       Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
       --grpc_max_message_recv_size int                  Maximum allowed RPC message size when receiving. If 0, defaults to grpc_max_message_size.
       --grpc_max_message_send_size int                  Maximum allowed RPC message size when sending. If 0, defaults to grpc_max_message_size.
+      --grpc_max_message_size int                       Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
       --grpc_prometheus                                 Enable gRPC monitoring with Prometheus.
   -h, --help                                            display usage and exit
       --init_db_name_override string                    (init parameter) override the name of the db used by vttablet

--- a/go/flags/endtoend/vtctlclient.txt
+++ b/go/flags/endtoend/vtctlclient.txt
@@ -11,6 +11,8 @@ Usage of vtctlclient:
       --grpc_keepalive_time duration           After a duration of this time, if the client doesn't see any activity, it pings the server to see if the transport is still alive. (default 10s)
       --grpc_keepalive_timeout duration        After having pinged for keepalive check, the client waits for a duration of Timeout and if no activity is seen even after that the connection is closed. (default 10s)
       --grpc_max_message_size int              Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
+      --grpc_max_message_recv_size int         Maximum allowed RPC message size when receiving. If 0, defaults to grpc_max_message_size.
+      --grpc_max_message_send_size int         Maximum allowed RPC message size when sending. If 0, defaults to grpc_max_message_size.
       --grpc_prometheus                        Enable gRPC monitoring with Prometheus.
   -h, --help                                   display usage and exit
       --jaeger-agent-host string               host and port to send spans to. if empty, no tracing will be done

--- a/go/flags/endtoend/vtctlclient.txt
+++ b/go/flags/endtoend/vtctlclient.txt
@@ -10,9 +10,9 @@ Usage of vtctlclient:
       --grpc_initial_window_size int           gRPC initial window size
       --grpc_keepalive_time duration           After a duration of this time, if the client doesn't see any activity, it pings the server to see if the transport is still alive. (default 10s)
       --grpc_keepalive_timeout duration        After having pinged for keepalive check, the client waits for a duration of Timeout and if no activity is seen even after that the connection is closed. (default 10s)
-      --grpc_max_message_size int              Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
       --grpc_max_message_recv_size int         Maximum allowed RPC message size when receiving. If 0, defaults to grpc_max_message_size.
       --grpc_max_message_send_size int         Maximum allowed RPC message size when sending. If 0, defaults to grpc_max_message_size.
+      --grpc_max_message_size int              Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
       --grpc_prometheus                        Enable gRPC monitoring with Prometheus.
   -h, --help                                   display usage and exit
       --jaeger-agent-host string               host and port to send spans to. if empty, no tracing will be done

--- a/go/flags/endtoend/vtctld.txt
+++ b/go/flags/endtoend/vtctld.txt
@@ -48,6 +48,8 @@ Usage of vtctld:
       --grpc_max_connection_age duration                                 Maximum age of a client connection before GoAway is sent. (default 2562047h47m16.854775807s)
       --grpc_max_connection_age_grace duration                           Additional grace period after grpc_max_connection_age, after which connections are forcibly closed. (default 2562047h47m16.854775807s)
       --grpc_max_message_size int                                        Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
+      --grpc_max_message_recv_size int                                   Maximum allowed RPC message size when receiving. If 0, defaults to grpc_max_message_size.
+      --grpc_max_message_send_size int                                   Maximum allowed RPC message size when sending. If 0, defaults to grpc_max_message_size.
       --grpc_port int                                                    Port to listen on for gRPC calls. If zero, do not listen.
       --grpc_prometheus                                                  Enable gRPC monitoring with Prometheus.
       --grpc_server_ca string                                            path to server CA in PEM format, which will be combine with server cert, return full certificate chain to clients

--- a/go/flags/endtoend/vtctld.txt
+++ b/go/flags/endtoend/vtctld.txt
@@ -47,9 +47,9 @@ Usage of vtctld:
       --grpc_key string                                                  server private key to use for gRPC connections, requires grpc_cert, enables TLS
       --grpc_max_connection_age duration                                 Maximum age of a client connection before GoAway is sent. (default 2562047h47m16.854775807s)
       --grpc_max_connection_age_grace duration                           Additional grace period after grpc_max_connection_age, after which connections are forcibly closed. (default 2562047h47m16.854775807s)
-      --grpc_max_message_size int                                        Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
       --grpc_max_message_recv_size int                                   Maximum allowed RPC message size when receiving. If 0, defaults to grpc_max_message_size.
       --grpc_max_message_send_size int                                   Maximum allowed RPC message size when sending. If 0, defaults to grpc_max_message_size.
+      --grpc_max_message_size int                                        Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
       --grpc_port int                                                    Port to listen on for gRPC calls. If zero, do not listen.
       --grpc_prometheus                                                  Enable gRPC monitoring with Prometheus.
       --grpc_server_ca string                                            path to server CA in PEM format, which will be combine with server cert, return full certificate chain to clients

--- a/go/flags/endtoend/vtctldclient.txt
+++ b/go/flags/endtoend/vtctldclient.txt
@@ -70,7 +70,7 @@ Available Commands:
   SetShardTabletControl       Sets the TabletControl record for a shard and tablet type. Only use this for an emergency fix or after a finished MoveTables.
   SetWritable                 Sets the specified tablet as writable or read-only.
   ShardReplicationFix         Walks through a ShardReplication object and fixes the first error encountered.
-  ShardReplicationPositions   
+  ShardReplicationPositions
   SleepTablet                 Blocks the action queue on the specified tablet for the specified amount of time. This is typically used for testing.
   SourceShardAdd              Adds the SourceShard record with the provided index for emergencies only. It does not call RefreshState for the shard primary.
   SourceShardDelete           Deletes the SourceShard record with the provided index. This should only be used for emergency cleanup. It does not call RefreshState for the shard primary.
@@ -99,6 +99,8 @@ Flags:
       --grpc_keepalive_time duration           After a duration of this time, if the client doesn't see any activity, it pings the server to see if the transport is still alive. (default 10s)
       --grpc_keepalive_timeout duration        After having pinged for keepalive check, the client waits for a duration of Timeout and if no activity is seen even after that the connection is closed. (default 10s)
       --grpc_max_message_size int              Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
+      --grpc_max_message_recv_size int         Maximum allowed RPC message size when receiving. If 0, defaults to grpc_max_message_size.
+      --grpc_max_message_send_size int         Maximum allowed RPC message size when sending. If 0, defaults to grpc_max_message_size.
       --grpc_prometheus                        Enable gRPC monitoring with Prometheus.
   -h, --help                                   help for vtctldclient
       --keep_logs duration                     keep logs for this long (using ctime) (zero to keep forever)

--- a/go/flags/endtoend/vtctldclient.txt
+++ b/go/flags/endtoend/vtctldclient.txt
@@ -70,7 +70,7 @@ Available Commands:
   SetShardTabletControl       Sets the TabletControl record for a shard and tablet type. Only use this for an emergency fix or after a finished MoveTables.
   SetWritable                 Sets the specified tablet as writable or read-only.
   ShardReplicationFix         Walks through a ShardReplication object and fixes the first error encountered.
-  ShardReplicationPositions
+  ShardReplicationPositions   
   SleepTablet                 Blocks the action queue on the specified tablet for the specified amount of time. This is typically used for testing.
   SourceShardAdd              Adds the SourceShard record with the provided index for emergencies only. It does not call RefreshState for the shard primary.
   SourceShardDelete           Deletes the SourceShard record with the provided index. This should only be used for emergency cleanup. It does not call RefreshState for the shard primary.
@@ -98,9 +98,9 @@ Flags:
       --grpc_initial_window_size int           gRPC initial window size
       --grpc_keepalive_time duration           After a duration of this time, if the client doesn't see any activity, it pings the server to see if the transport is still alive. (default 10s)
       --grpc_keepalive_timeout duration        After having pinged for keepalive check, the client waits for a duration of Timeout and if no activity is seen even after that the connection is closed. (default 10s)
-      --grpc_max_message_size int              Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
       --grpc_max_message_recv_size int         Maximum allowed RPC message size when receiving. If 0, defaults to grpc_max_message_size.
       --grpc_max_message_send_size int         Maximum allowed RPC message size when sending. If 0, defaults to grpc_max_message_size.
+      --grpc_max_message_size int              Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
       --grpc_prometheus                        Enable gRPC monitoring with Prometheus.
   -h, --help                                   help for vtctldclient
       --keep_logs duration                     keep logs for this long (using ctime) (zero to keep forever)

--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -55,6 +55,8 @@ Usage of vtgate:
       --grpc_max_connection_age duration                                 Maximum age of a client connection before GoAway is sent. (default 2562047h47m16.854775807s)
       --grpc_max_connection_age_grace duration                           Additional grace period after grpc_max_connection_age, after which connections are forcibly closed. (default 2562047h47m16.854775807s)
       --grpc_max_message_size int                                        Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
+      --grpc_max_message_recv_size int                                   Maximum allowed RPC message size when receiving. If 0, defaults to grpc_max_message_size.
+      --grpc_max_message_send_size int                                   Maximum allowed RPC message size when sending. If 0, defaults to grpc_max_message_size.
       --grpc_port int                                                    Port to listen on for gRPC calls. If zero, do not listen.
       --grpc_prometheus                                                  Enable gRPC monitoring with Prometheus.
       --grpc_server_ca string                                            path to server CA in PEM format, which will be combine with server cert, return full certificate chain to clients

--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -54,9 +54,9 @@ Usage of vtgate:
       --grpc_key string                                                  server private key to use for gRPC connections, requires grpc_cert, enables TLS
       --grpc_max_connection_age duration                                 Maximum age of a client connection before GoAway is sent. (default 2562047h47m16.854775807s)
       --grpc_max_connection_age_grace duration                           Additional grace period after grpc_max_connection_age, after which connections are forcibly closed. (default 2562047h47m16.854775807s)
-      --grpc_max_message_size int                                        Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
       --grpc_max_message_recv_size int                                   Maximum allowed RPC message size when receiving. If 0, defaults to grpc_max_message_size.
       --grpc_max_message_send_size int                                   Maximum allowed RPC message size when sending. If 0, defaults to grpc_max_message_size.
+      --grpc_max_message_size int                                        Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
       --grpc_port int                                                    Port to listen on for gRPC calls. If zero, do not listen.
       --grpc_prometheus                                                  Enable gRPC monitoring with Prometheus.
       --grpc_server_ca string                                            path to server CA in PEM format, which will be combine with server cert, return full certificate chain to clients

--- a/go/flags/endtoend/vtgr.txt
+++ b/go/flags/endtoend/vtgr.txt
@@ -17,9 +17,9 @@ Usage of vtgr:
       --grpc_initial_window_size int               gRPC initial window size
       --grpc_keepalive_time duration               After a duration of this time, if the client doesn't see any activity, it pings the server to see if the transport is still alive. (default 10s)
       --grpc_keepalive_timeout duration            After having pinged for keepalive check, the client waits for a duration of Timeout and if no activity is seen even after that the connection is closed. (default 10s)
-      --grpc_max_message_size int                  Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
       --grpc_max_message_recv_size int             Maximum allowed RPC message size when receiving. If 0, defaults to grpc_max_message_size.
       --grpc_max_message_send_size int             Maximum allowed RPC message size when sending. If 0, defaults to grpc_max_message_size.
+      --grpc_max_message_size int                  Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
       --grpc_prometheus                            Enable gRPC monitoring with Prometheus.
   -h, --help                                       display usage and exit
       --keep_logs duration                         keep logs for this long (using ctime) (zero to keep forever)

--- a/go/flags/endtoend/vtgr.txt
+++ b/go/flags/endtoend/vtgr.txt
@@ -18,6 +18,8 @@ Usage of vtgr:
       --grpc_keepalive_time duration               After a duration of this time, if the client doesn't see any activity, it pings the server to see if the transport is still alive. (default 10s)
       --grpc_keepalive_timeout duration            After having pinged for keepalive check, the client waits for a duration of Timeout and if no activity is seen even after that the connection is closed. (default 10s)
       --grpc_max_message_size int                  Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
+      --grpc_max_message_recv_size int             Maximum allowed RPC message size when receiving. If 0, defaults to grpc_max_message_size.
+      --grpc_max_message_send_size int             Maximum allowed RPC message size when sending. If 0, defaults to grpc_max_message_size.
       --grpc_prometheus                            Enable gRPC monitoring with Prometheus.
   -h, --help                                       display usage and exit
       --keep_logs duration                         keep logs for this long (using ctime) (zero to keep forever)

--- a/go/flags/endtoend/vtorc.txt
+++ b/go/flags/endtoend/vtorc.txt
@@ -17,6 +17,8 @@ Usage of vtorc:
       --grpc_keepalive_time duration                 After a duration of this time, if the client doesn't see any activity, it pings the server to see if the transport is still alive. (default 10s)
       --grpc_keepalive_timeout duration              After having pinged for keepalive check, the client waits for a duration of Timeout and if no activity is seen even after that the connection is closed. (default 10s)
       --grpc_max_message_size int                    Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
+      --grpc_max_message_recv_size int               Maximum allowed RPC message size when receiving. If 0, defaults to grpc_max_message_size.
+      --grpc_max_message_send_size int               Maximum allowed RPC message size when sending. If 0, defaults to grpc_max_message_size.
       --grpc_prometheus                              Enable gRPC monitoring with Prometheus.
   -h, --help                                         display usage and exit
       --instance-poll-time duration                  Timer duration on which VTOrc refreshes MySQL information (default 5s)

--- a/go/flags/endtoend/vtorc.txt
+++ b/go/flags/endtoend/vtorc.txt
@@ -16,9 +16,9 @@ Usage of vtorc:
       --grpc_initial_window_size int                 gRPC initial window size
       --grpc_keepalive_time duration                 After a duration of this time, if the client doesn't see any activity, it pings the server to see if the transport is still alive. (default 10s)
       --grpc_keepalive_timeout duration              After having pinged for keepalive check, the client waits for a duration of Timeout and if no activity is seen even after that the connection is closed. (default 10s)
-      --grpc_max_message_size int                    Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
       --grpc_max_message_recv_size int               Maximum allowed RPC message size when receiving. If 0, defaults to grpc_max_message_size.
       --grpc_max_message_send_size int               Maximum allowed RPC message size when sending. If 0, defaults to grpc_max_message_size.
+      --grpc_max_message_size int                    Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
       --grpc_prometheus                              Enable gRPC monitoring with Prometheus.
   -h, --help                                         display usage and exit
       --instance-poll-time duration                  Timer duration on which VTOrc refreshes MySQL information (default 5s)

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -135,6 +135,8 @@ Usage of vttablet:
       --grpc_max_connection_age duration                                 Maximum age of a client connection before GoAway is sent. (default 2562047h47m16.854775807s)
       --grpc_max_connection_age_grace duration                           Additional grace period after grpc_max_connection_age, after which connections are forcibly closed. (default 2562047h47m16.854775807s)
       --grpc_max_message_size int                                        Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
+      --grpc_max_message_recv_size int                                   Maximum allowed RPC message size when receiving. If 0, defaults to grpc_max_message_size.
+      --grpc_max_message_send_size int                                   Maximum allowed RPC message size when sending. If 0, defaults to grpc_max_message_size.
       --grpc_port int                                                    Port to listen on for gRPC calls. If zero, do not listen.
       --grpc_prometheus                                                  Enable gRPC monitoring with Prometheus.
       --grpc_server_ca string                                            path to server CA in PEM format, which will be combine with server cert, return full certificate chain to clients

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -134,9 +134,9 @@ Usage of vttablet:
       --grpc_key string                                                  server private key to use for gRPC connections, requires grpc_cert, enables TLS
       --grpc_max_connection_age duration                                 Maximum age of a client connection before GoAway is sent. (default 2562047h47m16.854775807s)
       --grpc_max_connection_age_grace duration                           Additional grace period after grpc_max_connection_age, after which connections are forcibly closed. (default 2562047h47m16.854775807s)
-      --grpc_max_message_size int                                        Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
       --grpc_max_message_recv_size int                                   Maximum allowed RPC message size when receiving. If 0, defaults to grpc_max_message_size.
       --grpc_max_message_send_size int                                   Maximum allowed RPC message size when sending. If 0, defaults to grpc_max_message_size.
+      --grpc_max_message_size int                                        Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
       --grpc_port int                                                    Port to listen on for gRPC calls. If zero, do not listen.
       --grpc_prometheus                                                  Enable gRPC monitoring with Prometheus.
       --grpc_server_ca string                                            path to server CA in PEM format, which will be combine with server cert, return full certificate chain to clients

--- a/go/flags/endtoend/vttestserver.txt
+++ b/go/flags/endtoend/vttestserver.txt
@@ -48,6 +48,8 @@ Usage of vttestserver:
       --grpc_max_connection_age duration                                 Maximum age of a client connection before GoAway is sent. (default 2562047h47m16.854775807s)
       --grpc_max_connection_age_grace duration                           Additional grace period after grpc_max_connection_age, after which connections are forcibly closed. (default 2562047h47m16.854775807s)
       --grpc_max_message_size int                                        Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
+      --grpc_max_message_recv_size int                                   Maximum allowed RPC message size when receiving. If 0, defaults to grpc_max_message_size.
+      --grpc_max_message_send_size int                                   Maximum allowed RPC message size when sending. If 0, defaults to grpc_max_message_size.
       --grpc_port int                                                    Port to listen on for gRPC calls. If zero, do not listen.
       --grpc_prometheus                                                  Enable gRPC monitoring with Prometheus.
       --grpc_server_ca string                                            path to server CA in PEM format, which will be combine with server cert, return full certificate chain to clients

--- a/go/flags/endtoend/vttestserver.txt
+++ b/go/flags/endtoend/vttestserver.txt
@@ -47,9 +47,9 @@ Usage of vttestserver:
       --grpc_key string                                                  server private key to use for gRPC connections, requires grpc_cert, enables TLS
       --grpc_max_connection_age duration                                 Maximum age of a client connection before GoAway is sent. (default 2562047h47m16.854775807s)
       --grpc_max_connection_age_grace duration                           Additional grace period after grpc_max_connection_age, after which connections are forcibly closed. (default 2562047h47m16.854775807s)
-      --grpc_max_message_size int                                        Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
       --grpc_max_message_recv_size int                                   Maximum allowed RPC message size when receiving. If 0, defaults to grpc_max_message_size.
       --grpc_max_message_send_size int                                   Maximum allowed RPC message size when sending. If 0, defaults to grpc_max_message_size.
+      --grpc_max_message_size int                                        Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
       --grpc_port int                                                    Port to listen on for gRPC calls. If zero, do not listen.
       --grpc_prometheus                                                  Enable gRPC monitoring with Prometheus.
       --grpc_server_ca string                                            path to server CA in PEM format, which will be combine with server cert, return full certificate chain to clients

--- a/go/vt/grpcclient/client.go
+++ b/go/vt/grpcclient/client.go
@@ -110,11 +110,12 @@ func Dial(target string, failFast FailFast, opts ...grpc.DialOption) (*grpc.Clie
 // what that should be.
 func DialContext(ctx context.Context, target string, failFast FailFast, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
 	grpccommon.EnableTracingOpt()
-	msgSize := grpccommon.MaxMessageSize()
+	maxSendSize := grpccommon.MaxMessageSendSize()
+	maxRecvSize := grpccommon.MaxMessageRecvSize()
 	newopts := []grpc.DialOption{
 		grpc.WithDefaultCallOptions(
-			grpc.MaxCallRecvMsgSize(msgSize),
-			grpc.MaxCallSendMsgSize(msgSize),
+			grpc.MaxCallRecvMsgSize(maxRecvSize),
+			grpc.MaxCallSendMsgSize(maxSendSize),
 			grpc.WaitForReady(bool(!failFast)),
 		),
 	}

--- a/go/vt/grpccommon/options.go
+++ b/go/vt/grpccommon/options.go
@@ -30,6 +30,8 @@ var (
 	// accept. Larger messages will be rejected.
 	// Note: We're using 16 MiB as default value because that's the default in MySQL
 	maxMessageSize = 16 * 1024 * 1024
+	maxMsgRecvSize = 0
+	maxMsgSendSize = 0
 	// enableTracing sets a flag to enable grpc client/server tracing.
 	enableTracing bool
 	// enablePrometheus sets a flag to enable grpc client/server grpc monitoring.
@@ -43,6 +45,8 @@ var (
 // command-line arguments.
 func RegisterFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&maxMessageSize, "grpc_max_message_size", maxMessageSize, "Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'.")
+	fs.IntVar(&maxMsgSendSize, "grpc_max_message_send_size", maxMsgSendSize, "")
+	fs.IntVar(&maxMsgRecvSize, "grpc_max_message_recv_size", maxMsgRecvSize, "")
 	fs.BoolVar(&enableTracing, "grpc_enable_tracing", enableTracing, "Enable gRPC tracing.")
 	fs.BoolVar(&enablePrometheus, "grpc_prometheus", enablePrometheus, "Enable gRPC monitoring with Prometheus.")
 }
@@ -68,6 +72,20 @@ func EnableGRPCPrometheus() bool {
 // MaxMessageSize returns the value of the --grpc_max_message_size flag.
 func MaxMessageSize() int {
 	return maxMessageSize
+}
+
+func MaxMessageRecvSize() int {
+	if maxMsgRecvSize > 0 {
+		return maxMsgRecvSize
+	}
+	return MaxMessageSize()
+}
+
+func MaxMessageSendSize() int {
+	if maxMsgSendSize > 0 {
+		return maxMsgSendSize
+	}
+	return MaxMessageSize()
 }
 
 func init() {

--- a/go/vt/grpccommon/options.go
+++ b/go/vt/grpccommon/options.go
@@ -30,6 +30,8 @@ var (
 	// accept. Larger messages will be rejected.
 	// Note: We're using 16 MiB as default value because that's the default in MySQL
 	maxMessageSize = 16 * 1024 * 1024
+	// These options override maxMessageSize if > 0, allowing us to control the max
+	// size sending independently from receiving.
 	maxMsgRecvSize = 0
 	maxMsgSendSize = 0
 	// enableTracing sets a flag to enable grpc client/server tracing.
@@ -45,8 +47,8 @@ var (
 // command-line arguments.
 func RegisterFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&maxMessageSize, "grpc_max_message_size", maxMessageSize, "Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'.")
-	fs.IntVar(&maxMsgSendSize, "grpc_max_message_send_size", maxMsgSendSize, "")
-	fs.IntVar(&maxMsgRecvSize, "grpc_max_message_recv_size", maxMsgRecvSize, "")
+	fs.IntVar(&maxMsgSendSize, "grpc_max_message_send_size", maxMsgSendSize, "Maximum allowed RPC message size when sending. If 0, defaults to grpc_max_message_size.")
+	fs.IntVar(&maxMsgRecvSize, "grpc_max_message_recv_size", maxMsgRecvSize, "Maximum allowed RPC message size when receiving. If 0, defaults to grpc_max_message_size.")
 	fs.BoolVar(&enableTracing, "grpc_enable_tracing", enableTracing, "Enable gRPC tracing.")
 	fs.BoolVar(&enablePrometheus, "grpc_prometheus", enablePrometheus, "Enable gRPC monitoring with Prometheus.")
 }

--- a/go/vt/servenv/grpc_server.go
+++ b/go/vt/servenv/grpc_server.go
@@ -207,10 +207,12 @@ func createGRPCServer() {
 	// grpc: received message length XXXXXXX exceeding the max size 4194304
 	// Note: For gRPC 1.0.0 it's sufficient to set the limit on the server only
 	// because it's not enforced on the client side.
-	msgSize := grpccommon.MaxMessageSize()
-	log.Infof("Setting grpc max message size to %d", msgSize)
-	opts = append(opts, grpc.MaxRecvMsgSize(msgSize))
-	opts = append(opts, grpc.MaxSendMsgSize(msgSize))
+
+	maxSendSize := grpccommon.MaxMessageSendSize()
+	maxRecvSize := grpccommon.MaxMessageRecvSize()
+	log.Infof("Setting grpc server max message sizes to %d (sending), %d (receiving)", maxSendSize, maxRecvSize)
+	opts = append(opts, grpc.MaxRecvMsgSize(maxRecvSize))
+	opts = append(opts, grpc.MaxSendMsgSize(maxSendSize))
 
 	if gRPCInitialConnWindowSize != 0 {
 		log.Infof("Setting grpc server initial conn window size to %d", int32(gRPCInitialConnWindowSize))


### PR DESCRIPTION
We would like to set the send and recv max message sizes independently on vtgates. This allows us to keep a small limit on the size of the messages received from tablets, while allowing vtgates to send a large aggregated response to clients.

Two new flags are added: `grpc_max_message_send_size` and `grpc_max_message_recv_size`. These are 0 by default, in which case the existing `grpc_max_message_size` flag is used with no change from the existing behaviour. If set to non-0, they override the setting for `grpc_max_message_size`.