### PR TITLE
[DRAFT] respect vtops downtime during recoveries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module vitess.io/vitess
 
-go 1.22.5
+go 1.22.7
 
 require (
 	cloud.google.com/go/storage v1.39.0
@@ -102,7 +102,7 @@ require (
 	github.com/kr/text v0.2.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
-	github.com/slackhq/vitess-addons v0.19.1
+	github.com/slackhq/vitess-addons v0.19.3-downtime2
 	github.com/slok/noglog v0.2.0
 	github.com/spf13/afero v1.11.0
 	github.com/spf13/jwalterweatherman v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -450,8 +450,8 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sjmudd/stopwatch v0.1.1 h1:x45OvxFB5OtCkjvYtzRF5fWB857Jzjjk84Oyd5C5ebw=
 github.com/sjmudd/stopwatch v0.1.1/go.mod h1:BLw0oIQJ1YLXBO/q9ufK/SgnKBVIkC2qrm6uy78Zw6U=
-github.com/slackhq/vitess-addons v0.19.1 h1:k8f8pAJ2zqtetN+dnehAs7DFcZnI9IQRSL18ZMwNRCw=
-github.com/slackhq/vitess-addons v0.19.1/go.mod h1:ZMzBBtadSA1MEuNIfZerztxLMhRFO+tmBZxv5HuV4lE=
+github.com/slackhq/vitess-addons v0.19.3-downtime2 h1:3vUHK8QzcwffAb/QtbP5WHRVQoowGC25Y18Vsu/PSpk=
+github.com/slackhq/vitess-addons v0.19.3-downtime2/go.mod h1:CP+xpAwBY1IR/+MQzLWyCsCfKMUhfnbHNSvm9KMRlPg=
 github.com/slok/noglog v0.2.0 h1:1czu4l2EoJ8L92UwdSXXa1Y+c5TIjFAFm2P+mjej95E=
 github.com/slok/noglog v0.2.0/go.mod h1:TfKxwpEZPT+UA83bQ6RME146k0MM4e8mwHLf6bhcGDI=
 github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=

--- a/go/vt/vtorc/inst/analysis.go
+++ b/go/vt/vtorc/inst/analysis.go
@@ -150,6 +150,7 @@ type ReplicationAnalysis struct {
 	MaxReplicaGTIDMode                        string
 	MaxReplicaGTIDErrant                      string
 	IsReadOnly                                bool
+	IsDowntimed                               bool
 }
 
 func (replicationAnalysis *ReplicationAnalysis) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
This allows vtorc to fetch whether a particular host has been downtimed within our tooling by calling vtops. If yes, it will skip recoveries. This is especially so that new shards coming up as a result of splits aren't interfered by vtorc. Context here:
https://slack-pde.slack.com/archives/C05NMQ73DH7/p1727290878318729

Depends on:
https://slack-github.com/slack/vtops/pull/1518
https://github.com/slackhq/vitess-addons/pull/6