### PR TITLE
Bug: dbCreated is false when db already exists

### DIFF
--- a/go/vt/sidecardb/sidecardb.go
+++ b/go/vt/sidecardb/sidecardb.go
@@ -262,6 +262,7 @@ func Init(ctx context.Context, env *vtenv.Environment, exec Exec) error {
 		}
 	}
 
+	// at this point db already exists or created if not
 	si.dbCreated = true
 
 	if err := si.setCurrentDatabase(sidecar.GetIdentifier()); err != nil {

--- a/go/vt/sidecardb/sidecardb.go
+++ b/go/vt/sidecardb/sidecardb.go
@@ -260,12 +260,10 @@ func Init(ctx context.Context, env *vtenv.Environment, exec Exec) error {
 		if err := si.createSidecarDB(); err != nil {
 			return err
 		}
-
-		si.dbCreated = true
 	}
 
 	// at this point db already exists or created if not
-	//si.dbCreated = true
+	si.dbCreated = true
 
 	if err := si.setCurrentDatabase(sidecar.GetIdentifier()); err != nil {
 		return err

--- a/go/vt/sidecardb/sidecardb.go
+++ b/go/vt/sidecardb/sidecardb.go
@@ -260,8 +260,9 @@ func Init(ctx context.Context, env *vtenv.Environment, exec Exec) error {
 		if err := si.createSidecarDB(); err != nil {
 			return err
 		}
-		si.dbCreated = true
 	}
+
+	si.dbCreated = true
 
 	if err := si.setCurrentDatabase(sidecar.GetIdentifier()); err != nil {
 		return err

--- a/go/vt/sidecardb/sidecardb.go
+++ b/go/vt/sidecardb/sidecardb.go
@@ -260,10 +260,12 @@ func Init(ctx context.Context, env *vtenv.Environment, exec Exec) error {
 		if err := si.createSidecarDB(); err != nil {
 			return err
 		}
+
+		si.dbCreated = true
 	}
 
 	// at this point db already exists or created if not
-	si.dbCreated = true
+	//si.dbCreated = true
 
 	if err := si.setCurrentDatabase(sidecar.GetIdentifier()); err != nil {
 		return err


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

dbCreated is set to false even when db already exists, which results in that tablet start always try to creeate the db. (credit to @vmogilev ) 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
