### PR TITLE
backport 13525: Fix `upgrade-downgrade` test setup and fix the `init_…

### DIFF
--- a/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
@@ -188,8 +188,8 @@ jobs:
         source build.env
 
         rm -f $PWD/bin/vtbackup $PWD/bin/vttablet
-        cp /tmp/vitess-build-current/bin/vtbackup $PWD/bin/vtbackup
-        cp /tmp/vitess-build-other/bin/vttablet $PWD/bin/vttablet
+        cp /tmp/vitess-build-other/bin/vtbackup $PWD/bin/vtbackup
+        cp /tmp/vitess-build-current/bin/vttablet $PWD/bin/vttablet
         vtbackup --version
         vttablet --version
 

--- a/go/test/endtoend/backup/vtbackup/main_test.go
+++ b/go/test/endtoend/backup/vtbackup/main_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"vitess.io/vitess/go/test/endtoend/cluster"
+	"vitess.io/vitess/go/test/endtoend/utils"
 	"vitess.io/vitess/go/vt/log"
 )
 
@@ -89,8 +90,12 @@ func TestMain(m *testing.M) {
 		dbCredentialFile = cluster.WriteDbCredentialToTmp(localCluster.TmpDirectory)
 		initDb, _ := os.ReadFile(path.Join(os.Getenv("VTROOT"), "/config/init_db.sql"))
 		sql := string(initDb)
+		// The original init_db.sql does not have any passwords. Here we update the init file with passwords
+		sql, err = utils.GetInitDBSQL(sql, cluster.GetPasswordUpdateSQL(localCluster), "")
+		if err != nil {
+			return 1, err
+		}
 		newInitDBFile = path.Join(localCluster.TmpDirectory, "init_db_with_passwords.sql")
-		sql = sql + cluster.GetPasswordUpdateSQL(localCluster)
 		err = os.WriteFile(newInitDBFile, []byte(sql), 0666)
 		if err != nil {
 			return 1, err

--- a/go/test/endtoend/cluster/mysqlctl_process.go
+++ b/go/test/endtoend/cluster/mysqlctl_process.go
@@ -30,6 +30,7 @@ import (
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/mysqlctl"
 	"vitess.io/vitess/go/vt/tlstest"
 )
 
@@ -211,17 +212,38 @@ func (mysqlctl *MysqlctlProcess) CleanupFiles(tabletUID int) {
 // MysqlCtlProcessInstanceOptionalInit returns a Mysqlctl handle for mysqlctl process
 // configured with the given Config.
 func MysqlCtlProcessInstanceOptionalInit(tabletUID int, mySQLPort int, tmpDirectory string, initMySQL bool) *MysqlctlProcess {
+	initFile, err := getInitDBFileUsed()
+	if err != nil {
+		log.Errorf("Couldn't find init db file - %v", err)
+	}
 	mysqlctl := &MysqlctlProcess{
 		Name:         "mysqlctl",
 		Binary:       "mysqlctl",
 		LogDirectory: tmpDirectory,
-		InitDBFile:   path.Join(os.Getenv("VTROOT"), "/config/init_db.sql"),
+		InitDBFile:   initFile,
 	}
 	mysqlctl.MySQLPort = mySQLPort
 	mysqlctl.TabletUID = tabletUID
 	mysqlctl.InitMysql = initMySQL
 	mysqlctl.SecureTransport = false
 	return mysqlctl
+}
+
+func getInitDBFileUsed() (string, error) {
+	versionStr, err := mysqlctl.GetVersionString()
+	if err != nil {
+		return "", err
+	}
+	flavor, _, err := mysqlctl.ParseVersionString(versionStr)
+	if err != nil {
+		return "", err
+	}
+	if flavor == mysqlctl.FlavorMySQL || flavor == mysqlctl.FlavorPercona {
+		return path.Join(os.Getenv("VTROOT"), "/config/init_db.sql"), nil
+	}
+	// Non-MySQL instances for example MariaDB, will use init_testserver_db.sql which does not contain super_read_only global variable.
+	// Even though MariaDB support is deprecated (https://github.com/vitessio/vitess/issues/9518) but we still support migration scenario.
+	return path.Join(os.Getenv("VTROOT"), "go/test/endtoend/vreplication/testdata/config/init_testserver_db.sql"), nil
 }
 
 // MysqlCtlProcessInstance returns a Mysqlctl handle for mysqlctl process

--- a/go/test/endtoend/utils/utils.go
+++ b/go/test/endtoend/utils/utils.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 

--- a/go/test/endtoend/utils/utils.go
+++ b/go/test/endtoend/utils/utils.go
@@ -239,3 +239,23 @@ func TimeoutAction(t *testing.T, timeout time.Duration, errMsg string, action fu
 		}
 	}
 }
+
+func GetInitDBSQL(initDBSQL string, updatedPasswords string, oldAlterTableMode string) (string, error) {
+	// Since password update is DML we need to insert it before we disable
+	// super_read_only therefore doing the split below.
+	splitString := strings.Split(initDBSQL, "# {{custom_sql}}")
+	if len(splitString) != 2 {
+		return "", fmt.Errorf("missing `# {{custom_sql}}` in init_db.sql file")
+	}
+	var builder strings.Builder
+	builder.WriteString(splitString[0])
+	builder.WriteString(updatedPasswords)
+
+	// https://github.com/vitessio/vitess/issues/8315
+	if oldAlterTableMode != "" {
+		builder.WriteString(oldAlterTableMode)
+	}
+	builder.WriteString(splitString[1])
+
+	return builder.String(), nil
+}

