### PR TITLE
`slack-19.0`: skip `vexplain`/`schematracker` tests in downgrade e2e tests

### DIFF
--- a/go/test/endtoend/vtgate/queries/vexplain/vexplain_test.go
+++ b/go/test/endtoend/vtgate/queries/vexplain/vexplain_test.go
@@ -53,6 +53,11 @@ func start(t *testing.T) (*mysql.Conn, func()) {
 }
 
 func TestVtGateVExplain(t *testing.T) {
+	if !utils.BinaryIsAtLeastAtVersion(16, "vtgate") {
+		t.Log("test requires version >= 16, skipping")
+		return
+	}
+
 	conn, closer := start(t)
 	defer closer()
 
@@ -136,6 +141,11 @@ func TestVtGateVExplain(t *testing.T) {
 }
 
 func TestVExplainPlan(t *testing.T) {
+	if !utils.BinaryIsAtLeastAtVersion(16, "vtgate") {
+		t.Log("test requires version >= 16, skipping")
+		return
+	}
+
 	conn, closer := start(t)
 	defer closer()
 
@@ -145,6 +155,11 @@ func TestVExplainPlan(t *testing.T) {
 }
 
 func TestVExplainAll(t *testing.T) {
+	if !utils.BinaryIsAtLeastAtVersion(16, "vtgate") {
+		t.Log("test requires version >= 16, skipping")
+		return
+	}
+
 	conn, closer := start(t)
 	defer closer()
 

--- a/go/test/endtoend/vtgate/schematracker/sharded/st_sharded_test.go
+++ b/go/test/endtoend/vtgate/schematracker/sharded/st_sharded_test.go
@@ -64,6 +64,12 @@ func TestMain(m *testing.M) {
 			return 1
 		}
 
+		// This test fails on slack-15.0, but we don't use schema tracking. Skip it.
+		if vtgateVer < 16 || vttabletVer < 16 {
+			fmt.Println("test requires version >= 16, skipping")
+			return 0
+		}
+
 		// For upgrade/downgrade tests.
 		if vtgateVer < 17 || vttabletVer < 17 {
 			// Then only the default sidecarDBName is supported.

--- a/go/test/endtoend/vtgate/schematracker/unsharded/st_unsharded_test.go
+++ b/go/test/endtoend/vtgate/schematracker/unsharded/st_unsharded_test.go
@@ -65,6 +65,12 @@ func TestMain(m *testing.M) {
 			return 1
 		}
 
+		// This test fails on slack-15.0, but we don't use schema tracking. Skip it.
+		if vtgateVer < 16 || vttabletVer < 16 {
+			fmt.Println("test requires version >= 16, skipping")
+			return 0
+		}
+
 		// For upgrade/downgrade tests.
 		if vtgateVer < 17 || vttabletVer < 17 {
 			// Then only the default sidecarDBName is supported.


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR ensures `vexplain` and known-failing-`schematracker` unit tests run on version >= v16 only. Hiding the failing `schematracker` tests is safe to do as we don't use the feature yet

The downgrade tests _(on `slack-15.0`)_ for `vexplain` currently fail because that feature doesn't exist yet

Downgrade CI _(with `slack-15.0`)_ after this PR:
<img width="500" alt="Screenshot 2024-10-13 at 03 27 05" src="https://github.com/user-attachments/assets/40d51adc-9791-4625-82bb-5b4c2299a300">

And still working on non-downgrade tests:
<img width="550" alt="Screenshot 2024-10-13 at 03 33 50" src="https://github.com/user-attachments/assets/bf453430-3096-46e2-8dee-a61a46bc5a30">

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
