### PR TITLE
`slack-19.0`: refactor support for shard ranges in `--clusters_to_watch`

### DIFF
--- a/go/vt/topo/wildcards.go
+++ b/go/vt/topo/wildcards.go
@@ -24,6 +24,7 @@ import (
 	"context"
 
 	"vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/vterrors"
 
 	"vitess.io/vitess/go/fileutil"
@@ -62,6 +63,10 @@ func (ts *Server) ResolveKeyspaceWildcard(ctx context.Context, param string) ([]
 type KeyspaceShard struct {
 	Keyspace string
 	Shard    string
+}
+
+func (ks KeyspaceShard) String() string {
+	return topoproto.KeyspaceShardString(ks.Keyspace, ks.Shard)
 }
 
 // ResolveShardWildcard will resolve shard wildcards. Both keyspace and shard

--- a/go/vt/vtorc/logic/tablet_discovery.go
+++ b/go/vt/vtorc/logic/tablet_discovery.go
@@ -82,8 +82,8 @@ func refreshAllTablets() {
 	}, false /* forceRefresh */)
 }
 
-// keyRangesContainShard returns true if a slice of key ranges contains the provided shard.
-func keyRangesContainShard(keyRanges []*topodatapb.KeyRange, shard string) (bool, error) {
+// hasShardInKeyRanges returns true if a slice of key ranges contains the provided shard.
+func hasShardInKeyRanges(shard string, keyRanges []*topodatapb.KeyRange) (bool, error) {
 	_, shardKeyRange, err := topo.ValidateShardName(shard)
 	if err != nil {
 		return false, err
@@ -139,7 +139,7 @@ func getKeyspaceShardsToWatch() ([]*topo.KeyspaceShard, error) {
 			}
 
 			for _, s := range shards {
-				if found, err := keyRangesContainShard(watchKeyRanges, s); err != nil {
+				if found, err := hasShardInKeyRanges(s, watchKeyRanges); err != nil {
 					log.Errorf("Failed to parse key ranges for shard %q: %+v", s, err)
 				} else if found {
 					keyspaceShardsMu.Lock()

--- a/go/vt/vtorc/logic/tablet_discovery.go
+++ b/go/vt/vtorc/logic/tablet_discovery.go
@@ -157,6 +157,12 @@ func getKeyspaceShardsToWatch() ([]*topo.KeyspaceShard, error) {
 		return nil, err
 	}
 
+	slices.SortStableFunc(keyspaceShards, func(a, b *topo.KeyspaceShard) int {
+		ksStrA := topoproto.KeyspaceShardString(a.Keyspace, a.Shard)
+		ksStrB := topoproto.KeyspaceShardString(b.Keyspace, b.Shard)
+		return strings.Compare(ksStrA, ksStrB)
+	})
+
 	return keyspaceShards, nil
 }
 

--- a/go/vt/vtorc/logic/tablet_discovery.go
+++ b/go/vt/vtorc/logic/tablet_discovery.go
@@ -158,10 +158,7 @@ func getKeyspaceShardsToWatch() ([]*topo.KeyspaceShard, error) {
 	}
 
 	slices.SortStableFunc(keyspaceShards, func(a, b *topo.KeyspaceShard) int {
-		return strings.Compare(
-			topoproto.KeyspaceShardString(a.Keyspace, a.Shard),
-			topoproto.KeyspaceShardString(b.Keyspace, b.Shard),
-		)
+		return strings.Compare(a.String(), b.String())
 	})
 
 	return keyspaceShards, nil

--- a/go/vt/vtorc/logic/tablet_discovery.go
+++ b/go/vt/vtorc/logic/tablet_discovery.go
@@ -84,7 +84,7 @@ func refreshAllTablets() {
 
 // keyRangesContainShard returns true if a slice of key ranges contains the provided shard.
 func keyRangesContainShard(keyRanges []*topodatapb.KeyRange, shard string) (bool, error) {
-	shard, shardKeyRange, err := topo.ValidateShardName(shard)
+	_, shardKeyRange, err := topo.ValidateShardName(shard)
 	if err != nil {
 		return false, err
 	}

--- a/go/vt/vtorc/logic/tablet_discovery.go
+++ b/go/vt/vtorc/logic/tablet_discovery.go
@@ -158,9 +158,10 @@ func getKeyspaceShardsToWatch() ([]*topo.KeyspaceShard, error) {
 	}
 
 	slices.SortStableFunc(keyspaceShards, func(a, b *topo.KeyspaceShard) int {
-		ksStrA := topoproto.KeyspaceShardString(a.Keyspace, a.Shard)
-		ksStrB := topoproto.KeyspaceShardString(b.Keyspace, b.Shard)
-		return strings.Compare(ksStrA, ksStrB)
+		return strings.Compare(
+			topoproto.KeyspaceShardString(a.Keyspace, a.Shard),
+			topoproto.KeyspaceShardString(b.Keyspace, b.Shard),
+		)
 	})
 
 	return keyspaceShards, nil

--- a/go/vt/vtorc/logic/tablet_discovery_test.go
+++ b/go/vt/vtorc/logic/tablet_discovery_test.go
@@ -19,6 +19,8 @@ package logic
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -395,6 +397,13 @@ func TestGetKeyspaceShardsToWatch(t *testing.T) {
 		t.Run(testcase.name, func(t *testing.T) {
 			clustersToWatch = testcase.clusters
 			res, err := getKeyspaceShardsToWatch()
+
+			slices.SortStableFunc(res, func(a, b *topo.KeyspaceShard) int {
+				return strings.Compare(a.String(), b.String())
+			})
+			slices.SortStableFunc(testcase.expected, func(a, b *topo.KeyspaceShard) int {
+				return strings.Compare(a.String(), b.String())
+			})
 
 			assert.NoError(t, err)
 			assert.ElementsMatch(t, testcase.expected, res)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
