### PR TITLE
`slack-15.0`: support consul topo stale reads

### DIFF
--- a/go/flags/endtoend/vtbackup.txt
+++ b/go/flags/endtoend/vtbackup.txt
@@ -161,6 +161,7 @@ Usage of vtbackup:
       --tablet_manager_grpc_key string                  the key to use to connect
       --tablet_manager_grpc_server_name string          the server name to use to validate server certificate
       --tablet_manager_protocol string                  Protocol to use to make tabletmanager RPCs to vttablets. (default "grpc")
+      --topo_consul_allow_stale_reads                   Allow stale reads from consul servers
       --topo_consul_idle_conn_timeout duration          Maximum amount of time to pool idle connections. (default 1m30s)
       --topo_consul_lock_delay duration                 LockDelay for consul session. (default 15s)
       --topo_consul_lock_session_checks string          List of checks for consul session. (default "serfHealth")

--- a/go/flags/endtoend/vtctld.txt
+++ b/go/flags/endtoend/vtctld.txt
@@ -124,6 +124,7 @@ Usage of vtctld:
       --tablet_refresh_interval duration                                 Tablet refresh interval. (default 1m0s)
       --tablet_refresh_known_tablets                                     Whether to reload the tablet's address/port map from topo in case they change. (default true)
       --tablet_url_template string                                       Format string describing debug tablet url formatting. See getTabletDebugURL() for how to customize this. (default "http://{{.GetTabletHostPort}}")
+      --topo_consul_allow_stale_reads                                    Allow stale reads from consul servers
       --topo_consul_idle_conn_timeout duration                           Maximum amount of time to pool idle connections. (default 1m30s)
       --topo_consul_lock_delay duration                                  LockDelay for consul session. (default 15s)
       --topo_consul_lock_session_checks string                           List of checks for consul session. (default "serfHealth")

--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -177,6 +177,7 @@ Usage of vtgate:
       --tablet_refresh_known_tablets                                     Whether to reload the tablet's address/port map from topo in case they change. (default true)
       --tablet_types_to_wait strings                                     Wait till connected for specified tablet types during Gateway initialization. Should be provided as a comma-separated set of tablet types.
       --tablet_url_template string                                       Format string describing debug tablet url formatting. See getTabletDebugURL() for how to customize this. (default "http://{{.GetTabletHostPort}}")
+      --topo_consul_allow_stale_reads                                    Allow stale reads from consul servers
       --topo_consul_idle_conn_timeout duration                           Maximum amount of time to pool idle connections. (default 1m30s)
       --topo_consul_lock_delay duration                                  LockDelay for consul session. (default 15s)
       --topo_consul_lock_session_checks string                           List of checks for consul session. (default "serfHealth")

--- a/go/flags/endtoend/vtgr.txt
+++ b/go/flags/endtoend/vtgr.txt
@@ -54,6 +54,7 @@ Usage of vtgr:
       --tablet_manager_grpc_key string             the key to use to connect
       --tablet_manager_grpc_server_name string     the server name to use to validate server certificate
       --tablet_manager_protocol string             Protocol to use to make tabletmanager RPCs to vttablets. (default "grpc")
+      --topo_consul_allow_stale_reads              Allow stale reads from consul servers
       --topo_consul_idle_conn_timeout duration     Maximum amount of time to pool idle connections. (default 1m30s)
       --topo_consul_lock_delay duration            LockDelay for consul session. (default 15s)
       --topo_consul_lock_session_checks string     List of checks for consul session. (default "serfHealth")

--- a/go/flags/endtoend/vtorc.txt
+++ b/go/flags/endtoend/vtorc.txt
@@ -64,6 +64,7 @@ Usage of vtorc:
       --tablet_manager_grpc_server_name string       the server name to use to validate server certificate
       --tablet_manager_protocol string               Protocol to use to make tabletmanager RPCs to vttablets. (default "grpc")
       --topo-information-refresh-duration duration   Timer duration on which VTOrc refreshes the keyspace and vttablet records from the topology server (default 15s)
+      --topo_consul_allow_stale_reads                Allow stale reads from consul servers
       --topo_consul_idle_conn_timeout duration       Maximum amount of time to pool idle connections. (default 1m30s)
       --topo_consul_lock_delay duration              LockDelay for consul session. (default 15s)
       --topo_consul_lock_session_checks string       List of checks for consul session. (default "serfHealth")

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -316,6 +316,7 @@ Usage of vttablet:
       --throttle_metrics_threshold float                                          Override default throttle threshold, respective to -throttle_metrics_query (default 1.7976931348623157e+308)
       --throttle_tablet_types string                                              Comma separated VTTablet types to be considered by the throttler. default: 'replica'. example: 'replica,rdonly'. 'replica' aways implicitly included (default "replica")
       --throttle_threshold duration                                               Replication lag threshold for default lag throttling (default 1s)