--- a/go/test/endtoend/vreplication/testdata/config/init_testserver_db.sql
+++ b/go/test/endtoend/vreplication/testdata/config/init_testserver_db.sql
@@ -1,5 +1,11 @@
-# This file is executed immediately after mysql_install_db,
-# to initialize a fresh data directory.
+# This file is for testing purpose only.
+# This file is executed immediately after initializing a fresh data directory.
+# It is equivalent of init_db.sql. Given init_db.sql is for mysql which has super_read_only
+# related stuff therefore for testing purpose we avoid setting `super_read_only` during initialization.
+
+###############################################################################
+# WARNING: Any change to init_db.sql should gets reflected in this file as well.
+###############################################################################
 
 ###############################################################################
 # WARNING: This sql is *NOT* safe for production use,
@@ -11,12 +17,9 @@
 ###############################################################################
 # Equivalent of mysql_secure_installation
 ###############################################################################
-# We need to ensure that super_read_only is disabled so that we can execute
-# these commands. Note that disabling it does NOT disable read_only.
-# We save the current value so that we only re-enable it at the end if it was
-# enabled before.
-SET @original_super_read_only=IF(@@global.super_read_only=1, 'ON', 'OFF');
-SET GLOBAL super_read_only='OFF';
+# We need to ensure that read_only is disabled so that we can execute
+# these commands.
+SET GLOBAL read_only='OFF';
 
 # Changes during the init db should not make it to the binlog.
 # They could potentially create errant transactions on replicas.
@@ -34,23 +37,6 @@ DROP DATABASE IF EXISTS test;
 # Vitess defaults
 ###############################################################################
 
-# Vitess-internal database.
-CREATE DATABASE IF NOT EXISTS _vt;
-# Note that definitions of local_metadata and shard_metadata should be the same
-# as in production which is defined in go/vt/mysqlctl/metadata_tables.go.
-CREATE TABLE IF NOT EXISTS _vt.local_metadata (
-  name VARCHAR(255) NOT NULL,
-  value VARCHAR(255) NOT NULL,
-  db_name VARBINARY(255) NOT NULL,
-  PRIMARY KEY (db_name, name)
-  ) ENGINE=InnoDB;
-CREATE TABLE IF NOT EXISTS _vt.shard_metadata (
-  name VARCHAR(255) NOT NULL,
-  value MEDIUMBLOB NOT NULL,
-  db_name VARBINARY(255) NOT NULL,
-  PRIMARY KEY (db_name, name)
-  ) ENGINE=InnoDB;
-
 # Admin user with all privileges.
 CREATE USER 'vt_dba'@'localhost';
 GRANT ALL ON *.* TO 'vt_dba'@'localhost';
