### PR TITLE
vtgateproxy: sticky random balancer and remote zone backup connections

### DIFF
--- a/go/vt/vtgateproxy/discovery.go
+++ b/go/vt/vtgateproxy/discovery.go
@@ -491,12 +491,13 @@ const (
 </style>
 <table>
 {{range $i, $p := .Pools}}  <tr>
-    <th colspan="3">{{$p}}</th>
+    <th colspan="4">{{$p}}</th>
   </tr>
 {{range index $.Targets $p}}  <tr>
 	<td>{{.Hostname}}</td>
 	<td>{{.Addr}}</td>
     <td>{{.Affinity}}</td>
+    <td>{{.IsLocal}}</td>
   </tr>{{end}}
 {{end}}
 </table>

--- a/go/vt/vtgateproxy/firstready_balancer.go
+++ b/go/vt/vtgateproxy/firstready_balancer.go
@@ -41,12 +41,13 @@ import (
 )
 
 // newBuilder creates a new first_ready balancer builder.
-func newBuilder() balancer.Builder {
+func newFirstReadyBuilder() balancer.Builder {
 	return base.NewBalancerBuilder("first_ready", &frPickerBuilder{currentConns: map[string]balancer.SubConn{}}, base.Config{HealthCheck: true})
 }
 
 func init() {
-	balancer.Register(newBuilder())
+	log.V(1).Infof("registering first_ready balancer")
+	balancer.Register(newFirstReadyBuilder())
 }
 
 // frPickerBuilder implements both the Builder and the Picker interfaces.

--- a/go/vt/vtgateproxy/mysql_server.go
+++ b/go/vt/vtgateproxy/mysql_server.go
@@ -201,6 +201,7 @@ func (ph *proxyHandler) ComQuery(c *mysql.Conn, query string, callback func(*sql
 		return mysql.NewSQLErrorFromError(err)
 	}
 
+	ctx = context.WithValue(ctx, CONN_ID_KEY, int(c.ConnectionID))
 	result, err := ph.proxy.Execute(ctx, session, query, make(map[string]*querypb.BindVariable))
 
 	if err := mysql.NewSQLErrorFromError(err); err != nil {

--- a/go/vt/vtgateproxy/sim/vtgateproxysim.go
+++ b/go/vt/vtgateproxy/sim/vtgateproxysim.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"math/rand"
+	"sort"
+	"time"
+
+	"github.com/guptarohit/asciigraph"
+)
+
+var (
+	numClients     = flag.Int("c", 9761, "Number of clients")
+	numVtgates     = flag.Int("v", 1068, "Number of vtgates")
+	numConnections = flag.Int("n", 4, "number of connections per client host")
+	numZones       = flag.Int("z", 4, "number of zones")
+)
+
+func main() {
+	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	flag.Parse()
+
+	fmt.Printf("Simulating %d clients => %d vtgates with %d zones %d conns per client\n\n",
+		*numClients, *numVtgates, *numZones, *numConnections)
+
+	var clients []string
+	for i := 0; i < *numClients; i++ {
+		clients = append(clients, fmt.Sprintf("client-%03d", i))
+	}
+
+	var vtgates []string
+	for i := 0; i < *numVtgates; i++ {
+		vtgates = append(vtgates, fmt.Sprintf("vtgate-%03d", i))
+	}
+
+	// for now just consider 1/N of the s "local"
+	localClients := clients[:*numClients / *numZones]
+	localVtgates := vtgates[:*numVtgates / *numZones]
+
+	conns := map[string][]string{}
+
+	// Simulate "discovery"
+	for _, client := range localClients {
+		var clientConns []string
+
+		for i := 0; i < *numConnections; i++ {
+			vtgate := localVtgates[rnd.Intn(len(localVtgates))]
+			clientConns = append(clientConns, vtgate)
+		}
+
+		conns[client] = clientConns
+	}
+
+	counts := map[string]int{}
+	for _, conns := range conns {
+		for _, vtgate := range conns {
+			counts[vtgate]++
+		}
+	}
+
+	histogram := map[int]int{}
+	max := 0
+	min := -1
+	for _, count := range counts {
+		histogram[count]++
+		if count > max {
+			max = count
+		}
+		if min == -1 || count < min {
+			min = count
+		}
+	}
+
+	fmt.Printf("Conns per vtgate\n%v\n\n", counts)
+	fmt.Printf("Histogram of conn counts\n%v\n\n", histogram)
+
+	plot := []float64{}
+	for i := 0; i < len(localVtgates); i++ {
+		plot = append(plot, float64(counts[localVtgates[i]]))
+	}
+	sort.Float64s(plot)
+	graph := asciigraph.Plot(plot)
+	fmt.Println("Number of conns per vtgate host")
+	fmt.Println(graph)
+	fmt.Println("")
+	fmt.Println("")
+
+	fmt.Printf("Conn count per vtgate distribution [%d - %d] (%d clients => %d vtgates with %d zones %d conns\n\n",
+		min, max, *numClients, *numVtgates, *numZones, *numConnections)
+	plot = []float64{}
+	for i := min; i < max; i++ {
+		plot = append(plot, float64(histogram[i]))
+	}
+	graph = asciigraph.Plot(plot)
+	fmt.Println(graph)
+
+	fmt.Printf("\nConn stats: min %d max %d spread %d spread/min %f spread/avg %f\n",
+		min, max, max-min, float64(max-min)/float64(min), float64(max-min)/float64((max+min)/2))
+}

--- a/go/vt/vtgateproxy/sticky_random_balancer.go
+++ b/go/vt/vtgateproxy/sticky_random_balancer.go
@@ -1,0 +1,82 @@
+/*
+ *
+ * Copyright 2017 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Sticky random is a derivative based on the round_robin balancer which uses a Context
+// variable to maintain client-side affinity to a given connection.
+
+package vtgateproxy
+
+import (
+	"math/rand/v2"
+
+	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/balancer/base"
+	"google.golang.org/grpc/grpclog"
+)
+
+type ConnIdKey string
+
+const CONN_ID_KEY = ConnIdKey("ConnId")
+
+const Name = "sticky_random"
+
+var logger = grpclog.Component("sticky_random")
+
+// newBuilder creates a new roundrobin balancer builder.
+func newStickyRandomBuilder() balancer.Builder {
+	return base.NewBalancerBuilder(Name, &stickyPickerBuilder{}, base.Config{HealthCheck: true})
+}
+
+func init() {
+	balancer.Register(newStickyRandomBuilder())
+}
+
+type stickyPickerBuilder struct{}
+
+func (*stickyPickerBuilder) Build(info base.PickerBuildInfo) balancer.Picker {
+	logger.Infof("stickyRandomPicker: Build called with info: %v", info)
+	if len(info.ReadySCs) == 0 {
+		return base.NewErrPicker(balancer.ErrNoSubConnAvailable)
+	}
+	scs := make([]balancer.SubConn, 0, len(info.ReadySCs))
+	for sc := range info.ReadySCs {
+		scs = append(scs, sc)
+	}
+	return &stickyPicker{
+		subConns: scs,
+	}
+}
+
+type stickyPicker struct {
+	// subConns is the snapshot of the  balancer when this picker was
+	// created. The slice is immutable.
+	subConns []balancer.SubConn
+}
+
+func (p *stickyPicker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
+
+	subConnsLen := len(p.subConns)
+
+	connId := info.Ctx.Value(CONN_ID_KEY).(int)
+	if connId == 0 {
+		connId = rand.IntN(subConnsLen) // shouldn't happen
+	}
+
+	sc := p.subConns[connId%subConnsLen]
+	return balancer.PickResult{SubConn: sc}, nil
+}

--- a/go/vt/vtgateproxy/vtgateproxy.go
+++ b/go/vt/vtgateproxy/vtgateproxy.go
@@ -53,6 +53,7 @@ const (
 var (
 	vtgateHostsFile = flag.String("vtgate_hosts_file", "", "json file describing the host list to use for vtgate:// resolution")
 	numConnections  = flag.Int("num_connections", 4, "number of outbound GPRC connections to maintain")
+	numBackupConns  = flag.Int("num_backup_conns", 1, "number of backup remote-zone GPRC connections to maintain")
 	poolTypeField   = flag.String("pool_type_field", "", "Field name used to specify the target vtgate type and filter the hosts")
 	affinityField   = flag.String("affinity_field", "", "Attribute (JSON file) used to specify the routing affinity , e.g. 'az_id'")
 	affinityValue   = flag.String("affinity_value", "", "Value to match for routing affinity , e.g. 'use-az1'")
@@ -233,6 +234,7 @@ func Init() {
 		*affinityField,
 		*affinityValue,
 		*numConnections,
+		*numBackupConns,
 	)
 
 	if err != nil {

--- a/go/vt/vtgateproxy/vtgateproxy.go
+++ b/go/vt/vtgateproxy/vtgateproxy.go
@@ -215,6 +215,7 @@ func Init() {
 	case "round_robin":
 	case "first_ready":
 	case "pick_first":
+	case "sticky_random":
 		break
 	default:
 		log.Fatalf("invalid balancer type %s", *balancerType)


### PR DESCRIPTION
## Description
Implement a couple improvements to the vtgateproxy to support:

* New sticky_random load balancer which implements round robin over connections while maintaining the mapping from a given webapp mysql connection to a given downstream GRPC.
* Add support to discovery of a new `--num_backup_connections` option to include of vtgates in _remote_ zones
* Respect the zone locality in the picker so that we bias towards local connections if available and only fall back if needed.

## Testing
Verified in dev by forcing a webapp host to use a hand-built proxy running on localhost

Running the client and looking at /channelz/ shows that sticky_random only uses the local conns when they're available.

Also verified that it's now picking one backup conn by including that in the debug output:
<img width="762" alt="image" src="https://github.com/user-attachments/assets/586bfa4c-4544-4a31-a4fb-28953924ebf7" />
