### PR TITLE
`slack-19.0`: fix broken github action workflows

### DIFF
--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
@@ -171,7 +171,6 @@ jobs:
 
         source build.env
         eatmydata -- go run test.go -skip-build -keep-data=false -docker=false -print-log -follow -tag upgrade_downgrade_query_serving_queries
->>>>>>> parent of 25a80acbfd ([release-19.0] Improve the queries upgrade/downgrade CI workflow by using same test code version as binary (#16494) (#16501))
 
     # Swap the binaries in the bin. Use vtgate version n-1 and keep vttablet at version n
     - name: Use last release's VTGate

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
@@ -165,7 +165,6 @@ jobs:
 
         source build.env
         eatmydata -- go run test.go -skip-build -keep-data=false -docker=false -print-log -follow -tag upgrade_downgrade_query_serving_queries
->>>>>>> parent of 25a80acbfd ([release-19.0] Improve the queries upgrade/downgrade CI workflow by using same test code version as binary (#16494) (#16501))
 
     # Swap the binaries in the bin. Use vtgate version n+1 and keep vttablet at version n
     - name: Use next release's VTGate


### PR DESCRIPTION
## Description

This PR fixes 2 x upgrade/downgrade query serving tests that were silently broken/disabled by a bad merge conflict fix in https://github.com/slackhq/vitess/pull/551

## Related Issue(s)

https://github.com/slackhq/vitess/pull/551

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
