### PR TITLE
`slack-19.0`: use `slackhq/vitess-addons@v0.19.5`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -101,7 +101,7 @@ require (
 	github.com/kr/text v0.2.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
-	github.com/slackhq/vitess-addons v0.19.4
+	github.com/slackhq/vitess-addons v0.19.5
 	github.com/slok/noglog v0.2.0
 	github.com/spf13/afero v1.11.0
 	github.com/spf13/jwalterweatherman v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -448,8 +448,8 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sjmudd/stopwatch v0.1.1 h1:x45OvxFB5OtCkjvYtzRF5fWB857Jzjjk84Oyd5C5ebw=
 github.com/sjmudd/stopwatch v0.1.1/go.mod h1:BLw0oIQJ1YLXBO/q9ufK/SgnKBVIkC2qrm6uy78Zw6U=
-github.com/slackhq/vitess-addons v0.19.4 h1:9BicIa9BK6ynqrJYCdE2fdFjN0LsfPS8DiYyYTO6vVQ=
-github.com/slackhq/vitess-addons v0.19.4/go.mod h1:2icrtf8lZyzdEH1r7PoXy8g66D4LG/bIhA9rQUqR+BQ=
+github.com/slackhq/vitess-addons v0.19.5 h1:ZrLHvZuMyZWlW9XY6+AEm4BeVC8/R8iNTOtQkKHbSwM=
+github.com/slackhq/vitess-addons v0.19.5/go.mod h1:2icrtf8lZyzdEH1r7PoXy8g66D4LG/bIhA9rQUqR+BQ=
 github.com/slok/noglog v0.2.0 h1:1czu4l2EoJ8L92UwdSXXa1Y+c5TIjFAFm2P+mjej95E=
 github.com/slok/noglog v0.2.0/go.mod h1:TfKxwpEZPT+UA83bQ6RME146k0MM4e8mwHLf6bhcGDI=
 github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=

--- a/go/vt/vtorc/logic/topology_recovery.go
+++ b/go/vt/vtorc/logic/topology_recovery.go
@@ -86,7 +86,7 @@ var (
 
 	// vtops
 	vtopsService      = fmt.Sprintf("%s-%s-%s", os.Getenv("BEDROCK_CONTAINER_NAME"), os.Getenv("POOL"), os.Getenv("VITESS_ENVIRONMENT"))
-	vtopsExec         = external.NewExecVTOps(os.Getenv("VTOPS_PATH"), vtopsService, os.Getenv("HOSTNAME"))
+	vtopsExec         = external.NewExecVTOps(os.Getenv("VTOPS_PATH"), vtopsService)
 	vtopsSlackChannel = os.Getenv("SLACK_CHANNEL")
 )
 


### PR DESCRIPTION
## Description

This PR updates `slackhq/vitess-addons` to [the `v0.19.5` tag](https://github.com/slackhq/vitess-addons/releases/tag/v0.19.5)

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
