### PR TITLE
`slack-19.0`: re-backport tweaks from vitessio/vitess#17911

### DIFF
--- a/go/vt/vtorc/inst/shard_dao.go
+++ b/go/vt/vtorc/inst/shard_dao.go
@@ -41,18 +41,6 @@ func ReadShardNames(keyspaceName string) (shardNames []string, err error) {
 	return shardNames, err
 }
 
-// ReadAllShardNames reads the names of all vitess shards by keyspace.
-func ReadAllShardNames() (shardNames map[string][]string, err error) {
-	shardNames = make(map[string][]string)
-	query := `select keyspace, shard from vitess_shard`
-	err = db.QueryVTOrc(query, nil, func(row sqlutils.RowMap) error {
-		ks := row.GetString("keyspace")
-		shardNames[ks] = append(shardNames[ks], row.GetString("shard"))
-		return nil
-	})
-	return shardNames, err
-}
-
 // ReadShardPrimaryInformation reads the vitess shard record and gets the shard primary alias and timestamp.
 func ReadShardPrimaryInformation(keyspaceName, shardName string) (primaryAlias string, primaryTimestamp string, err error) {
 	if err = topo.ValidateKeyspaceName(keyspaceName); err != nil {

--- a/go/vt/vtorc/inst/shard_dao_test.go
+++ b/go/vt/vtorc/inst/shard_dao_test.go
@@ -109,13 +109,6 @@ func TestSaveReadAndDeleteShard(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, []string{tt.shardName}, shardNames)
 
-			// ReadAllShardNames
-			allShardNames, err := ReadAllShardNames()
-			require.NoError(t, err)
-			ksShards, found := allShardNames[tt.keyspaceName]
-			require.True(t, found)
-			require.Equal(t, []string{tt.shardName}, ksShards)
-
 			// DeleteShard
 			require.NoError(t, DeleteShard(tt.keyspaceName, tt.shardName))
 			_, _, err = ReadShardPrimaryInformation(tt.keyspaceName, tt.shardName)

--- a/go/vt/vtorc/inst/tablet_dao_test.go
+++ b/go/vt/vtorc/inst/tablet_dao_test.go
@@ -136,7 +136,7 @@ func TestReadTabletCountsByKeyspaceShard(t *testing.T) {
 	tabletCounts, err := ReadTabletCountsByKeyspaceShard()
 	require.NoError(t, err)
 	require.Equal(t, map[string]map[string]int64{
-		"test": map[string]int64{
+		"test": {
 			"-40":   100,
 			"40-80": 100,
 			"80-c0": 100,

--- a/go/vt/vtorc/inst/tablet_dao_test.go
+++ b/go/vt/vtorc/inst/tablet_dao_test.go
@@ -113,7 +113,7 @@ func TestReadTabletCountsByCell(t *testing.T) {
 	require.Equal(t, map[string]int64{"cell1": 100}, tabletCounts)
 }
 
-func TestReadTabletCountsByShard(t *testing.T) {
+func TestReadTabletCountsByKeyspaceShard(t *testing.T) {
 	// Clear the database after the test. The easiest way to do that is to run all the initialization commands again.
 	defer func() {
 		db.ClearVTOrcDatabase()
@@ -133,12 +133,14 @@ func TestReadTabletCountsByShard(t *testing.T) {
 			uid++
 		}
 	}
-	tabletCounts, err := ReadTabletCountsByShard()
+	tabletCounts, err := ReadTabletCountsByKeyspaceShard()
 	require.NoError(t, err)
-	require.Equal(t, map[string]int64{
-		"test.-40":   100,
-		"test.40-80": 100,
-		"test.80-c0": 100,
-		"test.c0-":   100,
+	require.Equal(t, map[string]map[string]int64{
+		"test": map[string]int64{
+			"-40":   100,
+			"40-80": 100,
+			"80-c0": 100,
+			"c0-":   100,
+		},
 	}, tabletCounts)
 }

--- a/go/vt/vtorc/logic/keyspace_shard_discovery.go
+++ b/go/vt/vtorc/logic/keyspace_shard_discovery.go
@@ -23,34 +23,12 @@ import (
 	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
 
-	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/vt/key"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/vtorc/inst"
 )
-
-var statsShardsWatched = stats.NewGaugesFuncWithMultiLabels("ShardsWatched",
-	"Keyspace/shards currently watched",
-	[]string{"Keyspace", "Shard"},
-	getShardsWatchedStats)
-
-// getShardsWatchedStats returns the keyspace/shards watched in a format for stats.
-func getShardsWatchedStats() map[string]int64 {
-	shardsWatched := make(map[string]int64)
-	allShardNames, err := inst.ReadAllShardNames()
-	if err != nil {
-		log.Errorf("Failed to read all shard names: %+v", err)
-		return shardsWatched
-	}
-	for ks, shards := range allShardNames {
-		for _, shard := range shards {
-			shardsWatched[ks+"."+shard] = 1
-		}
-	}
-	return shardsWatched
-}
 
 // refreshAllKeyspacesAndShardsMu ensures RefreshAllKeyspacesAndShards
 // is not executed concurrently.

--- a/go/vt/vtorc/logic/tablet_discovery.go
+++ b/go/vt/vtorc/logic/tablet_discovery.go
@@ -63,7 +63,7 @@ var (
 		[]string{"Cell"},
 		getTabletsWatchedByCellStats,
 	)
-	statsTabletsWatchedByShards = stats.NewGaugesFuncWithMultiLabels(
+	statsTabletsWatchedByShard = stats.NewGaugesFuncWithMultiLabels(
 		"TabletsWatchedByShard",
 		"Number of tablets watched by keyspace/shard",
 		[]string{"Keyspace", "Shard"},
@@ -76,21 +76,21 @@ var (
 
 // getTabletsWatchedByCellStats returns the number of tablets watched by cell in stats format.
 func getTabletsWatchedByCellStats() map[string]int64 {
-	tabletsCountsByCell, err := inst.ReadTabletCountsByCell()
+	tabletCountsByCell, err := inst.ReadTabletCountsByCell()
 	if err != nil {
 		log.Errorf("Failed to read tablet counts by cell: %+v", err)
 	}
-	return tabletsCountsByCell
+	return tabletCountsByCell
 }
 
 // getTabletsWatchedByShardStats returns the number of tablets watched by keyspace/shard in stats format.
 func getTabletsWatchedByShardStats() map[string]int64 {
 	tabletsWatchedByShard := make(map[string]int64)
-	tabletsCountsByKS, err := inst.ReadTabletCountsByKeyspaceShard()
+	tabletCountsByKS, err := inst.ReadTabletCountsByKeyspaceShard()
 	if err != nil {
 		log.Errorf("Failed to read tablet counts by shard: %+v", err)
 	}
-	for keyspace, countsByShard := range tabletsCountsByKS {
+	for keyspace, countsByShard := range tabletCountsByKS {
 		for shard, tabletCount := range countsByShard {
 			tabletsWatchedByShard[keyspace+"."+shard] = tabletCount
 		}

--- a/go/vt/vtorc/logic/tablet_discovery.go
+++ b/go/vt/vtorc/logic/tablet_discovery.go
@@ -84,11 +84,17 @@ func getTabletsWatchedByCellStats() map[string]int64 {
 
 // getTabletsWatchedByShardStats returns the number of tablets watched by keyspace/shard in stats format.
 func getTabletsWatchedByShardStats() map[string]int64 {
-	tabletsCountsByShard, err := inst.ReadTabletCountsByShard()
+	tabletsWatchedByShard := make(map[string]int64)
+	tabletsCountsByKS, err := inst.ReadTabletCountsByKeyspaceShard()
 	if err != nil {
 		log.Errorf("Failed to read tablet counts by shard: %+v", err)
 	}
-	return tabletsCountsByShard
+	for keyspace, countsByShard := range tabletsCountsByKS {
+		for shard, tabletCount := range countsByShard {
+			tabletsWatchedByShard[keyspace+"."+shard] = tabletCount
+		}
+	}
+	return tabletsWatchedByShard
 }
 
 // RegisterFlags registers the flags required by VTOrc

--- a/go/vt/vtorc/logic/tablet_discovery.go
+++ b/go/vt/vtorc/logic/tablet_discovery.go
@@ -56,23 +56,39 @@ var (
 	// This is populated by parsing `--clusters_to_watch` flag.
 	shardsToWatch map[string][]*topodatapb.KeyRange
 
-	statsTabletsWatched = stats.NewGaugesFuncWithMultiLabels(
-		"TabletsWatched",
+	// tablet stats
+	statsTabletsWatchedByCell = stats.NewGaugesFuncWithMultiLabels(
+		"TabletsWatchedByCell",
 		"Number of tablets watched by cell",
 		[]string{"cell"},
-		getTabletsWatchedByCell,
+		getTabletsWatchedByCellStats,
 	)
+	statsTabletsWatchedByShards = stats.NewGaugesFuncWithMultiLabels(
+		"TabletsWatchedByShard",
+		"Number of tablets watched by keyspace/shard",
+		[]string{"Keyspace", "Shard"},
+		getTabletsWatchedByShardStats)
 
 	// ErrNoPrimaryTablet is a fixed error message.
 	ErrNoPrimaryTablet = errors.New("no primary tablet found")
 )
 
-func getTabletsWatchedByCell() map[string]int64 {
+// getTabletsWatchedByCellStats returns the number of tablets watched by cell in stats format.
+func getTabletsWatchedByCellStats() map[string]int64 {
 	tabletsCountsByCell, err := inst.ReadTabletCountsByCell()
 	if err != nil {
 		log.Errorf("Failed to read tablet counts by cell: %+v", err)
 	}
 	return tabletsCountsByCell
+}
+
+// getTabletsWatchedByShardStats returns the number of tablets watched by keyspace/shard in stats format.
+func getTabletsWatchedByShardStats() map[string]int64 {
+	tabletsCountsByShard, err := inst.ReadTabletCountsByShard()
+	if err != nil {
+		log.Errorf("Failed to read tablet counts by shard: %+v", err)
+	}
+	return tabletsCountsByShard
 }
 
 // RegisterFlags registers the flags required by VTOrc

--- a/go/vt/vtorc/logic/tablet_discovery.go
+++ b/go/vt/vtorc/logic/tablet_discovery.go
@@ -71,7 +71,6 @@ func getTabletsWatchedByCell() map[string]int64 {
 	tabletsCountsByCell, err := inst.ReadTabletCountsByCell()
 	if err != nil {
 		log.Errorf("Failed to read tablet counts by cell: %+v", err)
-		return tabletsCountsByCell
 	}
 	return tabletsCountsByCell
 }

--- a/go/vt/vtorc/logic/tablet_discovery.go
+++ b/go/vt/vtorc/logic/tablet_discovery.go
@@ -68,16 +68,12 @@ var (
 )
 
 func getTabletsWatchedByCell() map[string]int64 {
-	tabletsWatchedByCell := make(map[string]int64)
-	tabletsByCell, err := inst.ReadTabletCountsByCell()
-	if err == nil {
+	tabletsCountsByCell, err := inst.ReadTabletCountsByCell()
+	if err != nil {
 		log.Errorf("Failed to read tablet counts by cell: %+v", err)
-		return tabletsWatchedByCell
+		return tabletsCountsByCell
 	}
-	for cell, tabletCount := range tabletsByCell {
-		tabletsWatchedByCell[cell] = tabletCount
-	}
-	return tabletsWatchedByCell
+	return tabletsCountsByCell
 }
 
 // RegisterFlags registers the flags required by VTOrc

--- a/go/vt/vtorc/logic/tablet_discovery.go
+++ b/go/vt/vtorc/logic/tablet_discovery.go
@@ -60,14 +60,15 @@ var (
 	statsTabletsWatchedByCell = stats.NewGaugesFuncWithMultiLabels(
 		"TabletsWatchedByCell",
 		"Number of tablets watched by cell",
-		[]string{"cell"},
+		[]string{"Cell"},
 		getTabletsWatchedByCellStats,
 	)
 	statsTabletsWatchedByShards = stats.NewGaugesFuncWithMultiLabels(
 		"TabletsWatchedByShard",
 		"Number of tablets watched by keyspace/shard",
 		[]string{"Keyspace", "Shard"},
-		getTabletsWatchedByShardStats)
+		getTabletsWatchedByShardStats,
+	)
 
 	// ErrNoPrimaryTablet is a fixed error message.
 	ErrNoPrimaryTablet = errors.New("no primary tablet found")


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR backports more tweaks from v22 PR https://github.com/vitessio/vitess/pull/17911 based on testing. It is still unmerged

TL;DR: tablets-by-cell and tablets-by-shard counts are added, replacing the `ShardsWatch` metric

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
