### PR TITLE
vtgateproxy v19 fixes

### DIFF
--- a/go/cmd/vtgateproxy/vtgateproxy.go
+++ b/go/cmd/vtgateproxy/vtgateproxy.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	"net/http"
 
 	channelz "github.com/rantav/go-grpc-channelz"
 	"google.golang.org/grpc/channelz/service"

--- a/go/cmd/vtgateproxy/vtgateproxy.go
+++ b/go/cmd/vtgateproxy/vtgateproxy.go
@@ -48,7 +48,7 @@ func main() {
 		service.RegisterChannelzServiceToServer(servenv.GRPCServer)
 
 		// Register the channelz handler to /channelz/ (note trailing / which is required).
-		http.Handle("/", channelz.CreateHandler("/", fmt.Sprintf(":%d", servenv.GRPCPort())))
+		servenv.HTTPHandle("/", channelz.CreateHandler("/", fmt.Sprintf(":%d", servenv.GRPCPort())))
 
 		vtgateproxy.Init()
 	})

--- a/go/vt/vtgateproxy/sim/go.mod
+++ b/go/vt/vtgateproxy/sim/go.mod
@@ -1,0 +1,5 @@
+module github.com/slackhq/vitess/go/vt/vtgateproxy/sim
+
+go 1.22.8
+
+require github.com/guptarohit/asciigraph v0.7.3

--- a/go/vt/vtgateproxy/sim/go.sum
+++ b/go/vt/vtgateproxy/sim/go.sum
@@ -1,0 +1,2 @@
+github.com/guptarohit/asciigraph v0.7.3 h1:p05XDDn7cBTWiBqWb30mrwxd6oU0claAjqeytllnsPY=
+github.com/guptarohit/asciigraph v0.7.3/go.mod h1:dYl5wwK4gNsnFf9Zp+l06rFiDZ5YtXM6x7SRWZ3KGag=


### PR DESCRIPTION
a couple of minor things
- add a `go.mod` to `go/vt/vtgateproxy/sim` - missing deps breaking the main build
- rewire channelz endpoint - servenv stopped using the default servemux which inadvertently broke our channelz setup

this branch is currently deployed to loadtest dev and working fine