### PR TITLE
add more metrics buckets

### DIFF
--- a/go/stats/timings.go
+++ b/go/stats/timings.go
@@ -181,7 +181,7 @@ func (t *Timings) Label() string {
 	return t.label
 }
 
-var bucketCutoffs = []int64{5e5, 1e6, 5e6, 1e7, 5e7, 1e8, 5e8, 1e9, 5e9, 1e10}
+var bucketCutoffs = []int64{5e5, 1e6, 5e6, 1e7, 5e7, 1e8, 5e8, 1e9, 2e9, 3e9, 4e9, 5e9, 1e10}
 
 var bucketLabels []string
 


### PR DESCRIPTION

## Description

This adds 200ms, 300ms, 400ms buckets for additional precision on histograms. 

## Related Issue(s)

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes
