### PR TITLE
`slack-19.0`: topo efficiency backports for `vtorc`, pt. 2

### DIFF
--- a/go/flags/endtoend/vtbackup.txt
+++ b/go/flags/endtoend/vtbackup.txt
@@ -235,6 +235,7 @@ Flags:
       --topo_global_root string                                     the path of the global topology data in the global topology server
       --topo_global_server_address string                           the address of the global topology server
       --topo_implementation string                                  the topology implementation to use
+      --topo_read_concurrency int                                   Maximum concurrency of topo reads per global or local cell. (default 32)
       --topo_zk_auth_file string                                    auth to use when connecting to the zk topo server, file contents should be <scheme>:<auth>, e.g., digest:user:pass
       --topo_zk_base_timeout duration                               zk base timeout (see zk.Connect) (default 30s)
       --topo_zk_max_concurrency int                                 maximum number of pending requests to send to a Zookeeper server. (default 64)

--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -379,7 +379,7 @@ Flags:
       --topo_global_root string                                          the path of the global topology data in the global topology server
       --topo_global_server_address string                                the address of the global topology server
       --topo_implementation string                                       the topology implementation to use
-      --topo_read_concurrency int                                        Concurrency of topo reads. (default 32)
+      --topo_read_concurrency int                                        Maximum concurrency of topo reads per global or local cell. (default 32)
       --topo_zk_auth_file string                                         auth to use when connecting to the zk topo server, file contents should be <scheme>:<auth>, e.g., digest:user:pass
       --topo_zk_base_timeout duration                                    zk base timeout (see zk.Connect) (default 30s)
       --topo_zk_max_concurrency int                                      maximum number of pending requests to send to a Zookeeper server. (default 64)

--- a/go/flags/endtoend/vtctld.txt
+++ b/go/flags/endtoend/vtctld.txt
@@ -169,7 +169,7 @@ Flags:
       --topo_global_root string                                          the path of the global topology data in the global topology server
       --topo_global_server_address string                                the address of the global topology server
       --topo_implementation string                                       the topology implementation to use
-      --topo_read_concurrency int                                        Concurrency of topo reads. (default 32)
+      --topo_read_concurrency int                                        Maximum concurrency of topo reads per global or local cell. (default 32)
       --topo_zk_auth_file string                                         auth to use when connecting to the zk topo server, file contents should be <scheme>:<auth>, e.g., digest:user:pass
       --topo_zk_base_timeout duration                                    zk base timeout (see zk.Connect) (default 30s)
       --topo_zk_max_concurrency int                                      maximum number of pending requests to send to a Zookeeper server. (default 64)

--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -227,7 +227,7 @@ Flags:
       --topo_global_root string                                          the path of the global topology data in the global topology server
       --topo_global_server_address string                                the address of the global topology server
       --topo_implementation string                                       the topology implementation to use
-      --topo_read_concurrency int                                        Concurrency of topo reads. (default 32)
+      --topo_read_concurrency int                                        Maximum concurrency of topo reads per global or local cell. (default 32)
       --topo_zk_auth_file string                                         auth to use when connecting to the zk topo server, file contents should be <scheme>:<auth>, e.g., digest:user:pass
       --topo_zk_base_timeout duration                                    zk base timeout (see zk.Connect) (default 30s)
       --topo_zk_max_concurrency int                                      maximum number of pending requests to send to a Zookeeper server. (default 64)

--- a/go/flags/endtoend/vtorc.txt
+++ b/go/flags/endtoend/vtorc.txt
@@ -107,7 +107,7 @@ Flags:
       --topo_global_root string                                     the path of the global topology data in the global topology server
       --topo_global_server_address string                           the address of the global topology server
       --topo_implementation string                                  the topology implementation to use
