### PR TITLE
`vtorc`: pre-alloc underlying array in `sqlutils.RowToArray`

### DIFF
--- a/go/vt/external/golib/sqlutils/sqlutils.go
+++ b/go/vt/external/golib/sqlutils/sqlutils.go
@@ -163,8 +163,9 @@ func GetSQLiteDB(dbFile string) (*sql.DB, bool, error) {
 // RowToArray is a convenience function, typically not called directly, which maps a
 // single read database row into a NullString
 func RowToArray(rows *sql.Rows, columns []string) ([]CellData, error) {
-	buff := make([]any, len(columns))
-	data := make([]CellData, len(columns))
+	numColumns := len(columns)
+	buff := make([]any, numColumns, numColumns)
+	data := make([]CellData, numColumns, numColumns)
 	for i := range buff {
 		buff[i] = data[i].NullString()
 	}


### PR DESCRIPTION
## Description

This PR adds an optimisation to a hot path of `vtorc`: `sqlutils.RowToArray`

This change ensures the backing array of the slice made by this `func` is pre-allocated to the known static size, which can avoid overhead in the runtime

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
