### PR TITLE
`slack 19.0`: pre backport vitessio/vitess#18152

### DIFF
--- a/go/vt/topo/consultopo/server.go
+++ b/go/vt/topo/consultopo/server.go
@@ -31,6 +31,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/vterrors"
@@ -102,6 +103,10 @@ func getClientCreds() (creds map[string]*ClientAuthCred, err error) {
 
 	if err := json.Unmarshal(data, &creds); err != nil {
 		err = vterrors.Wrapf(err, "Error parsing consul_auth_static_file")
+		return creds, err
+	}
+	if len(creds) == 0 {
+		err = vterrors.New(vtrpc.Code_FAILED_PRECONDITION, "Found no credentials in consul_auth_static_file")
 		return creds, err
 	}
 	return creds, nil

--- a/go/vt/topo/consultopo/server_flaky_test.go
+++ b/go/vt/topo/consultopo/server_flaky_test.go
@@ -304,7 +304,7 @@ func TestConsulTopoWithAuthFailure(t *testing.T) {
 		}
 
 		// Create the server on the new root.
-		ts, err := topo.OpenServer("consul", serverAddr, path.Join("globalRoot", topo.GlobalCell))
+		_, err := topo.OpenServer("consul", serverAddr, path.Join("globalRoot", topo.GlobalCell))
 		if err == nil {
 			t.Fatal("Expected OpenServer() to return an error due to bad config, got nil")
 		}

--- a/go/vt/topo/consultopo/server_flaky_test.go
+++ b/go/vt/topo/consultopo/server_flaky_test.go
@@ -26,11 +26,10 @@ import (
 	"testing"
 	"time"
 
-	"vitess.io/vitess/go/vt/log"
-
 	"github.com/hashicorp/consul/api"
 
 	"vitess.io/vitess/go/testfiles"
+	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/test"
 
@@ -306,19 +305,8 @@ func TestConsulTopoWithAuthFailure(t *testing.T) {
 
 		// Create the server on the new root.
 		ts, err := topo.OpenServer("consul", serverAddr, path.Join("globalRoot", topo.GlobalCell))
-		if err != nil {
-			t.Fatalf("OpenServer() failed: %v", err)
-		}
-
-		// Attempt to Create the CellInfo.
-		err = ts.CreateCellInfo(context.Background(), test.LocalCellName, &topodatapb.CellInfo{
-			ServerAddress: serverAddr,
-			Root:          path.Join("globalRoot", test.LocalCellName),
-		})
-
-		want := "Failed request: ACL not found"
-		if err == nil || err.Error() != want {
-			t.Errorf("Expected CreateCellInfo to fail: got  %v, want %s", err, want)
+		if err == nil {
+			t.Fatal("Expected OpenServer() to return an error due to bad config, got nil")
 		}
 	}
 


### PR DESCRIPTION
## Description

This PR is an early backport of v23 PR: https://github.com/vitessio/vitess/pull/18152

This PR checks that consul static credentials were actually loaded, to address a problem we saw when the consul token is valid but empty, eg: `{}`

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
