### PR TITLE
Revert "Add debugging logs for stale shard health stats on vtgates (#…

### DIFF
--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -499,8 +499,6 @@ func (hc *HealthCheckImpl) updateHealth(th *TabletHealth, prevTarget *query.Targ
 	hc.mu.Lock()
 	defer hc.mu.Unlock()
 
-	log.Infof("updating tablet health: trivialUpdate: %v, up: %v, target: %v; tablet: %v; serving: %v", trivialUpdate, up, th.Target, th.Tablet, th.Serving)
-
 	tabletAlias := tabletAliasString(topoproto.TabletAliasString(th.Tablet.Alias))
 	// let's be sure that this tablet hasn't been deleted from the authoritative map
 	// so that we're not racing to update it and in effect re-adding a copy of the
@@ -518,9 +516,6 @@ func (hc *HealthCheckImpl) updateHealth(th *TabletHealth, prevTarget *query.Targ
 		// keyspace and shard are not expected to change, but just in case ...
 		// move this tabletHealthCheck to the correct map
 		oldTargetKey := KeyFromTarget(prevTarget)
-
-		log.Infof("deleting tablet %v from health stats", th.Tablet)
-
 		delete(hc.healthData[oldTargetKey], tabletAlias)
 		_, ok := hc.healthData[targetKey]
 		if !ok {
@@ -559,7 +554,6 @@ func (hc *HealthCheckImpl) updateHealth(th *TabletHealth, prevTarget *query.Targ
 			alias := tabletAliasString(topoproto.TabletAliasString(healthy[0].Tablet.Alias))
 			// Clear healthy list for primary if the existing tablet is down
 			if alias == tabletAlias {
-				log.Warningf("Removing tablet %v from the healthy map.", tabletAlias)
 				hc.healthy[targetKey] = []*TabletHealth{}
 			}
 		}
@@ -569,7 +563,6 @@ func (hc *HealthCheckImpl) updateHealth(th *TabletHealth, prevTarget *query.Targ
 		// We re-sort the healthy tablet list whenever we get a health update for tablets we can route to.
 		// Tablets from other cells for non-primary targets should not trigger a re-sort;
 		// they should also be excluded from healthy list.
-		log.Infof("Recomputing tablet healthy stats for %v", th.Tablet)
 		if th.Target.TabletType != topodata.TabletType_PRIMARY && hc.isIncluded(th.Target.TabletType, th.Tablet.Alias) {
 			hc.recomputeHealthy(targetKey)
 		}

--- a/go/vt/discovery/tablet_health_check.go
+++ b/go/vt/discovery/tablet_health_check.go
@@ -224,8 +224,6 @@ func (thc *tabletHealthCheck) processResponse(hc *HealthCheckImpl, shr *query.St
 	}
 	thc.setServingState(serving, reason)
 
-	log.Infof("healthcheck update for tablet %v: serving: %v, reason: %s", thc.Tablet, thc.Serving, reason)
-
 	// notify downstream for primary change
 	hc.updateHealth(thc.SimpleCopy(), prevTarget, trivialUpdate, thc.Serving)
 	return nil
@@ -328,7 +326,6 @@ func (thc *tabletHealthCheck) checkConn(hc *HealthCheckImpl) {
 			}
 			// trivialUpdate = false because this is an error
 			// up = false because we did not get a healthy response
-			log.Errorf("healthcheck got error for tablet %v : %v", thc.Tablet, err.Error())
 			hc.updateHealth(thc.SimpleCopy(), thc.Target, false, false)
 		}
 		// If there was a timeout send an error. We do this after stream has returned.
@@ -340,7 +337,6 @@ func (thc *tabletHealthCheck) checkConn(hc *HealthCheckImpl) {
 			hcErrorCounters.Add([]string{thc.Target.Keyspace, thc.Target.Shard, topoproto.TabletTypeLString(thc.Target.TabletType)}, 1)
 			// trivialUpdate = false because this is an error
 			// up = false because we did not get a healthy response within the timeout
-			log.Warningf("healthcheck timed out for tablet %v", thc.Tablet)
 			hc.updateHealth(thc.SimpleCopy(), thc.Target, false, false)
 		}
 


### PR DESCRIPTION
…579)"

This reverts commit e0ac1975d3ee820062bd8a4392873412553d6a75.

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

The added logging is too heavy (every 1 second), will think about a different approach.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
