### PR TITLE
`slack-19.0`: backport additional `vtorc` stats from vitessio/vitess#17977

### DIFF
--- a/go/vt/vtorc/logic/topology_recovery.go
+++ b/go/vt/vtorc/logic/topology_recovery.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"sync/atomic"
 	"time"
 
 	"github.com/patrickmn/go-cache"

--- a/go/vt/vtorc/logic/topology_recovery.go
+++ b/go/vt/vtorc/logic/topology_recovery.go
@@ -19,6 +19,7 @@ package logic
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/rand"
 	"os"
@@ -75,6 +76,9 @@ var (
 		"Shard",
 	})
 
+	// shardsLockCounter is a count of in-flight shard locks. Use atomics to read/update.
+	shardsLockCounter int64
+
 	// recoveriesCounter counts the number of recoveries that VTOrc has performed
 	recoveriesCounter = stats.NewCountersWithSingleLabel("RecoveriesCount", "Count of the different recoveries performed", "RecoveryType", actionableRecoveriesNames...)
 
@@ -87,6 +91,10 @@ var (
 	// vtops
 	vtopsExec         = external.NewExecVTOps()
 	vtopsSlackChannel = os.Getenv("SLACK_CHANNEL")
+
+	// shardLockTimings measures the timing of LockShard operations.
+	shardLockTimingsActions = []string{"Lock", "Unlock"}
+	shardLockTimings        = stats.NewTimings("ShardLockTimings", "Timings of global shard locks", "Action", shardLockTimingsActions...)
 )
 
 // recoveryFunction is the code of the recovery function to be used
@@ -171,6 +179,10 @@ var emergencyRestartReplicaTopologyInstanceMap *cache.Cache
 var emergencyOperationGracefulPeriodMap *cache.Cache
 
 func init() {
+	// ShardLocksActive is a stats representation of shardsLockCounter.
+	stats.NewGaugeFunc("ShardLocksActive", "Number of actively-held shard locks", func() int64 {
+		return atomic.LoadInt64(&shardsLockCounter)
+	})
 	go initializeTopologyRecoveryPostConfiguration()
 }
 
@@ -180,6 +192,45 @@ func initializeTopologyRecoveryPostConfiguration() {
 	emergencyReadTopologyInstanceMap = cache.New(time.Second, time.Millisecond*250)
 	emergencyRestartReplicaTopologyInstanceMap = cache.New(time.Second*30, time.Second)
 	emergencyOperationGracefulPeriodMap = cache.New(time.Second*5, time.Millisecond*500)
+}
+
+func getLockAction(analysedInstance string, code inst.AnalysisCode) string {
+	return fmt.Sprintf("VTOrc Recovery for %v on %v", code, analysedInstance)
+}
+
+// LockShard locks the keyspace-shard preventing others from performing conflicting actions.
+func LockShard(ctx context.Context, keyspace, shard, lockAction string) (context.Context, func(*error), error) {
+	if keyspace == "" {
+		return nil, nil, errors.New("can't lock shard: keyspace is unspecified")
+	}
+	if shard == "" {
+		return nil, nil, errors.New("can't lock shard: shard name is unspecified")
+	}
+	val := atomic.LoadInt32(&hasReceivedSIGTERM)
+	if val > 0 {
+		return nil, nil, errors.New("can't lock shard: SIGTERM received")
+	}
+
+	startTime := time.Now()
+	defer func() {
+		lockTime := time.Since(startTime)
+		shardLockTimings.Add("Lock", lockTime)
+	}()
+
+	atomic.AddInt64(&shardsLockCounter, 1)
+	ctx, unlock, err := ts.TryLockShard(ctx, keyspace, shard, lockAction)
+	if err != nil {
+		atomic.AddInt64(&shardsLockCounter, -1)
+		return nil, nil, err
+	}
+	return ctx, func(e *error) {
+		startTime := time.Now()
+		defer func() {
+			atomic.AddInt64(&shardsLockCounter, -1)
+			shardLockTimings.Add("Unlock", time.Since(startTime))
+		}()
+		unlock(e)
+	}, nil
 }
 
 // AuditTopologyRecovery audits a single step in a topology recovery process.

--- a/go/vt/vtorc/logic/vtorc_test.go
+++ b/go/vt/vtorc/logic/vtorc_test.go
@@ -29,10 +29,10 @@ func TestWaitForLocksRelease(t *testing.T) {
 
 	t.Run("Timeout from shutdownWaitTime", func(t *testing.T) {
 		// Increment shardsLockCounter to simulate locking of a shard
-		atomic.AddInt32(&shardsLockCounter, +1)
+		atomic.AddInt64(&shardsLockCounter, +1)
 		defer func() {
 			// Restore the initial value
-			atomic.StoreInt32(&shardsLockCounter, 0)
+			atomic.StoreInt64(&shardsLockCounter, 0)
 		}()
 		shutdownWaitTime = 200 * time.Millisecond
 		timeSpent := waitForLocksReleaseAndGetTimeWaitedFor()
@@ -42,12 +42,12 @@ func TestWaitForLocksRelease(t *testing.T) {
 
 	t.Run("Successful wait for locks release", func(t *testing.T) {
 		// Increment shardsLockCounter to simulate locking of a shard
-		atomic.AddInt32(&shardsLockCounter, +1)
+		atomic.AddInt64(&shardsLockCounter, +1)
 		shutdownWaitTime = 500 * time.Millisecond
 		// Release the locks after 200 milliseconds
 		go func() {
 			time.Sleep(200 * time.Millisecond)
-			atomic.StoreInt32(&shardsLockCounter, 0)
+			atomic.StoreInt64(&shardsLockCounter, 0)
 		}()
 		timeSpent := waitForLocksReleaseAndGetTimeWaitedFor()
 		assert.Greater(t, timeSpent, 100*time.Millisecond, "waitForLocksRelease should wait for the locks and not return early")


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR backports additional `vtorc` stats from https://github.com/vitessio/vitess/pull/17977

## Related Issue(s)

https://github.com/vitessio/vitess/pull/17977

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
