### PR TITLE
Patch: disable extensive keyspace events logging

### DIFF
--- a/go/vt/discovery/keyspace_events.go
+++ b/go/vt/discovery/keyspace_events.go
@@ -312,10 +312,12 @@ func (kss *keyspaceState) ensureConsistentLocked() {
 			Serving: sstate.serving,
 		})
 
-		log.Infof("keyspace event resolved: %s/%s is now consistent (serving: %v)",
-			sstate.target.Keyspace, sstate.target.Keyspace,
-			sstate.serving,
-		)
+		// Disable it due to log storm in production
+		// thread https://slack-pde.slack.com/archives/C06CPL4HMED/p1729896804879749
+		// log.Infof("keyspace event resolved: %s/%s is now consistent (serving: %v)",
+		//	sstate.target.Keyspace, sstate.target.Keyspace,
+		//	sstate.serving,
+		// )
 
 		if !sstate.serving {
 			delete(kss.shards, shard)

--- a/go/vt/vtgate/buffer/shard_buffer.go
+++ b/go/vt/vtgate/buffer/shard_buffer.go
@@ -475,8 +475,10 @@ func (sb *shardBuffer) recordKeyspaceEvent(alias *topodatapb.TabletAlias, stillS
 	sb.mu.Lock()
 	defer sb.mu.Unlock()
 
-	log.Infof("disruption in shard %s/%s resolved (serving: %v), movetable state %#v",
-		sb.keyspace, sb.shard, stillServing, keyspaceEvent.MoveTablesState)
+	// Disable it due to log storm in production
+	// thread https://slack-pde.slack.com/archives/C06CPL4HMED/p1729896804879749
+	// log.Infof("disruption in shard %s/%s resolved (serving: %v), movetable state %#v",
+	//	sb.keyspace, sb.shard, stillServing, keyspaceEvent.MoveTablesState)
 
 	if !topoproto.TabletAliasEqual(alias, sb.currentPrimary) {
 		if sb.currentPrimary != nil {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

The 2 log messages were heavily dumped in production, millions of records per second, and blocked the log ingestion due to heavy volume. While commenting out the 2 log lines, we will work with the upstream on an official fix.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
