### PR TITLE
backport: fixing issue with xtrabackup and long gtids (#16304)

### DIFF
--- a/go/vt/mysqlctl/xtrabackupengine_test.go
+++ b/go/vt/mysqlctl/xtrabackupengine_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"vitess.io/vitess/go/vt/logutil"
 )
 

--- a/go/vt/mysqlctl/xtrabackupengine_test.go
+++ b/go/vt/mysqlctl/xtrabackupengine_test.go
@@ -20,8 +20,12 @@ import (
 	"bytes"
 	"io"
 	"math/rand"
+
+	"os"
+	"path"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"vitess.io/vitess/go/vt/logutil"
 )
 
@@ -50,27 +54,48 @@ func TestFindReplicationPosition(t *testing.T) {
 		t.Errorf("findReplicationPosition() = %v; want %v", got, want)
 	}
 }
+func TestFindReplicationPositionFromXtrabackupInfo(t *testing.T) {
+	input := `tool_version = 8.0.35-30
+	binlog_pos = filename 'vt-0476396352-bin.000005', position '310088991', GTID of the last change '145e508e-ae54-11e9-8ce6-46824dd1815e:1-3,
+	1e51f8be-ae54-11e9-a7c6-4280a041109b:1-3,
+	47b59de1-b368-11e9-b48b-624401d35560:1-152981,
+	557def0a-b368-11e9-84ed-f6fffd91cc57:1-3,
+	599ef589-ae55-11e9-9688-ca1f44501925:1-14857169,
+	b9ce485d-b36b-11e9-9b17-2a6e0a6011f4:1-371262'
+	format = xbstream
+	`
+	want := "145e508e-ae54-11e9-8ce6-46824dd1815e:1-3,1e51f8be-ae54-11e9-a7c6-4280a041109b:1-3,47b59de1-b368-11e9-b48b-624401d35560:1-152981,557def0a-b368-11e9-84ed-f6fffd91cc57:1-3,599ef589-ae55-11e9-9688-ca1f44501925:1-14857169,b9ce485d-b36b-11e9-9b17-2a6e0a6011f4:1-371262"
 
-func TestFindReplicationPositionNoMatch(t *testing.T) {
+	tmp, err := os.MkdirTemp(t.TempDir(), "test")
+	assert.NoError(t, err)
+
+	f, err := os.Create(path.Join(tmp, xtrabackupInfoFile))
+	assert.NoError(t, err)
+	_, err = f.WriteString(input)
+	assert.NoError(t, err)
+	assert.NoError(t, f.Close())
+
+	pos, err := findReplicationPositionFromXtrabackupInfo(tmp, "MySQL56", logutil.NewConsoleLogger())
+	assert.NoError(t, err)
+	assert.Equal(t, want, pos.String())
+}
+
+func TestFindReplicationPositionNoMatchFromXtrabackupInfo(t *testing.T) {
 	// Make sure failure to find a match triggers an error.
 	input := `nothing`
 
-	_, err := findReplicationPosition(input, "MySQL56", logutil.NewConsoleLogger())
-	if err == nil {
-		t.Fatalf("expected error from findReplicationPosition but got nil")
-	}
+	_, err := findReplicationPositionFromXtrabackupInfo(input, "MySQL56", logutil.NewConsoleLogger())
+	assert.Error(t, err)
 }
 
-func TestFindReplicationPositionEmptyMatch(t *testing.T) {
+func TestFindReplicationPositionEmptyMatchFromXtrabackupInfo(t *testing.T) {
 	// Make sure failure to find a match triggers an error.
 	input := `GTID of the last change '
 	
 	'`
 
-	_, err := findReplicationPosition(input, "MySQL56", logutil.NewConsoleLogger())
-	if err == nil {
-		t.Fatalf("expected error from findReplicationPosition but got nil")
-	}
+	_, err := findReplicationPositionFromXtrabackupInfo(input, "MySQL56", logutil.NewConsoleLogger())
+	assert.Error(t, err)
 }
 
 func TestStripeRoundTrip(t *testing.T) {

--- a/go/vt/mysqlctl/xtrabackupengine_test.go
+++ b/go/vt/mysqlctl/xtrabackupengine_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"io"
 	"math/rand"
-
 	"os"
 	"path"
 	"testing"
@@ -54,6 +53,7 @@ func TestFindReplicationPosition(t *testing.T) {
 		t.Errorf("findReplicationPosition() = %v; want %v", got, want)
 	}
 }
+
 func TestFindReplicationPositionFromXtrabackupInfo(t *testing.T) {
 	input := `tool_version = 8.0.35-30
 	binlog_pos = filename 'vt-0476396352-bin.000005', position '310088991', GTID of the last change '145e508e-ae54-11e9-8ce6-46824dd1815e:1-3,


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

backport upstream https://github.com/vitessio/vitess/pull/16304

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
