### PR TITLE
`slack-19.0`: skip tests that will fail on v15 downgrade testing

### DIFF
--- a/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
+++ b/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
@@ -116,12 +116,16 @@ func TestGroupBy(t *testing.T) {
 	mcmp.Exec("insert into t3(id5, id6, id7) values(1,1,2), (2,2,4), (3,2,4), (4,1,2), (5,1,2), (6,3,6)")
 	// test ordering and group by int column
 	mcmp.AssertMatches("select id6, id7, count(*) k from t3 group by id6, id7 order by k", `[[INT64(3) INT64(6) INT64(1)] [INT64(2) INT64(4) INT64(2)] [INT64(1) INT64(2) INT64(3)]]`)
-	mcmp.AssertMatches("select id6+id7, count(*) k from t3 group by id6+id7 order by k", `[[INT64(9) INT64(1)] [INT64(6) INT64(2)] [INT64(3) INT64(3)]]`)
+	if utils.BinaryIsAtLeastAtVersion(18, "vtgate") {
+		mcmp.AssertMatches("select id6+id7, count(*) k from t3 group by id6+id7 order by k", `[[INT64(9) INT64(1)] [INT64(6) INT64(2)] [INT64(3) INT64(3)]]`)
+	}
 
 	// Test the same queries in streaming mode
 	utils.Exec(t, mcmp.VtConn, "set workload = olap")
 	mcmp.AssertMatches("select id6, id7, count(*) k from t3 group by id6, id7 order by k", `[[INT64(3) INT64(6) INT64(1)] [INT64(2) INT64(4) INT64(2)] [INT64(1) INT64(2) INT64(3)]]`)
-	mcmp.AssertMatches("select id6+id7, count(*) k from t3 group by id6+id7 order by k", `[[INT64(9) INT64(1)] [INT64(6) INT64(2)] [INT64(3) INT64(3)]]`)
+	if utils.BinaryIsAtLeastAtVersion(18, "vtgate") {
+		mcmp.AssertMatches("select id6+id7, count(*) k from t3 group by id6+id7 order by k", `[[INT64(9) INT64(1)] [INT64(6) INT64(2)] [INT64(3) INT64(3)]]`)
+	}
 }
 
 func TestEqualFilterOnScatter(t *testing.T) {

--- a/go/test/endtoend/vtgate/queries/derived/derived_test.go
+++ b/go/test/endtoend/vtgate/queries/derived/derived_test.go
@@ -56,6 +56,7 @@ func TestDerivedTableWithOrderByLimit(t *testing.T) {
 }
 
 func TestDerivedAggregationOnRHS(t *testing.T) {
+	utils.SkipIfBinaryIsBelowVersion(t, 18, "vtgate")
 	mcmp, closer := start(t)
 	defer closer()
 

--- a/go/test/endtoend/vtgate/queries/foundrows/found_rows_test.go
+++ b/go/test/endtoend/vtgate/queries/foundrows/found_rows_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestFoundRows(t *testing.T) {
+	utils.SkipIfBinaryIsBelowVersion(t, 18, "vtgate")
 	defer cluster.PanicHandler(t)
 	mcmp, err := utils.NewMySQLCompare(t, vtParams, mysqlParams)
 	require.NoError(t, err)


### PR DESCRIPTION
## Description

This PR addresses several query serving CI failures when upgrade/downgrade testing with `slack-15.0` VTGates that don't have certain functionality

For context: v18 was used as the previous version because upstream's `release-19.0` branch successfully downgrades with v18

Example failures below:

```
2025-02-10T15:04:33.0364151Z === RUN   TestGroupBy
2025-02-10T15:05:33.1593242Z     aggregation_test.go:119: 
2025-02-10T15:05:33.1595331Z         	Error Trace:	/home/runner/work/vitess/vitess/go/test/endtoend/utils/cmp.go:201
2025-02-10T15:05:33.1596608Z         	            				/home/runner/work/vitess/vitess/go/test/endtoend/utils/cmp.go:65
2025-02-10T15:05:33.1598036Z         	            				/home/runner/work/vitess/vitess/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go:119
2025-02-10T15:05:33.1598782Z         	Error:      	Received unexpected error:
2025-02-10T15:05:33.1601385Z         	            	unsupported: in scatter query: complex order by expression: id6 + id7 (errno 1235) (sqlstate 42000) during query: select id6+id7, count(*) k from t3 group by id6+id7 order by k
2025-02-10T15:05:33.1602260Z         	Test:       	TestGroupBy
2025-02-10T15:05:33.1602942Z         	Messages:   	[Vitess Error] for query: select id6+id7, count(*) k from t3 group by id6+id7 order by k
2025-02-10T15:05:33.1797086Z --- FAIL: TestGroupBy (60.14s)
```
This complex order-by expression isn't in v15 tests, skipping it

And:
```
2025-02-10T15:24:12.1300969Z === RUN   TestDerivedAggregationOnRHS
2025-02-10T15:24:12.1385703Z     derived_test.go:63: 
2025-02-10T15:24:12.1386538Z         	Error Trace:	/home/runner/work/vitess/vitess/go/test/endtoend/utils/cmp.go:201
2025-02-10T15:24:12.1388427Z         	            				/home/runner/work/vitess/vitess/go/test/endtoend/vtgate/queries/derived/derived_test.go:63
2025-02-10T15:24:12.1389225Z         	Error:      	Received unexpected error:
2025-02-10T15:24:12.1393316Z         	            	using aggregation on top of a *planbuilder.orderedAggregate plan is not yet supported (errno 1235) (sqlstate 42000) during query: select d.a from music join (select id, count(*) as a from user) as d on music.user_id = d.id group by 1
2025-02-10T15:24:12.1394653Z         	Test:       	TestDerivedAggregationOnRHS
2025-02-10T15:24:12.1395738Z         	Messages:   	[Vitess Error] for query: select d.a from music join (select id, count(*) as a from user) as d on music.user_id = d.id group by 1
2025-02-10T15:24:12.1419041Z --- FAIL: TestDerivedAggregationOnRHS (0.01s)
```
`plan is not yet supported` == skip it

And:
```
2025-02-10T15:24:37.3112453Z === RUN   TestFoundRows
2025-02-10T15:25:37.3365607Z     found_rows_test.go:48: 
2025-02-10T15:25:37.3366787Z         	Error Trace:	/home/runner/work/vitess/vitess/go/test/endtoend/vtgate/queries/foundrows/found_rows_test.go:48
2025-02-10T15:25:37.3367648Z         	Error:      	Received unexpected error:
2025-02-10T15:25:37.3368822Z         	            	schema tracking didn't mark table ks_found_rows.t2 as authoritative until timeout
2025-02-10T15:25:37.3369445Z         	Test:       	TestFoundRows
2025-02-10T15:25:37.3420839Z --- FAIL: TestFoundRows (60.03s)
2025-02-10T15:25:37.3421157Z FAIL
```
We don't run schema tracking yet, so 🧹

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
