### PR TITLE
`slack-19.0`: vtorc: Switch to Vitess stats (#15948)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,6 @@ require (
 	github.com/planetscale/vtprotobuf v0.5.0
 	github.com/prometheus/client_golang v1.19.0
 	github.com/prometheus/common v0.49.0 // indirect
-	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 	github.com/sjmudd/stopwatch v0.1.1
 	github.com/soheilhy/cmux v0.1.5
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -422,8 +422,6 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
-github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
-github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/richardartoul/molecule v1.0.1-0.20221107223329-32cfee06a052 h1:Qp27Idfgi6ACvFQat5+VJvlYToylpM/hcyLBI3WaKPA=

--- a/go/vt/vtorc/inst/analysis_dao.go
+++ b/go/vt/vtorc/inst/analysis_dao.go
@@ -20,31 +20,27 @@ import (
 	"fmt"
 	"time"
 
-	"vitess.io/vitess/go/vt/external/golib/sqlutils"
-	"vitess.io/vitess/go/vt/log"
-	"vitess.io/vitess/go/vt/topo/topoproto"
-
+	"github.com/patrickmn/go-cache"
 	"google.golang.org/protobuf/encoding/prototext"
 
+	"vitess.io/vitess/go/stats"
+	"vitess.io/vitess/go/vt/external/golib/sqlutils"
+	"vitess.io/vitess/go/vt/log"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/vtctl/reparentutil"
 	"vitess.io/vitess/go/vt/vtorc/config"
 	"vitess.io/vitess/go/vt/vtorc/db"
 	"vitess.io/vitess/go/vt/vtorc/process"
 	"vitess.io/vitess/go/vt/vtorc/util"
-
-	"github.com/patrickmn/go-cache"
-	"github.com/rcrowley/go-metrics"
 )
 
-var analysisChangeWriteCounter = metrics.NewCounter()
+var analysisChangeWriteCounter = stats.NewCounter("analysis.change.write", "Number of times analysis has changed")
 
 var recentInstantAnalysis *cache.Cache
 
 func init() {
-	_ = metrics.Register("analysis.change.write", analysisChangeWriteCounter)
-
 	go initializeAnalysisDaoPostConfiguration()
 }
 
@@ -748,7 +744,7 @@ func auditInstanceAnalysisInChangelog(tabletAlias string, analysisCode AnalysisC
 		tabletAlias, string(analysisCode),
 	)
 	if err == nil {
-		analysisChangeWriteCounter.Inc(1)
+		analysisChangeWriteCounter.Add(1)
 	} else {
 		log.Error(err)
 	}

--- a/go/vt/vtorc/inst/analysis_dao_test.go
+++ b/go/vt/vtorc/inst/analysis_dao_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/patrickmn/go-cache"
-	"github.com/rcrowley/go-metrics"
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/vt/external/golib/sqlutils"
@@ -864,7 +863,7 @@ func TestAuditInstanceAnalysisInChangelog(t *testing.T) {
 			oldAnalysisChangeWriteCounter := analysisChangeWriteCounter
 
 			recentInstantAnalysis = cache.New(tt.cacheExpiration, 100*time.Millisecond)
-			analysisChangeWriteCounter = metrics.NewCounter()
+			before := analysisChangeWriteCounter.Get()
 
 			defer func() {
 				// Set the old values back.
@@ -877,7 +876,7 @@ func TestAuditInstanceAnalysisInChangelog(t *testing.T) {
 			updates := []struct {
 				tabletAlias             string
 				analysisCode            AnalysisCode
-				writeCounterExpectation int
+				writeCounterExpectation int64
 				wantErr                 string
 			}{
 				{
@@ -908,7 +907,7 @@ func TestAuditInstanceAnalysisInChangelog(t *testing.T) {
 					continue
 				}
 				require.NoError(t, err)
-				require.EqualValues(t, upd.writeCounterExpectation, analysisChangeWriteCounter.Count())
+				require.EqualValues(t, upd.writeCounterExpectation, analysisChangeWriteCounter.Get()-before)
 			}
 		})
 	}

--- a/go/vt/vtorc/inst/audit_dao.go
+++ b/go/vt/vtorc/inst/audit_dao.go
@@ -21,18 +21,13 @@ import (
 	"os"
 	"time"
 
-	"github.com/rcrowley/go-metrics"
-
+	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/vtorc/config"
 	"vitess.io/vitess/go/vt/vtorc/db"
 )
 
-var auditOperationCounter = metrics.NewCounter()
-
-func init() {
-	_ = metrics.Register("audit.write", auditOperationCounter)
-}
+var auditOperationCounter = stats.NewCounter("audit.write", "Number of audit operations performed")
 
 // AuditOperation creates and writes a new audit entry by given params
 func AuditOperation(auditType string, tabletAlias string, message string) error {
@@ -86,7 +81,7 @@ func AuditOperation(auditType string, tabletAlias string, message string) error 
 	if !auditWrittenToFile {
 		log.Infof(logMessage)
 	}
-	auditOperationCounter.Inc(1)
+	auditOperationCounter.Add(1)
 
 	return nil
 }


### PR DESCRIPTION
## Description

Backport v20 PR https://github.com/vitessio/vitess/pull/15948 to `slack-19.0` so we can observe several stats that are hidden from us _(due to being exported as `go-metrics` only)_

## Related Issue(s)

https://github.com/vitessio/vitess/pull/15948

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
