### PR TITLE
`slack-15.0`: Add sql text counts stats to `vtcombo`,`vtgate`+`vttablet` (vitessio#15897)

### DIFF
--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -307,7 +307,7 @@ func Init(
 			[]string{"Operation", "Keyspace", "DbType"}),
 		queryTextCharsProcessed: stats.NewCountersWithMultiLabels(
 			"VtgateQueryTextCharactersProcessed",
-			"Vtgate API query SQL text counts",
+			"Query text characters processed through the VTGate API",
 			[]string{"Operation", "Keyspace", "DbType"}),
 
 		logExecute:       logutil.NewThrottledLogger("Execute", 5*time.Second),

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -306,7 +306,7 @@ func Init(
 			"Rows affected by a write (DML) operation through the VTgate API",
 			[]string{"Operation", "Keyspace", "DbType"}),
 		queryTextCharsProcessed: stats.NewCountersWithMultiLabels(
-			"VtgateSQLTextCounts",
+			"VtgateQueryTextCharactersProcessed",
 			"Vtgate API query SQL text counts",
 			[]string{"Operation", "Keyspace", "DbType"}),
 


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR re-backport the early backport of upstream PR #15897

It seems the rename of this metric was not backported down after the early backport. [Correct name on `main` here](https://github.com/vitessio/vitess/blob/main/go/vt/vtgate/vtgate.go#L214)

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
