### PR TITLE
Backport: add S3 minimum part size defined by the user 

### DIFF
--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -511,6 +511,9 @@ spec:
                           maxLength: 256
                           pattern: ^[^\r\n]*$
                           type: string
+                        minPartSize:
+                          format: int64
+                          type: integer
                         region:
                           minLength: 1
                           type: string
@@ -1351,6 +1354,9 @@ spec:
                                 maxLength: 256
                                 pattern: ^[^\r\n]*$
                                 type: string
+                              minPartSize:
+                                format: int64
+                                type: integer
                               region:
                                 minLength: 1
                                 type: string
@@ -3898,6 +3904,9 @@ spec:
                             maxLength: 256
                             pattern: ^[^\r\n]*$
                             type: string
+                          minPartSize:
+                            format: int64
+                            type: integer
                           region:
                             minLength: 1
                             type: string
@@ -5247,6 +5256,9 @@ spec:
                             maxLength: 256
                             pattern: ^[^\r\n]*$
                             type: string
+                          minPartSize:
+                            format: int64
+                            type: integer
                           region:
                             minLength: 1
                             type: string

--- a/go.mod
+++ b/go.mod
@@ -93,6 +93,7 @@ require (
 require (
 	github.com/Shopify/toxiproxy/v2 v2.8.0
 	github.com/bndr/gotabulate v1.1.2
+	github.com/dustin/go-humanize v1.0.1
 	github.com/gammazero/deque v0.2.1
 	github.com/google/safehtml v0.1.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
@@ -133,7 +134,6 @@ require (
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.3 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/ebitengine/purego v0.6.1 // indirect
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect

--- a/go/flags/endtoend/vtbackup.txt
+++ b/go/flags/endtoend/vtbackup.txt
@@ -196,6 +196,7 @@ Flags:
       --remote_operation_timeout duration                           time to wait for a remote operation (default 15s)
       --restart_before_backup                                       Perform a mysqld clean/full restart after applying binlogs, but before taking the backup. Only makes sense to work around xtrabackup bugs.
       --s3_backup_aws_endpoint string                               endpoint of the S3 backend (region must be provided).
+      --s3_backup_aws_min_partsize int                              Minimum part size to use, defaults to 5MiB but can be increased due to the dataset size. (default 5242880)
       --s3_backup_aws_region string                                 AWS region to use. (default "us-east-1")
       --s3_backup_aws_retries int                                   AWS request retries. (default -1)
       --s3_backup_force_path_style                                  force the s3 path style.

--- a/go/flags/endtoend/vtctld.txt
+++ b/go/flags/endtoend/vtctld.txt
@@ -110,6 +110,7 @@ Flags:
       --purge_logs_interval duration                                     how often try to remove old logs (default 1h0m0s)
       --remote_operation_timeout duration                                time to wait for a remote operation (default 15s)
       --s3_backup_aws_endpoint string                                    endpoint of the S3 backend (region must be provided).
+      --s3_backup_aws_min_partsize int                                   Minimum part size to use, defaults to 5MiB but can be increased due to the dataset size. (default 5242880)
       --s3_backup_aws_region string                                      AWS region to use. (default "us-east-1")
       --s3_backup_aws_retries int                                        AWS request retries. (default -1)
       --s3_backup_force_path_style                                       force the s3 path style.

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -313,6 +313,7 @@ Flags:
       --restore_from_backup_ts string                                    (init restore parameter) if set, restore the latest backup taken at or before this timestamp. Example: '2021-04-29.133050'
       --retain_online_ddl_tables duration                                How long should vttablet keep an old migrated table before purging it (default 24h0m0s)
       --s3_backup_aws_endpoint string                                    endpoint of the S3 backend (region must be provided).
+      --s3_backup_aws_min_partsize int                                   Minimum part size to use, defaults to 5MiB but can be increased due to the dataset size. (default 5242880)
       --s3_backup_aws_region string                                      AWS region to use. (default "us-east-1")
       --s3_backup_aws_retries int                                        AWS request retries. (default -1)
       --s3_backup_force_path_style                                       force the s3 path style.

--- a/go/vt/mysqlctl/s3backupstorage/s3_test.go
+++ b/go/vt/mysqlctl/s3backupstorage/s3_test.go
@@ -296,3 +296,68 @@ func TestWithParams(t *testing.T) {
 	assert.NotNil(t, s3.transport.DialContext)
 	assert.NotNil(t, s3.transport.Proxy)
 }
+
+func TestCalculateUploadPartSize(t *testing.T) {
+	originalMinimum := minPartSize
+	defer func() { minPartSize = originalMinimum }()
+
+	tests := []struct {
+		name            string
+		filesize        int64
+		minimumPartSize int64
+		want            int64
+		err             error
+	}{
+		{
+			name:            "minimum - 10 MiB",
+			filesize:        1024 * 1024 * 10, // 10 MiB
+			minimumPartSize: 1024 * 1024 * 5,  // 5 MiB
+			want:            1024 * 1024 * 5,  // 5 MiB,
+			err:             nil,
+		},
+		{
+			name:            "below minimum - 10 MiB",
+			filesize:        1024 * 1024 * 10, // 10 MiB
+			minimumPartSize: 1024 * 1024 * 8,  // 8 MiB
+			want:            1024 * 1024 * 8,  // 8 MiB,
+			err:             nil,
+		},
+		{
+			name:            "above minimum - 1 TiB",
+			filesize:        1024 * 1024 * 1024 * 1024, // 1 TiB
+			minimumPartSize: 1024 * 1024 * 5,           // 5 MiB
+			want:            109951163,                 // ~104 MiB
+			err:             nil,
+		},
+		{
+			name:            "below minimum - 1 TiB",
+			filesize:        1024 * 1024 * 1024 * 1024, // 1 TiB
+			minimumPartSize: 1024 * 1024 * 200,         // 200 MiB
+			want:            1024 * 1024 * 200,         // 200 MiB
+			err:             nil,
+		},
+		{
+			name:            "below S3 limits - 5 MiB",
+			filesize:        1024 * 1024 * 3, // 3 MiB
+			minimumPartSize: 1024 * 1024 * 4, // 4 MiB
+			want:            1024 * 1024 * 5, // 5 MiB - should always return the minimum
+			err:             nil,
+		},
+		{
+			name:            "above S3 limits - 5 GiB",
+			filesize:        1024 * 1024 * 1024 * 1024, // 1 TiB
+			minimumPartSize: 1024 * 1024 * 1024 * 6,    // 6 GiB
+			want:            0,
+			err:             ErrPartSize,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			minPartSize = tt.minimumPartSize
+			partSize, err := calculateUploadPartSize(tt.filesize)
+			require.ErrorIs(t, err, tt.err)
+			require.Equal(t, tt.want, partSize)
+		})
+	}
+}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This backports https://github.com/vitessio/vitess/pull/17171 to v19.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)



<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
