### PR TITLE
topo support stale reads for consul

### DIFF
--- a/go/vt/discovery/topology_watcher.go
+++ b/go/vt/discovery/topology_watcher.go
@@ -112,7 +112,7 @@ func NewTopologyWatcher(ctx context.Context, topoServer *topo.Server, hc HealthC
 }
 
 func (tw *TopologyWatcher) getTablets() ([]*topo.TabletInfo, error) {
-	return tw.topoServer.GetTabletsByCell(tw.ctx, tw.cell, &topo.GetTabletsByCellOptions{Concurrency: tw.concurrency})
+	return tw.topoServer.GetTabletsByCell(tw.ctx, tw.cell, &topo.GetTabletsByCellOptions{Concurrency: tw.concurrency, Polling: true})
 }
 
 // Start starts the topology watcher.

--- a/go/vt/topo/conn.go
+++ b/go/vt/topo/conn.go
@@ -75,8 +75,10 @@ type Conn interface {
 	// List returns KV pairs, along with metadata like the version, for
 	// entries where the key contains the specified prefix.
 	// filePathPrefix is a path relative to the root directory of the cell.
+	// polling indicates if the caller will be repeatedly calling for results and
+	// therefore can accept relaxed consistency
 	// Can return ErrNoNode if there are no matches.
-	List(ctx context.Context, filePathPrefix string) ([]KVInfo, error)
+	List(ctx context.Context, filePathPrefix string, polling bool) ([]KVInfo, error)
 
 	// Delete deletes the provided file.
 	// If version is nil, it is an unconditional delete.

--- a/go/vt/topo/consultopo/file.go
+++ b/go/vt/topo/consultopo/file.go
@@ -99,7 +99,7 @@ func (s *Server) Get(ctx context.Context, filePath string) ([]byte, topo.Version
 }
 
 // List is part of the topo.Conn interface.
-func (s *Server) List(ctx context.Context, filePathPrefix string) ([]topo.KVInfo, error) {
+func (s *Server) List(ctx context.Context, filePathPrefix string, polling bool) ([]topo.KVInfo, error) {
 	nodePathPrefix := path.Join(s.root, filePathPrefix)
 
 	pairs, _, err := s.kv.List(nodePathPrefix, nil)

--- a/go/vt/topo/consultopo/file.go
+++ b/go/vt/topo/consultopo/file.go
@@ -102,7 +102,12 @@ func (s *Server) Get(ctx context.Context, filePath string) ([]byte, topo.Version
 func (s *Server) List(ctx context.Context, filePathPrefix string, polling bool) ([]topo.KVInfo, error) {
 	nodePathPrefix := path.Join(s.root, filePathPrefix)
 
-	pairs, _, err := s.kv.List(nodePathPrefix, nil)
+	opts := api.QueryOptions{}
+	if consulAllowStalePolling && polling {
+		opts.AllowStale = true
+	}
+
+	pairs, _, err := s.kv.List(nodePathPrefix, &opts)
 	if err != nil {
 		return []topo.KVInfo{}, err
 	}

--- a/go/vt/topo/consultopo/server.go
+++ b/go/vt/topo/consultopo/server.go
@@ -41,6 +41,7 @@ var (
 	consulLockSessionChecks = "serfHealth"
 	consulLockSessionTTL    string
 	consulLockDelay         = 15 * time.Second
+	consulAllowStalePolling bool
 )
 
 func init() {
@@ -52,6 +53,7 @@ func registerServerFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&consulLockSessionChecks, "topo_consul_lock_session_checks", consulLockSessionChecks, "List of checks for consul session.")
 	fs.StringVar(&consulLockSessionTTL, "topo_consul_lock_session_ttl", consulLockSessionTTL, "TTL for consul session.")
 	fs.DurationVar(&consulLockDelay, "topo_consul_lock_delay", consulLockDelay, "LockDelay for consul session.")
+	fs.BoolVar(&consulAllowStalePolling, "topo_consul_allow_stale_polling", consulAllowStalePolling, "Set AllowStale as an option when reading in a polling context.")
 }
 
 // ClientAuthCred credential to use for consul clusters

--- a/go/vt/topo/etcd2topo/file.go
+++ b/go/vt/topo/etcd2topo/file.go
@@ -89,7 +89,7 @@ func (s *Server) Get(ctx context.Context, filePath string) ([]byte, topo.Version
 }
 
 // List is part of the topo.Conn interface.
-func (s *Server) List(ctx context.Context, filePathPrefix string) ([]topo.KVInfo, error) {
+func (s *Server) List(ctx context.Context, filePathPrefix string, polling bool) ([]topo.KVInfo, error) {
 	nodePathPrefix := path.Join(s.root, filePathPrefix)
 
 	resp, err := s.cli.Get(ctx, nodePathPrefix, clientv3.WithPrefix())

--- a/go/vt/topo/faketopo/faketopo.go
+++ b/go/vt/topo/faketopo/faketopo.go
@@ -255,7 +255,7 @@ func (f *FakeConn) Get(ctx context.Context, filePath string) ([]byte, topo.Versi
 }
 
 // List is part of the topo.Conn interface.
-func (f *FakeConn) List(ctx context.Context, filePathPrefix string) ([]topo.KVInfo, error) {
+func (f *FakeConn) List(ctx context.Context, filePathPrefix string, polling bool) ([]topo.KVInfo, error) {
 	return nil, topo.NewError(topo.NoImplementation, "List not supported in fake topo")
 }
 

--- a/go/vt/topo/helpers/tee.go
+++ b/go/vt/topo/helpers/tee.go
@@ -144,8 +144,8 @@ func (c *TeeConn) Get(ctx context.Context, filePath string) ([]byte, topo.Versio
 }
 
 // List is part of the topo.Conn interface.
-func (c *TeeConn) List(ctx context.Context, filePathPrefix string) ([]topo.KVInfo, error) {
-	return c.primary.List(ctx, filePathPrefix)
+func (c *TeeConn) List(ctx context.Context, filePathPrefix string, polling bool) ([]topo.KVInfo, error) {
+	return c.primary.List(ctx, filePathPrefix, polling)
 }
 
 // Delete is part of the topo.Conn interface.

--- a/go/vt/topo/memorytopo/file.go
+++ b/go/vt/topo/memorytopo/file.go
@@ -176,7 +176,7 @@ func (c *Conn) Get(ctx context.Context, filePath string) ([]byte, topo.Version, 
 }
 
 // List is part of the topo.Conn interface.
-func (c *Conn) List(ctx context.Context, filePathPrefix string) ([]topo.KVInfo, error) {
+func (c *Conn) List(ctx context.Context, filePathPrefix string, polling bool) ([]topo.KVInfo, error) {
 	if err := c.dial(ctx); err != nil {
 		return nil, err
 	}

--- a/go/vt/topo/stats_conn.go
+++ b/go/vt/topo/stats_conn.go
@@ -116,11 +116,11 @@ func (st *StatsConn) Get(ctx context.Context, filePath string) ([]byte, Version,
 }
 
 // List is part of the Conn interface
-func (st *StatsConn) List(ctx context.Context, filePathPrefix string) ([]KVInfo, error) {
+func (st *StatsConn) List(ctx context.Context, filePathPrefix string, polling bool) ([]KVInfo, error) {
 	startTime := time.Now()
 	statsKey := []string{"List", st.cell}
 	defer topoStatsConnTimings.Record(statsKey, startTime)
-	bytes, err := st.conn.List(ctx, filePathPrefix)
+	bytes, err := st.conn.List(ctx, filePathPrefix, polling)
 	if err != nil {
 		topoStatsConnErrors.Add(statsKey, int64(1))
 		return bytes, err

--- a/go/vt/topo/stats_conn_test.go
+++ b/go/vt/topo/stats_conn_test.go
@@ -74,7 +74,7 @@ func (st *fakeConn) Get(ctx context.Context, filePath string) (bytes []byte, ver
 }
 
 // List is part of the Conn interface
-func (st *fakeConn) List(ctx context.Context, filePathPrefix string) (bytes []KVInfo, err error) {
+func (st *fakeConn) List(ctx context.Context, filePathPrefix string, polling bool) (bytes []KVInfo, err error) {
 	if filePathPrefix == "error" {
 		return bytes, fmt.Errorf("Dummy error")
 	}

--- a/go/vt/topo/tablet.go
+++ b/go/vt/topo/tablet.go
@@ -289,6 +289,9 @@ func (ts *Server) GetTabletAliasesByCell(ctx context.Context, cell string) ([]*t
 type GetTabletsByCellOptions struct {
 	// Concurrency controls the maximum number of concurrent calls to GetTablet.
 	Concurrency int64
+	// Polling indicates if the caller is getting tablets in a polling loop and is
+	// used in some topo implementations to improve performance by relaxing consistency.
+	Polling bool
 }
 
 // GetTabletsByCell returns all the tablets in the cell.
@@ -300,7 +303,7 @@ func (ts *Server) GetTabletsByCell(ctx context.Context, cellAlias string, opt *G
 	if err != nil {
 		return nil, err
 	}
-	listResults, err := cellConn.List(ctx, TabletsPath)
+	listResults, err := cellConn.List(ctx, TabletsPath, opt.Polling)
 	if err != nil || len(listResults) == 0 {
 		// Currently the ZooKeeper implementation does not support scans
 		// so we fall back to the more costly method of fetching the tablets one by one.

--- a/go/vt/topo/test/file.go
+++ b/go/vt/topo/test/file.go
@@ -213,7 +213,7 @@ func checkList(t *testing.T, ctx context.Context, ts *topo.Server) {
 		t.Fatalf("Create('/myfile') failed: %v", err)
 	}
 
-	_, err = conn.List(ctx, "/")
+	_, err = conn.List(ctx, "/", false /*polling*/)
 	if topo.IsErrType(err, topo.NoImplementation) {
 		// If this is not supported, skip the test
 		t.Skipf("%T does not support List()", conn)
@@ -229,7 +229,7 @@ func checkList(t *testing.T, ctx context.Context, ts *topo.Server) {
 	}
 
 	for _, path := range []string{"/top", "/toplevel", "/toplevel/", "/toplevel/nes", "/toplevel/nested/myfile"} {
-		entries, err := conn.List(ctx, path)
+		entries, err := conn.List(ctx, path, false /*polling*/)
 		if err != nil {
 			t.Fatalf("List failed(path: %q): %v", path, err)
 		}

--- a/go/vt/topo/zk2topo/file.go
+++ b/go/vt/topo/zk2topo/file.go
@@ -89,7 +89,7 @@ func (zs *Server) Get(ctx context.Context, filePath string) ([]byte, topo.Versio
 }
 
 // List is part of the topo.Conn interface.
-func (zs *Server) List(ctx context.Context, filePathPrefix string) ([]topo.KVInfo, error) {
+func (zs *Server) List(ctx context.Context, filePathPrefix string, polling bool) ([]topo.KVInfo, error) {
 	return nil, topo.NewError(topo.NoImplementation, "List not supported in ZK2 topo")
 }
 


### PR DESCRIPTION
## Description
Add optional support for AllowStale reads in the consul topo when polling for tablets in discovery.

Consul supports relaxed consistency on K/V reads as described in https://developer.hashicorp.com/consul/api-docs/features/consistency.

In particular there is a performant option for stale reads that allow lagged replies from a replica:

> [stale](https://developer.hashicorp.com/consul/api-docs/features/consistency#stale) - [Consul DNS queries use stale mode by default](https://developer.hashicorp.com/consul/api-docs/features/consistency#consul-dns-queries). This mode allows any server to handle the read regardless of whether it is the leader. The trade-off is very fast and scalable reads with a higher likelihood of stale values. Results are generally consistent to within 50 milliseconds of the leader, though there is no upper limit on this staleness. Since this mode allows reads without a leader, a cluster that is unavailable (no quorum) can still respond to queries.

None of the Vitess K/V options utilize this mode however, which means that all operations must go to the primary leader.

At the same time, the discovery TopologyWatcher as used by vtgate and other components repeatedly polls the tablet list to discover new tablets that have been added to the registry. As such, it can tolerate stale reads on a given request since it will turn around and re-request in the future.

To make this more efficient, this PR plumbs through an option so that this polling workloads sets the more relaxed `AllowStale` consistency option on the KV read, which should improve consul topo service performance.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