+      --topo_consul_allow_stale_reads                                             Allow stale reads from consul servers
       --topo_consul_idle_conn_timeout duration                                    Maximum amount of time to pool idle connections. (default 1m30s)
       --topo_consul_lock_delay duration                                           LockDelay for consul session. (default 15s)
       --topo_consul_lock_session_checks string                                    List of checks for consul session. (default "serfHealth")

--- a/go/flags/endtoend/vttestserver.txt
+++ b/go/flags/endtoend/vttestserver.txt
@@ -118,6 +118,7 @@ Usage of vttestserver:
       --tablet_manager_grpc_key string                                   the key to use to connect
       --tablet_manager_grpc_server_name string                           the server name to use to validate server certificate
       --tablet_manager_protocol string                                   Protocol to use to make tabletmanager RPCs to vttablets. (default "grpc")
+      --topo_consul_allow_stale_reads                                    Allow stale reads from consul servers
       --topo_consul_idle_conn_timeout duration                           Maximum amount of time to pool idle connections. (default 1m30s)
       --topo_consul_lock_delay duration                                  LockDelay for consul session. (default 15s)
       --topo_consul_lock_session_checks string                           List of checks for consul session. (default "serfHealth")

--- a/go/vt/topo/consultopo/file.go
+++ b/go/vt/topo/consultopo/file.go
@@ -87,7 +87,9 @@ func (s *Server) Update(ctx context.Context, filePath string, contents []byte, v
 func (s *Server) Get(ctx context.Context, filePath string) ([]byte, topo.Version, error) {
 	nodePath := path.Join(s.root, filePath)
 
-	pair, _, err := s.kv.Get(nodePath, nil)
+	pair, _, err := s.kv.Get(nodePath, &api.QueryOptions{
+		AllowStale: consulAllowStaleReads,
+	})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -102,7 +104,9 @@ func (s *Server) Get(ctx context.Context, filePath string) ([]byte, topo.Version
 func (s *Server) List(ctx context.Context, filePathPrefix string) ([]topo.KVInfo, error) {
 	nodePathPrefix := path.Join(s.root, filePathPrefix)
 
-	pairs, _, err := s.kv.List(nodePathPrefix, nil)
+	pairs, _, err := s.kv.List(nodePathPrefix, &api.QueryOptions{
+		AllowStale: consulAllowStaleReads,
+	})
 	if err != nil {
 		return []topo.KVInfo{}, err
 	}

--- a/go/vt/topo/consultopo/server.go
+++ b/go/vt/topo/consultopo/server.go
@@ -46,6 +46,7 @@ var (
 	consulMaxConnsPerHost   int = 250 // do not use client default of 0/unlimited
 	consulMaxIdleConns      int
 	consulIdleConnTimeout   time.Duration
+	consulAllowStaleReads   bool
 )
 
 func init() {
@@ -65,6 +66,7 @@ func registerServerFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&consulMaxConnsPerHost, "topo_consul_max_conns_per_host", consulMaxConnsPerHost, "Maximum number of consul connections per host.")
 	fs.IntVar(&consulMaxIdleConns, "topo_consul_max_idle_conns", defaultConsulPooledTransport.MaxIdleConns, "Maximum number of idle consul connections.")
 	fs.DurationVar(&consulIdleConnTimeout, "topo_consul_idle_conn_timeout", defaultConsulPooledTransport.IdleConnTimeout, "Maximum amount of time to pool idle connections.")
+	fs.BoolVar(&consulAllowStaleReads, "topo_consul_allow_stale_reads", consulAllowStaleReads, "Allow stale reads from consul servers")
 }
 
 // ClientAuthCred credential to use for consul clusters


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR allows Vitess components to use stale reads from consul. This is enabled with the flag `--topo_allow_stale_reads`, which is default `false` and should be considered experimental

[`*api.QueryOptions`](https://pkg.go.dev/github.com/hashicorp/consul/api#QueryOptions):
> // AllowStale allows any Consul server (non-leader) to service
>	// a read. This allows for lower latency and higher throughput
>	AllowStale [bool](https://pkg.go.dev/builtin#bool)

This flag allow us to distribute topo `.Get(...)` and `.List(...)` load to consul replicas. Also it limits the impact of elections

It may be safe in use cases like `txthrottler` if stale reads have no impact to any other `vttablet` operations. It may be safe to use in `vtorc` also

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