-      --topo_read_concurrency int                                   Concurrency of topo reads. (default 32)
+      --topo_read_concurrency int                                   Maximum concurrency of topo reads per global or local cell. (default 32)
       --topo_zk_auth_file string                                    auth to use when connecting to the zk topo server, file contents should be <scheme>:<auth>, e.g., digest:user:pass
       --topo_zk_base_timeout duration                               zk base timeout (see zk.Connect) (default 30s)
       --topo_zk_max_concurrency int                                 maximum number of pending requests to send to a Zookeeper server. (default 64)

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -381,6 +381,7 @@ Flags:
       --topo_global_root string                                          the path of the global topology data in the global topology server
       --topo_global_server_address string                                the address of the global topology server
       --topo_implementation string                                       the topology implementation to use
+      --topo_read_concurrency int                                        Maximum concurrency of topo reads per global or local cell. (default 32)
       --topo_zk_auth_file string                                         auth to use when connecting to the zk topo server, file contents should be <scheme>:<auth>, e.g., digest:user:pass
       --topo_zk_base_timeout duration                                    zk base timeout (see zk.Connect) (default 30s)
       --topo_zk_max_concurrency int                                      maximum number of pending requests to send to a Zookeeper server. (default 64)

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -381,7 +381,7 @@ func NewHealthCheck(ctx context.Context, retryDelay, healthCheckTimeout time.Dur
 		if c == "" {
 			continue
 		}
-		topoWatchers = append(topoWatchers, NewTopologyWatcher(ctx, topoServer, hc, filters, c, refreshInterval, refreshKnownTablets, topo.DefaultConcurrency))
+		topoWatchers = append(topoWatchers, NewTopologyWatcher(ctx, topoServer, hc, filters, c, refreshInterval, refreshKnownTablets))
 	}
 
 	hc.topoWatchers = topoWatchers

