### PR TITLE
skip warmup time on e2e tests

### DIFF
--- a/go/test/endtoend/vtgateproxy/main_test.go
+++ b/go/test/endtoend/vtgateproxy/main_test.go
@@ -168,6 +168,7 @@ func NewVtgateProxyProcess(logDir, vtgateHostsFile, affinity, balancerType strin
 		GrpcPort:        grpcPort,
 		MySQLPort:       mySQLPort,
 		VerifyURL:       "http://" + net.JoinHostPort("localhost", strconv.Itoa(httpPort)) + "/debug/vars",
+		WarmupTime:      0 * time.Second,
 	}
 }
 
@@ -188,6 +189,7 @@ type VtgateProxyProcess struct {
 	MySQLPort       int
 	ExtraArgs       []string
 	VerifyURL       string
+	WarmupTime      time.Duration
 
 	proc *exec.Cmd
 	exit chan error
@@ -207,6 +209,7 @@ func (vt *VtgateProxyProcess) Setup() error {
 		"--affinity_value", vt.AffinityValue,
 		"--num_connections", strconv.Itoa(vt.NumConnections),
 		"--log_dir", vt.LogDir,
+		"--warmup_time", vt.WarmupTime.String(),
 		"--v", "999",
 		"--mysql_auth_server_impl", "none",
 		"--alsologtostderr",


### PR DESCRIPTION
connection warmup time is causing e2e tests to fail because we only wait until the discovery file is parsed not until the connection pool has settled - this is the easiest fix for now, tested e2e tests on a beach

this is just going onto the v15 branch which we're not using yet - I'll be running a branch build of this to try it out on dev loadtest as soon as I get a chance