@@ -59,9 +45,9 @@ GRANT GRANT OPTION ON *.* TO 'vt_dba'@'localhost';
 # User for app traffic, with global read-write access.
 CREATE USER 'vt_app'@'localhost';
 GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, PROCESS, FILE,
-  REFERENCES, INDEX, ALTER, SHOW DATABASES, CREATE TEMPORARY TABLES,
+    REFERENCES, INDEX, ALTER, SHOW DATABASES, CREATE TEMPORARY TABLES,
   LOCK TABLES, EXECUTE, REPLICATION CLIENT, CREATE VIEW,
-  SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER
+    SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER
   ON *.* TO 'vt_app'@'localhost';
 
 # User for app debug traffic, with global read access.
@@ -72,9 +58,9 @@ GRANT SELECT, SHOW DATABASES, PROCESS ON *.* TO 'vt_appdebug'@'localhost';
 # Same permissions as vt_app here.
 CREATE USER 'vt_allprivs'@'localhost';
 GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, PROCESS, FILE,
-  REFERENCES, INDEX, ALTER, SHOW DATABASES, CREATE TEMPORARY TABLES,
+    REFERENCES, INDEX, ALTER, SHOW DATABASES, CREATE TEMPORARY TABLES,
   LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, CREATE VIEW,
-  SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER
+    SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER
   ON *.* TO 'vt_allprivs'@'localhost';
 
 # User for slave replication connections.
@@ -84,24 +70,17 @@ GRANT REPLICATION SLAVE ON *.* TO 'vt_repl'@'%';
 # User for Vitess VReplication (base vstreamers and vplayer).
 CREATE USER 'vt_filtered'@'localhost';
 GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, PROCESS, FILE,
-  REFERENCES, INDEX, ALTER, SHOW DATABASES, CREATE TEMPORARY TABLES,
+    REFERENCES, INDEX, ALTER, SHOW DATABASES, CREATE TEMPORARY TABLES,
   LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, CREATE VIEW,
-  SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER
+    SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER
   ON *.* TO 'vt_filtered'@'localhost';
 
 # User for general MySQL monitoring.
 CREATE USER 'vt_monitoring'@'localhost';
 GRANT SELECT, PROCESS, SUPER, REPLICATION CLIENT, RELOAD
-  ON *.* TO 'vt_monitoring'@'localhost';
+      ON *.* TO 'vt_monitoring'@'localhost';
 GRANT SELECT, UPDATE, DELETE, DROP
-  ON performance_schema.* TO 'vt_monitoring'@'localhost';
-
-# User for Orchestrator (https://github.com/openark/orchestrator).
-CREATE USER 'orc_client_user'@'%' IDENTIFIED BY 'orc_client_user_password';
-GRANT SUPER, PROCESS, REPLICATION SLAVE, RELOAD
-  ON *.* TO 'orc_client_user'@'%';
-GRANT SELECT
-  ON _vt.* TO 'orc_client_user'@'%';
+      ON performance_schema.* TO 'vt_monitoring'@'localhost';
 
 FLUSH PRIVILEGES;
 
@@ -110,6 +89,3 @@ RESET MASTER;
 
 # custom sql is used to add custom scripts like creating users/passwords. We use it in our tests
 # {{custom_sql}}
-
-# We need to set super_read_only back to what it was before
-SET GLOBAL super_read_only=IFNULL(@original_super_read_only, 'ON');


### PR DESCRIPTION
…db.sql` (#13525)

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
