### PR TITLE
Always include one non-local target during discovery

### DIFF
--- a/go/vt/vtgateproxy/discovery.go
+++ b/go/vt/vtgateproxy/discovery.go
@@ -323,7 +323,9 @@ func (b *JSONGateResolverBuilder) parse() (bool, error) {
 	for poolType := range targets {
 		b.sorter.shuffleSort(targets[poolType], b.affinityField, b.affinityValue)
 		if len(targets[poolType]) > *numConnections {
-			targets[poolType] = targets[poolType][:b.numConnections]
+			// Always grab one non-local target to protect against a complete local failure.
+			nonLocal := targets[poolType][len(targets[poolType])-1]
+			targets[poolType] = append(targets[poolType][:b.numConnections], nonLocal)
 		}
 		targetCount.Set(poolType, int64(len(targets[poolType])))
 	}


### PR DESCRIPTION
In case an entire AZ, or other affinity group, fails at once it's useful to have one backup target in another AZ. So let's grab one every time we set the targets for a given pool. The target should be shuffle-sorted to the end of the target list, so in the normal state it should never get used.