### PR TITLE
Increase health check channel buffer (#17821)

### DIFF
--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -69,6 +69,9 @@ var (
 	hcPrimaryPromotedCounters = stats.NewCountersWithMultiLabels("HealthcheckPrimaryPromoted", "Primary promoted in keyspace/shard name because of health check errors", []string{"Keyspace", "ShardName"})
 	healthcheckOnce           sync.Once
 
+	// counter that tells us how many healthcheck messages have been dropped
+	hcChannelFullCounter = stats.NewCounter("HealthCheckChannelFullErrors", "Number of times the healthcheck broadcast channel was full")
+
 	// TabletURLTemplateString is a flag to generate URLs for the tablets that vtgate discovers.
 	TabletURLTemplateString = "http://{{.GetTabletHostPort}}"
 	tabletURLTemplate       *template.Template
@@ -635,7 +638,7 @@ func (hc *HealthCheckImpl) recomputeHealthy(key KeyspaceShardTabletType) {
 func (hc *HealthCheckImpl) Subscribe() chan *TabletHealth {
 	hc.subMu.Lock()
 	defer hc.subMu.Unlock()
-	c := make(chan *TabletHealth, broadcastChannelBufferSize)
+	c := make(chan *TabletHealth, 2048)
 	hc.subscribers[c] = struct{}{}
 	return c
 }
@@ -655,6 +658,7 @@ func (hc *HealthCheckImpl) broadcast(th *TabletHealth) {
 		case c <- th:
 		default:
 			// If the channel is full, we drop the message.
+			hcChannelFullCounter.Add(1)
 			log.Warningf("HealthCheck broadcast channel is full, dropping message for %s", topotools.TabletIdent(th.Tablet))
 		}
 	}

--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1479,7 +1480,6 @@ func TestDebugURLFormatting(t *testing.T) {
 // Added in response to https://github.com/vitessio/vitess/issues/17629.
 func TestConcurrentUpdates(t *testing.T) {
 	ctx := utils.LeakCheckContext(t)
-	var mu sync.Mutex
 	// reset error counters
 	hcErrorCounters.ResetAll()
 	ts := memorytopo.NewServer(ctx, "cell")
@@ -1491,12 +1491,10 @@ func TestConcurrentUpdates(t *testing.T) {
 	// Subscribe to the healthcheck
 	// Make the receiver keep track of the updates received.
 	ch := hc.Subscribe()
-	totalCount := 0
+	var totalCount atomic.Int32
 	go func() {
 		for range ch {
-			mu.Lock()
-			totalCount++
-			mu.Unlock()
+			totalCount.Add(1)
 			// Simulate a somewhat slow consumer.
 			time.Sleep(100 * time.Millisecond)
 		}
@@ -1513,9 +1511,7 @@ func TestConcurrentUpdates(t *testing.T) {
 	hc.Unsubscribe(ch)
 	defer close(ch)
 	require.Eventuallyf(t, func() bool {
-		mu.Lock()
-		defer mu.Unlock()
-		return totalUpdates == totalCount
+		return totalUpdates == int(totalCount.Load())
 	}, 5*time.Second, 100*time.Millisecond, "expected all updates to be processed")
 }
 


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
This PR backports https://github.com/vitessio/vitess/pull/17821 as it solves an https://github.com/vitessio/vitess/issues/17629 in which vtgate buffering would time out after receiving a healthcheck from a new primary.
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
https://github.com/vitessio/vitess/issues/17629
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