--- a/go/vt/discovery/topology_watcher_test.go
+++ b/go/vt/discovery/topology_watcher_test.go
@@ -67,7 +67,7 @@ func TestStartAndCloseTopoWatcher(t *testing.T) {
 	fhc := NewFakeHealthCheck(nil)
 	defer fhc.Close()
 	topologyWatcherOperations.ZeroAll()
-	tw := NewTopologyWatcher(context.Background(), ts, fhc, nil, "aa", 100*time.Microsecond, true, 5)
+	tw := NewTopologyWatcher(context.Background(), ts, fhc, nil, "aa", 100*time.Microsecond, true)
 
 	done := make(chan bool, 3)
 	result := make(chan bool, 1)
@@ -127,7 +127,7 @@ func checkWatcher(t *testing.T, refreshKnownTablets bool) {
 	logger := logutil.NewMemoryLogger()
 	topologyWatcherOperations.ZeroAll()
 	counts := topologyWatcherOperations.Counts()
-	tw := NewTopologyWatcher(context.Background(), ts, fhc, filter, "aa", 10*time.Minute, refreshKnownTablets, 5)
+	tw := NewTopologyWatcher(context.Background(), ts, fhc, filter, "aa", 10*time.Minute, refreshKnownTablets)
 
 	counts = checkOpCounts(t, counts, map[string]int64{})
 	checkChecksum(t, tw, 0)
@@ -421,7 +421,7 @@ func TestFilterByKeyspace(t *testing.T) {
 	f := TabletFilters{NewFilterByKeyspace(testKeyspacesToWatch)}
 	ts := memorytopo.NewServer(ctx, testCell)
 	defer ts.Close()
-	tw := NewTopologyWatcher(context.Background(), ts, hc, f, testCell, 10*time.Minute, true, 5)
+	tw := NewTopologyWatcher(context.Background(), ts, hc, f, testCell, 10*time.Minute, true)
 
 	for _, test := range testFilterByKeyspace {
 		// Add a new tablet to the topology.
@@ -502,7 +502,7 @@ func TestFilterByKeyspaceSkipsIgnoredTablets(t *testing.T) {
 	topologyWatcherOperations.ZeroAll()
 	counts := topologyWatcherOperations.Counts()
 	f := TabletFilters{NewFilterByKeyspace(testKeyspacesToWatch)}
-	tw := NewTopologyWatcher(context.Background(), ts, fhc, f, "aa", 10*time.Minute, false /*refreshKnownTablets*/, 5)
+	tw := NewTopologyWatcher(context.Background(), ts, fhc, f, "aa", 10*time.Minute, false /*refreshKnownTablets*/)
 
 	counts = checkOpCounts(t, counts, map[string]int64{})
 	checkChecksum(t, tw, 0)
@@ -639,7 +639,7 @@ func TestGetTabletErrorDoesNotRemoveFromHealthcheck(t *testing.T) {
 	defer fhc.Close()
 	topologyWatcherOperations.ZeroAll()
 	counts := topologyWatcherOperations.Counts()
-	tw := NewTopologyWatcher(context.Background(), ts, fhc, nil, "aa", 10*time.Minute, true, 5)
+	tw := NewTopologyWatcher(context.Background(), ts, fhc, nil, "aa", 10*time.Minute, true)
 	defer tw.Stop()
 
 	// Force fallback to getting tablets individually.

--- a/go/vt/topo/shard.go
+++ b/go/vt/topo/shard.go
@@ -671,16 +671,8 @@ func (ts *Server) GetTabletsByShardCell(ctx context.Context, keyspace, shard str
 		}
 	}
 
-	// Divide the concurrency limit by the number of cells. If there are more
-	// cells than the limit, default to concurrency of 1.
-	cellConcurrency := 1
-	if len(cells) < DefaultConcurrency {
-		cellConcurrency = DefaultConcurrency / len(cells)
-	}
-
 	mu := sync.Mutex{}
 	eg, ctx := errgroup.WithContext(ctx)
-	eg.SetLimit(DefaultConcurrency)
 
 	tablets := make([]*TabletInfo, 0, len(cells))
 	var kss *KeyspaceShard
@@ -691,7 +683,6 @@ func (ts *Server) GetTabletsByShardCell(ctx context.Context, keyspace, shard str
 		}
 	}
 	options := &GetTabletsByCellOptions{
-		Concurrency:   cellConcurrency,
 		KeyspaceShard: kss,
 	}
 	for _, cell := range cells {

--- a/go/vt/topo/stats_conn.go
+++ b/go/vt/topo/stats_conn.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"time"
 
+	"golang.org/x/sync/semaphore"
+
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
@@ -37,6 +39,11 @@ var (
 		"TopologyConnErrors",
 		"TopologyConnErrors errors per operation",
 		[]string{"Operation", "Cell"})
+
+	topoStatsConnReadWaitTimings = stats.NewMultiTimings(
+		"TopologyConnReadWaits",
+		"TopologyConnReadWait timings",
+		[]string{"Operation", "Cell"})
 )
 
 const readOnlyErrorStrFormat = "cannot perform %s on %s as the topology server connection is read-only"
@@ -46,14 +53,16 @@ type StatsConn struct {
 	cell     string
 	conn     Conn
 	readOnly bool
+	readSem  *semaphore.Weighted
 }
 
 // NewStatsConn returns a StatsConn
-func NewStatsConn(cell string, conn Conn) *StatsConn {
+func NewStatsConn(cell string, conn Conn, readSem *semaphore.Weighted) *StatsConn {
 	return &StatsConn{
 		cell:     cell,
 		conn:     conn,
 		readOnly: false,
+		readSem:  readSem,
 	}
 }
 
@@ -61,6 +70,12 @@ func NewStatsConn(cell string, conn Conn) *StatsConn {
 func (st *StatsConn) ListDir(ctx context.Context, dirPath string, full bool) ([]DirEntry, error) {
 	startTime := time.Now()
 	statsKey := []string{"ListDir", st.cell}
+	if err := st.readSem.Acquire(ctx, 1); err != nil {
+		return nil, err
+	}
+	defer st.readSem.Release(1)
+	topoStatsConnReadWaitTimings.Record(statsKey, startTime)
+	startTime = time.Now() // reset
 	defer topoStatsConnTimings.Record(statsKey, startTime)
 	res, err := st.conn.ListDir(ctx, dirPath, full)
 	if err != nil {
@@ -106,6 +121,12 @@ func (st *StatsConn) Update(ctx context.Context, filePath string, contents []byt
 func (st *StatsConn) Get(ctx context.Context, filePath string) ([]byte, Version, error) {
 	startTime := time.Now()
 	statsKey := []string{"Get", st.cell}
+	if err := st.readSem.Acquire(ctx, 1); err != nil {
+		return nil, nil, err
+	}
+	defer st.readSem.Release(1)
+	topoStatsConnReadWaitTimings.Record(statsKey, startTime)
+	startTime = time.Now() // reset
 	defer topoStatsConnTimings.Record(statsKey, startTime)
 	bytes, version, err := st.conn.Get(ctx, filePath)
 	if err != nil {
@@ -119,6 +140,12 @@ func (st *StatsConn) Get(ctx context.Context, filePath string) ([]byte, Version,
 func (st *StatsConn) List(ctx context.Context, filePathPrefix string) ([]KVInfo, error) {
 	startTime := time.Now()
 	statsKey := []string{"List", st.cell}
+	if err := st.readSem.Acquire(ctx, 1); err != nil {
+		return nil, err
+	}
+	defer st.readSem.Release(1)
+	topoStatsConnReadWaitTimings.Record(statsKey, startTime)
+	startTime = time.Now() // reset
 	defer topoStatsConnTimings.Record(statsKey, startTime)
 	bytes, err := st.conn.List(ctx, filePathPrefix)
 	if err != nil {

--- a/go/vt/topo/stats_conn_test.go
+++ b/go/vt/topo/stats_conn_test.go
@@ -20,10 +20,15 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
+
+	"golang.org/x/sync/semaphore"
 
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
 )
+
+var testStatsConnReadSem = semaphore.NewWeighted(1)
 
 // The fakeConn is a wrapper for a Conn that emits stats for every operation
 type fakeConn struct {
@@ -150,16 +155,31 @@ func (st *fakeConn) IsReadOnly() bool {
 	return st.readOnly
 }
 
+// createTestReadSemaphoreContention simulates semaphore contention on the test read semaphore.
+func createTestReadSemaphoreContention(ctx context.Context, duration time.Duration) {
+	if err := testStatsConnReadSem.Acquire(ctx, 1); err != nil {
+		panic(err)
+	}
+	defer testStatsConnReadSem.Release(1)
+	time.Sleep(duration)
+}
+
 // TestStatsConnTopoListDir emits stats on ListDir
 func TestStatsConnTopoListDir(t *testing.T) {
 	conn := &fakeConn{}
-	statsConn := NewStatsConn("global", conn)
+	statsConn := NewStatsConn("global", conn, testStatsConnReadSem)
 	ctx := context.Background()
 
+	go createTestReadSemaphoreContention(ctx, 100*time.Millisecond)
 	statsConn.ListDir(ctx, "", true)
 	timingCounts := topoStatsConnTimings.Counts()["ListDir.global"]
 	if got, want := timingCounts, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
+	}
+
+	waitTimingsCounts := topoStatsConnReadWaitTimings.Counts()["ListDir.global"]
+	if got := waitTimingsCounts; got != 1 {
+		t.Errorf("stats were not properly recorded: got = %d, want = 1", got)
 	}
 
 	// error is zero before getting an error
@@ -180,7 +200,7 @@ func TestStatsConnTopoListDir(t *testing.T) {
 // TestStatsConnTopoCreate emits stats on Create
 func TestStatsConnTopoCreate(t *testing.T) {
 	conn := &fakeConn{}
-	statsConn := NewStatsConn("global", conn)
+	statsConn := NewStatsConn("global", conn, testStatsConnReadSem)
 	ctx := context.Background()
 
 	statsConn.Create(ctx, "", []byte{})
@@ -207,7 +227,7 @@ func TestStatsConnTopoCreate(t *testing.T) {
 // TestStatsConnTopoUpdate emits stats on Update
 func TestStatsConnTopoUpdate(t *testing.T) {
 	conn := &fakeConn{}
-	statsConn := NewStatsConn("global", conn)
+	statsConn := NewStatsConn("global", conn, testStatsConnReadSem)
 	ctx := context.Background()
 
 	statsConn.Update(ctx, "", []byte{}, conn.v)
@@ -234,13 +254,19 @@ func TestStatsConnTopoUpdate(t *testing.T) {
 // TestStatsConnTopoGet emits stats on Get
 func TestStatsConnTopoGet(t *testing.T) {
 	conn := &fakeConn{}
-	statsConn := NewStatsConn("global", conn)
+	statsConn := NewStatsConn("global", conn, testStatsConnReadSem)
 	ctx := context.Background()
 
+	go createTestReadSemaphoreContention(ctx, time.Millisecond*100)
 	statsConn.Get(ctx, "")
 	timingCounts := topoStatsConnTimings.Counts()["Get.global"]
 	if got, want := timingCounts, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
+	}
+
+	waitTimingsCounts := topoStatsConnReadWaitTimings.Counts()["Get.global"]
+	if got := waitTimingsCounts; got != 1 {
+		t.Errorf("stats were not properly recorded: got = %d, want = 1", got)
 	}
 
 	// error is zero before getting an error
@@ -261,7 +287,7 @@ func TestStatsConnTopoGet(t *testing.T) {
 // TestStatsConnTopoDelete emits stats on Delete
 func TestStatsConnTopoDelete(t *testing.T) {
 	conn := &fakeConn{}
-	statsConn := NewStatsConn("global", conn)
+	statsConn := NewStatsConn("global", conn, testStatsConnReadSem)
 	ctx := context.Background()
 
 	statsConn.Delete(ctx, "", conn.v)
@@ -288,7 +314,7 @@ func TestStatsConnTopoDelete(t *testing.T) {
 // TestStatsConnTopoLock emits stats on Lock
 func TestStatsConnTopoLock(t *testing.T) {
 	conn := &fakeConn{}
-	statsConn := NewStatsConn("global", conn)
+	statsConn := NewStatsConn("global", conn, testStatsConnReadSem)
 	ctx := context.Background()
 
 	statsConn.Lock(ctx, "", "")
@@ -315,7 +341,7 @@ func TestStatsConnTopoLock(t *testing.T) {
 // TestStatsConnTopoWatch emits stats on Watch
 func TestStatsConnTopoWatch(t *testing.T) {
 	conn := &fakeConn{}
-	statsConn := NewStatsConn("global", conn)
+	statsConn := NewStatsConn("global", conn, testStatsConnReadSem)
 	ctx := context.Background()
 
 	statsConn.Watch(ctx, "")
@@ -329,7 +355,7 @@ func TestStatsConnTopoWatch(t *testing.T) {
 // TestStatsConnTopoNewLeaderParticipation emits stats on NewLeaderParticipation
 func TestStatsConnTopoNewLeaderParticipation(t *testing.T) {
 	conn := &fakeConn{}
-	statsConn := NewStatsConn("global", conn)
+	statsConn := NewStatsConn("global", conn, testStatsConnReadSem)
 
 	_, _ = statsConn.NewLeaderParticipation("", "")
 	timingCounts := topoStatsConnTimings.Counts()["NewLeaderParticipation.global"]
@@ -355,7 +381,7 @@ func TestStatsConnTopoNewLeaderParticipation(t *testing.T) {
 // TestStatsConnTopoClose emits stats on Close
 func TestStatsConnTopoClose(t *testing.T) {
 	conn := &fakeConn{}
-	statsConn := NewStatsConn("global", conn)
+	statsConn := NewStatsConn("global", conn, testStatsConnReadSem)
 
 	statsConn.Close()
 	timingCounts := topoStatsConnTimings.Counts()["Close.global"]

--- a/go/vt/topo/tablet_test.go
+++ b/go/vt/topo/tablet_test.go
@@ -69,7 +69,6 @@ func TestServerGetTabletsByCell(t *testing.T) {
 				},
 			},
 			// Ensure this doesn't panic.
-			opt: &topo.GetTabletsByCellOptions{Concurrency: -1},
 		},
 		{
 			name: "single",
@@ -151,7 +150,6 @@ func TestServerGetTabletsByCell(t *testing.T) {
 					Shard:    shard,
 				},
 			},
-			opt: &topo.GetTabletsByCellOptions{Concurrency: 8},
 		},
 		{
 			name: "multiple with list error",
@@ -210,7 +208,6 @@ func TestServerGetTabletsByCell(t *testing.T) {
 					Shard:    shard,
 				},
 			},
-			opt:       &topo.GetTabletsByCellOptions{Concurrency: 8},
 			listError: topo.NewError(topo.ResourceExhausted, ""),
 		},
 		{
@@ -249,7 +246,6 @@ func TestServerGetTabletsByCell(t *testing.T) {
 				},
 			},
 			opt: &topo.GetTabletsByCellOptions{
-				Concurrency: 1,
 				KeyspaceShard: &topo.KeyspaceShard{
 					Keyspace: keyspace,
 					Shard:    shard,
@@ -317,7 +313,6 @@ func TestServerGetTabletsByCell(t *testing.T) {
 				},
 			},
 			opt: &topo.GetTabletsByCellOptions{
-				Concurrency: 1,
 				KeyspaceShard: &topo.KeyspaceShard{
 					Keyspace: keyspace,
 					Shard:    "",

--- a/go/vt/topo/wildcards.go
+++ b/go/vt/topo/wildcards.go
@@ -24,6 +24,7 @@ import (
 	"context"
 
 	"vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/vterrors"
 
 	"vitess.io/vitess/go/fileutil"
@@ -62,6 +63,10 @@ func (ts *Server) ResolveKeyspaceWildcard(ctx context.Context, param string) ([]
 type KeyspaceShard struct {
 	Keyspace string
 	Shard    string
+}
+
+func (ks KeyspaceShard) String() string {
+	return topoproto.KeyspaceShardString(ks.Keyspace, ks.Shard)
 }
 
 // ResolveShardWildcard will resolve shard wildcards. Both keyspace and shard

--- a/go/vt/vtorc/logic/tablet_discovery.go
+++ b/go/vt/vtorc/logic/tablet_discovery.go
@@ -210,7 +210,7 @@ func refreshTabletsUsing(loader func(tabletAlias string), forceRefresh bool) {
 }
 
 func refreshTabletsInCell(ctx context.Context, cell string, loader func(tabletAlias string), forceRefresh bool) {
-	tablets, err := ts.GetTabletsByCell(ctx, cell, &topo.GetTabletsByCellOptions{Concurrency: topo.DefaultConcurrency})
+	tablets, err := ts.GetTabletsByCell(ctx, cell, nil)
 	if err != nil {
 		log.Errorf("Error fetching topo info for cell %v: %v", cell, err)
 		return

--- a/go/vt/vtorc/logic/tablet_discovery.go
+++ b/go/vt/vtorc/logic/tablet_discovery.go
@@ -82,8 +82,8 @@ func refreshAllTablets() {
 	}, false /* forceRefresh */)
 }
 
-// keyRangesContainShard returns true if a slice of key ranges contains the provided shard.
-func keyRangesContainShard(keyRanges []*topodatapb.KeyRange, shard string) (bool, error) {
+// hasShardInKeyRanges returns true if a slice of key ranges contains the provided shard.
+func hasShardInKeyRanges(shard string, keyRanges []*topodatapb.KeyRange) (bool, error) {
 	_, shardKeyRange, err := topo.ValidateShardName(shard)
 	if err != nil {
 		return false, err
@@ -139,7 +139,7 @@ func getKeyspaceShardsToWatch() ([]*topo.KeyspaceShard, error) {
 			}
 
 			for _, s := range shards {
-				if found, err := keyRangesContainShard(watchKeyRanges, s); err != nil {
+				if found, err := hasShardInKeyRanges(s, watchKeyRanges); err != nil {
 					log.Errorf("Failed to parse key ranges for shard %q: %+v", s, err)
 				} else if found {
 					keyspaceShardsMu.Lock()

--- a/go/vt/vtorc/logic/tablet_discovery.go
+++ b/go/vt/vtorc/logic/tablet_discovery.go
@@ -157,6 +157,12 @@ func getKeyspaceShardsToWatch() ([]*topo.KeyspaceShard, error) {
 		return nil, err
 	}
 
+	slices.SortStableFunc(keyspaceShards, func(a, b *topo.KeyspaceShard) int {
+		ksStrA := topoproto.KeyspaceShardString(a.Keyspace, a.Shard)
+		ksStrB := topoproto.KeyspaceShardString(b.Keyspace, b.Shard)
+		return strings.Compare(ksStrA, ksStrB)
+	})
+
 	return keyspaceShards, nil
 }
 

--- a/go/vt/vtorc/logic/tablet_discovery.go
+++ b/go/vt/vtorc/logic/tablet_discovery.go
@@ -158,10 +158,7 @@ func getKeyspaceShardsToWatch() ([]*topo.KeyspaceShard, error) {
 	}
 
 	slices.SortStableFunc(keyspaceShards, func(a, b *topo.KeyspaceShard) int {
-		return strings.Compare(
-			topoproto.KeyspaceShardString(a.Keyspace, a.Shard),
-			topoproto.KeyspaceShardString(b.Keyspace, b.Shard),
-		)
+		return strings.Compare(a.String(), b.String())
 	})
 
 	return keyspaceShards, nil

--- a/go/vt/vtorc/logic/tablet_discovery.go
+++ b/go/vt/vtorc/logic/tablet_discovery.go
@@ -84,7 +84,7 @@ func refreshAllTablets() {
 
 // keyRangesContainShard returns true if a slice of key ranges contains the provided shard.
 func keyRangesContainShard(keyRanges []*topodatapb.KeyRange, shard string) (bool, error) {
-	shard, shardKeyRange, err := topo.ValidateShardName(shard)
+	_, shardKeyRange, err := topo.ValidateShardName(shard)
 	if err != nil {
 		return false, err
 	}

--- a/go/vt/vtorc/logic/tablet_discovery.go
+++ b/go/vt/vtorc/logic/tablet_discovery.go
@@ -158,9 +158,10 @@ func getKeyspaceShardsToWatch() ([]*topo.KeyspaceShard, error) {
 	}
 
 	slices.SortStableFunc(keyspaceShards, func(a, b *topo.KeyspaceShard) int {
-		ksStrA := topoproto.KeyspaceShardString(a.Keyspace, a.Shard)
-		ksStrB := topoproto.KeyspaceShardString(b.Keyspace, b.Shard)
-		return strings.Compare(ksStrA, ksStrB)
+		return strings.Compare(
+			topoproto.KeyspaceShardString(a.Keyspace, a.Shard),
+			topoproto.KeyspaceShardString(b.Keyspace, b.Shard),
+		)
 	})
 
 	return keyspaceShards, nil

--- a/go/vt/vtorc/logic/tablet_discovery_test.go
+++ b/go/vt/vtorc/logic/tablet_discovery_test.go
@@ -19,6 +19,8 @@ package logic
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -395,6 +397,13 @@ func TestGetKeyspaceShardsToWatch(t *testing.T) {
 		t.Run(testcase.name, func(t *testing.T) {
 			clustersToWatch = testcase.clusters
 			res, err := getKeyspaceShardsToWatch()
+
+			slices.SortStableFunc(res, func(a, b *topo.KeyspaceShard) int {
+				return strings.Compare(a.String(), b.String())
+			})
+			slices.SortStableFunc(testcase.expected, func(a, b *topo.KeyspaceShard) int {
+				return strings.Compare(a.String(), b.String())
+			})
 
 			assert.NoError(t, err)
 			assert.ElementsMatch(t, testcase.expected, res)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
