### PR TITLE
Revert upstream 13623: remove the call of verifyAllTabletsReachable in PRS

### DIFF
--- a/examples/backups/restart_tablets.sh
+++ b/examples/backups/restart_tablets.sh
@@ -36,8 +36,8 @@ done
 sleep 5
 
 # Wait for all the replica tablets to be in the serving state before initiating
-# InitShardPrimary. This is essential, since we want the RESTORE phase to be
-# complete before we start InitShardPrimary, otherwise we end up reading the
+# PlannedReparentShard. This is essential, since we want the RESTORE phase to be
+# complete before we start PlannedReparentShard, otherwise we end up reading the
 # tablet type to RESTORE and do not set semi-sync, which leads to the primary
 # hanging on writes.
 totalTime=600

--- a/examples/backups/restart_tablets.sh
+++ b/examples/backups/restart_tablets.sh
@@ -35,9 +35,9 @@ for i in 300 301 302; do
 done
 sleep 5
 
-# Wait for all the tablets to be in the serving state before initiating
-# PlannedReparentShard. This is essential, since we want the RESTORE phase to be
-# complete before we start PlannedReparentShard, otherwise we end up reading the
+# Wait for all the replica tablets to be in the serving state before initiating
+# InitShardPrimary. This is essential, since we want the RESTORE phase to be
+# complete before we start InitShardPrimary, otherwise we end up reading the
 # tablet type to RESTORE and do not set semi-sync, which leads to the primary
 # hanging on writes.
 totalTime=600
@@ -50,27 +50,11 @@ for i in 101 201 301; do
   done
 done
 
-for i in 102 202 302; do
-  while [ $totalTime -gt 0 ]; do
-    status=$(curl "http://$hostname:15$i/debug/status_details")
-    echo "$status" | grep "RDONLY: Serving" && break
-    totalTime=$((totalTime-1))
-    sleep 0.1
-  done
-done
-
 # Check that all the replica tablets have reached REPLICA: Serving state
 for i in 101 201 301; do
   status=$(curl "http://$hostname:15$i/debug/status_details")
   echo "$status" | grep "REPLICA: Serving" && continue
   echo "tablet-$i did not reach REPLICA: Serving state. Exiting due to failure."
-  exit 1
-done
-# Check that all the rdonly tablets have reached RDONLY: Serving state
-for i in 102 202 302; do
-  status=$(curl "http://$hostname:15$i/debug/status_details")
-  echo "$status" | grep "RDONLY: Serving" && continue
-  echo "tablet-$i did not reach RDONLY: Serving state. Exiting due to failure."
   exit 1
 done
 

--- a/go/test/endtoend/reparent/plannedreparent/reparent_test.go
+++ b/go/test/endtoend/reparent/plannedreparent/reparent_test.go
@@ -155,7 +155,11 @@ func TestReparentAvoid(t *testing.T) {
 	utils.StopTablet(t, tablets[0], true)
 	out, err := utils.PrsAvoid(t, clusterInstance, tablets[1])
 	require.Error(t, err)
-	assert.Contains(t, out, "cannot find a tablet to reparent to in the same cell as the current primary")
+	if clusterInstance.VtctlMajorVersion <= 17 {
+		assert.Contains(t, out, "cannot find a tablet to reparent to in the same cell as the current primary")
+	} else {
+		assert.Contains(t, out, "rpc error: code = DeadlineExceeded desc = latest balancer error")
+	}
 	utils.ValidateTopology(t, clusterInstance, false)
 	utils.CheckPrimaryTablet(t, clusterInstance, tablets[1])
 }

--- a/go/test/endtoend/reparent/plannedreparent/reparent_test.go
+++ b/go/test/endtoend/reparent/plannedreparent/reparent_test.go
@@ -123,16 +123,9 @@ func TestReparentReplicaOffline(t *testing.T) {
 	// Perform a graceful reparent operation.
 	out, err := utils.PrsWithTimeout(t, clusterInstance, tablets[1], false, "", "31s")
 	require.Error(t, err)
+	assert.True(t, utils.SetReplicationSourceFailed(tablets[3], out))
 
-	// Assert that PRS failed
-	if clusterInstance.VtctlMajorVersion <= 17 {
-		assert.True(t, utils.SetReplicationSourceFailed(tablets[3], out))
-		utils.CheckPrimaryTablet(t, clusterInstance, tablets[1])
-	} else {
-		assert.Contains(t, out, "rpc error: code = DeadlineExceeded desc")
-		utils.CheckPrimaryTablet(t, clusterInstance, tablets[0])
-	}
-
+	utils.CheckPrimaryTablet(t, clusterInstance, tablets[1])
 }
 
 func TestReparentAvoid(t *testing.T) {
@@ -162,11 +155,7 @@ func TestReparentAvoid(t *testing.T) {
 	utils.StopTablet(t, tablets[0], true)
 	out, err := utils.PrsAvoid(t, clusterInstance, tablets[1])
 	require.Error(t, err)
-	if clusterInstance.VtctlMajorVersion <= 17 {
-		assert.Contains(t, out, "cannot find a tablet to reparent to in the same cell as the current primary")
-	} else {
-		assert.Contains(t, out, "rpc error: code = DeadlineExceeded desc = latest balancer error")
-	}
+	assert.Contains(t, out, "cannot find a tablet to reparent to in the same cell as the current primary")
 	utils.ValidateTopology(t, clusterInstance, false)
 	utils.CheckPrimaryTablet(t, clusterInstance, tablets[1])
 }
@@ -293,24 +282,18 @@ func TestReparentWithDownReplica(t *testing.T) {
 	// Perform a graceful reparent operation. It will fail as one tablet is down.
 	out, err := utils.Prs(t, clusterInstance, tablets[1])
 	require.Error(t, err)
-	var insertVal int
-	// Assert that PRS failed
-	if clusterInstance.VtctlMajorVersion <= 17 {
-		assert.True(t, utils.SetReplicationSourceFailed(tablets[2], out))
-		// insert data into the new primary, check the connected replica work
-		insertVal = utils.ConfirmReplication(t, tablets[1], []*cluster.Vttablet{tablets[0], tablets[3]})
-	} else {
-		assert.Contains(t, out, fmt.Sprintf("TabletManager.PrimaryStatus on %s", tablets[2].Alias))
-		// insert data into the old primary, check the connected replica works. The primary tablet shouldn't have changed.
-		insertVal = utils.ConfirmReplication(t, tablets[0], []*cluster.Vttablet{tablets[1], tablets[3]})
-	}
+
+	assert.True(t, utils.SetReplicationSourceFailed(tablets[2], out))
+
+	// insert data into the new primary, check the connected replica work
+	insertVal := utils.ConfirmReplication(t, tablets[1], []*cluster.Vttablet{tablets[0], tablets[3]})
 
 	// restart mysql on the old replica, should still be connecting to the old primary
 	tablets[2].MysqlctlProcess.InitMysql = false
 	err = tablets[2].MysqlctlProcess.Start()
 	require.NoError(t, err)
 
-	// Use the same PlannedReparentShard command to promote the new primary.
+	// Use the same PlannedReparentShard command to fix up the tablet.
 	_, err = utils.Prs(t, clusterInstance, tablets[1])
 	require.NoError(t, err)
 

--- a/go/vt/vtctl/grpcvtctldserver/server_slow_test.go
+++ b/go/vt/vtctl/grpcvtctldserver/server_slow_test.go
@@ -402,21 +402,6 @@ func TestPlannedReparentShardSlow(t *testing.T) {
 						Error: nil,
 					},
 				},
-				// This is only needed to verify reachability, so empty results are fine.
-				PrimaryStatusResults: map[string]struct {
-					Status *replicationdatapb.PrimaryStatus
-					Error  error
-				}{
-					"zone1-0000000200": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000101": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000100": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-				},
 				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
@@ -517,21 +502,6 @@ func TestPlannedReparentShardSlow(t *testing.T) {
 							Position: "primary-demotion position",
 						},
 						Error: nil,
-					},
-				},
-				// This is only needed to verify reachability, so empty results are fine.
-				PrimaryStatusResults: map[string]struct {
-					Status *replicationdatapb.PrimaryStatus
-					Error  error
-				}{
-					"zone1-0000000200": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000101": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000100": {
-						Status: &replicationdatapb.PrimaryStatus{},
 					},
 				},
 				PrimaryPositionResults: map[string]struct {

--- a/go/vt/vtctl/grpcvtctldserver/server_test.go
+++ b/go/vt/vtctl/grpcvtctldserver/server_test.go
@@ -8078,21 +8078,6 @@ func TestPlannedReparentShard(t *testing.T) {
 						Error: nil,
 					},
 				},
-				// This is only needed to verify reachability, so empty results are fine.
-				PrimaryStatusResults: map[string]struct {
-					Status *replicationdatapb.PrimaryStatus
-					Error  error
-				}{
-					"zone1-0000000200": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000101": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000100": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-				},
 				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error

--- a/go/vt/vtctl/grpcvtctldserver/server_test.go
+++ b/go/vt/vtctl/grpcvtctldserver/server_test.go
@@ -8078,6 +8078,21 @@ func TestPlannedReparentShard(t *testing.T) {
 						Error: nil,
 					},
 				},
+				// This is only needed to verify reachability, so empty results are fine.
+				PrimaryStatusResults: map[string]struct {
+					Status *replicationdatapb.PrimaryStatus
+					Error  error
+				}{
+					"zone1-0000000200": {
+						Status: &replicationdatapb.PrimaryStatus{},
+					},
+					"zone1-0000000101": {
+						Status: &replicationdatapb.PrimaryStatus{},
+					},
+					"zone1-0000000100": {
+						Status: &replicationdatapb.PrimaryStatus{},
+					},
+				},
 				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
@@ -8191,7 +8206,23 @@ func TestPlannedReparentShard(t *testing.T) {
 					Shard:    "-",
 				},
 			},
-			tmc: nil,
+			tmc: &testutil.TabletManagerClient{
+				// This is only needed to verify reachability, so empty results are fine.
+				PrimaryStatusResults: map[string]struct {
+					Status *replicationdatapb.PrimaryStatus
+					Error  error
+				}{
+					"zone1-0000000200": {
+						Error: fmt.Errorf("primary status failed"),
+					},
+					"zone1-0000000101": {
+						Status: &replicationdatapb.PrimaryStatus{},
+					},
+					"zone1-0000000100": {
+						Status: &replicationdatapb.PrimaryStatus{},
+					},
+				},
+			},
 			req: &vtctldatapb.PlannedReparentShardRequest{
 				Keyspace: "testkeyspace",
 				Shard:    "-",

--- a/go/vt/vtctl/grpcvtctldserver/server_test.go
+++ b/go/vt/vtctl/grpcvtctldserver/server_test.go
@@ -8078,21 +8078,6 @@ func TestPlannedReparentShard(t *testing.T) {
 						Error: nil,
 					},
 				},
-				// This is only needed to verify reachability, so empty results are fine.
-				PrimaryStatusResults: map[string]struct {
-					Status *replicationdatapb.PrimaryStatus
-					Error  error
-				}{
-					"zone1-0000000200": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000101": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000100": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-				},
 				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
@@ -8206,23 +8191,7 @@ func TestPlannedReparentShard(t *testing.T) {
 					Shard:    "-",
 				},
 			},
-			tmc: &testutil.TabletManagerClient{
-				// This is only needed to verify reachability, so empty results are fine.
-				PrimaryStatusResults: map[string]struct {
-					Status *replicationdatapb.PrimaryStatus
-					Error  error
-				}{
-					"zone1-0000000200": {
-						Error: fmt.Errorf("primary status failed"),
-					},
-					"zone1-0000000101": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000100": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-				},
-			},
+			tmc: nil,
 			req: &vtctldatapb.PlannedReparentShardRequest{
 				Keyspace: "testkeyspace",
 				Shard:    "-",

--- a/go/vt/vtctl/grpcvtctldserver/server_test.go
+++ b/go/vt/vtctl/grpcvtctldserver/server_test.go
@@ -8191,23 +8191,7 @@ func TestPlannedReparentShard(t *testing.T) {
 					Shard:    "-",
 				},
 			},
-			tmc: &testutil.TabletManagerClient{
-				// This is only needed to verify reachability, so empty results are fine.
-				PrimaryStatusResults: map[string]struct {
-					Status *replicationdatapb.PrimaryStatus
-					Error  error
-				}{
-					"zone1-0000000200": {
-						Error: fmt.Errorf("primary status failed"),
-					},
-					"zone1-0000000101": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000100": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-				},
-			},
+			tmc: nil,
 			req: &vtctldatapb.PlannedReparentShardRequest{
 				Keyspace: "testkeyspace",
 				Shard:    "-",

--- a/go/vt/vtctl/grpcvtctldserver/server_test.go
+++ b/go/vt/vtctl/grpcvtctldserver/server_test.go
@@ -8156,54 +8156,6 @@ func TestPlannedReparentShard(t *testing.T) {
 			},
 			expectedErr: "duration: seconds:-1 nanos:1 is out of range for time.Duration",
 		},
-		{
-			name: "tablet unreachable",
-			ts:   memorytopo.NewServer(ctx, "zone1"),
-			tablets: []*topodatapb.Tablet{
-				{
-					Alias: &topodatapb.TabletAlias{
-						Cell: "zone1",
-						Uid:  100,
-					},
-					Type: topodatapb.TabletType_PRIMARY,
-					PrimaryTermStartTime: &vttime.Time{
-						Seconds: 100,
-					},
-					Keyspace: "testkeyspace",
-					Shard:    "-",
-				},
-				{
-					Alias: &topodatapb.TabletAlias{
-						Cell: "zone1",
-						Uid:  200,
-					},
-					Type:     topodatapb.TabletType_REPLICA,
-					Keyspace: "testkeyspace",
-					Shard:    "-",
-				},
-				{
-					Alias: &topodatapb.TabletAlias{
-						Cell: "zone1",
-						Uid:  101,
-					},
-					Type:     topodatapb.TabletType_RDONLY,
-					Keyspace: "testkeyspace",
-					Shard:    "-",
-				},
-			},
-			tmc: nil,
-			req: &vtctldatapb.PlannedReparentShardRequest{
-				Keyspace: "testkeyspace",
-				Shard:    "-",
-				NewPrimary: &topodatapb.TabletAlias{
-					Cell: "zone1",
-					Uid:  200,
-				},
-				WaitReplicasTimeout: protoutil.DurationToProto(time.Millisecond * 10),
-			},
-			expectEventsToOccur: true,
-			expectedErr:         "primary status failed",
-		},
 	}
 
 	for _, tt := range tests {

--- a/go/vt/vtctl/grpcvtctldserver/testutil/test_tmclient.go
+++ b/go/vt/vtctl/grpcvtctldserver/testutil/test_tmclient.go
@@ -295,11 +295,6 @@ type TabletManagerClient struct {
 		Position *replicationdatapb.Status
 		Error    error
 	}
-	PrimaryStatusDelays  map[string]time.Duration
-	PrimaryStatusResults map[string]struct {
-		Status *replicationdatapb.PrimaryStatus
-		Error  error
-	}
 	RestoreFromBackupResults map[string]struct {
 		Events        []*logutilpb.Event
 		EventInterval time.Duration
@@ -942,32 +937,6 @@ func (fake *TabletManagerClient) ReplicationStatus(ctx context.Context, tablet *
 			result.Position.BackupRunning = fake.TabletsBackupState[key]
 		}
 		return result.Position, result.Error
-	}
-
-	return nil, assert.AnError
-}
-
-// PrimaryStatus is part of the tmclient.TabletManagerClient interface.
-func (fake *TabletManagerClient) PrimaryStatus(ctx context.Context, tablet *topodatapb.Tablet) (*replicationdatapb.PrimaryStatus, error) {
-	if fake.PrimaryStatusResults == nil {
-		return nil, assert.AnError
-	}
-
-	key := topoproto.TabletAliasString(tablet.Alias)
-
-	if fake.PrimaryStatusDelays != nil {
-		if delay, ok := fake.PrimaryStatusDelays[key]; ok {
-			select {
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			case <-time.After(delay):
-				// proceed to results
-			}
-		}
-	}
-
-	if result, ok := fake.PrimaryStatusResults[key]; ok {
-		return result.Status, result.Error
 	}
 
 	return nil, assert.AnError

--- a/go/vt/vtctl/grpcvtctldserver/testutil/test_tmclient.go
+++ b/go/vt/vtctl/grpcvtctldserver/testutil/test_tmclient.go
@@ -295,6 +295,11 @@ type TabletManagerClient struct {
 		Position *replicationdatapb.Status
 		Error    error
 	}
+	PrimaryStatusDelays  map[string]time.Duration
+	PrimaryStatusResults map[string]struct {
+		Status *replicationdatapb.PrimaryStatus
+		Error  error
+	}
 	RestoreFromBackupResults map[string]struct {
 		Events        []*logutilpb.Event
 		EventInterval time.Duration
@@ -937,6 +942,32 @@ func (fake *TabletManagerClient) ReplicationStatus(ctx context.Context, tablet *
 			result.Position.BackupRunning = fake.TabletsBackupState[key]
 		}
 		return result.Position, result.Error
+	}
+
+	return nil, assert.AnError
+}
+
+// PrimaryStatus is part of the tmclient.TabletManagerClient interface.
+func (fake *TabletManagerClient) PrimaryStatus(ctx context.Context, tablet *topodatapb.Tablet) (*replicationdatapb.PrimaryStatus, error) {
+	if fake.PrimaryStatusResults == nil {
+		return nil, assert.AnError
+	}
+
+	key := topoproto.TabletAliasString(tablet.Alias)
+
+	if fake.PrimaryStatusDelays != nil {
+		if delay, ok := fake.PrimaryStatusDelays[key]; ok {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(delay):
+				// proceed to results
+			}
+		}
+	}
+
+	if result, ok := fake.PrimaryStatusResults[key]; ok {
+		return result.Status, result.Error
 	}
 
 	return nil, assert.AnError

--- a/go/vt/vtctl/reparentutil/planned_reparenter.go
+++ b/go/vt/vtctl/reparentutil/planned_reparenter.go
@@ -587,12 +587,12 @@ func (pr *PlannedReparenter) reparentShardLocked(
 	// inserted in the new primary's journal, so we can use it below to check
 	// that all the replicas have attached to new primary successfully.
 	switch {
-	case currentPrimary == nil && ev.ShardInfo.PrimaryTermStartTime == nil:
+	case currentPrimary == nil && ev.ShardInfo.PrimaryAlias == nil:
 		// Case (1): no primary has been elected ever. Initialize
 		// the primary-elect tablet
 		reparentJournalPos, err = pr.performInitialPromotion(ctx, ev.NewPrimary, opts)
 		needsRefresh = true
-	case currentPrimary == nil && ev.ShardInfo.PrimaryTermStartTime != nil:
+	case currentPrimary == nil && ev.ShardInfo.PrimaryAlias != nil:
 		// Case (2): no clear current primary. Try to find a safe promotion
 		// candidate, and promote to it.
 		err = pr.performPotentialPromotion(ctx, keyspace, shard, ev.NewPrimary, tabletMap, opts)

--- a/go/vt/vtctl/reparentutil/planned_reparenter.go
+++ b/go/vt/vtctl/reparentutil/planned_reparenter.go
@@ -587,12 +587,12 @@ func (pr *PlannedReparenter) reparentShardLocked(
 	// inserted in the new primary's journal, so we can use it below to check
 	// that all the replicas have attached to new primary successfully.
 	switch {
-	case currentPrimary == nil && ev.ShardInfo.PrimaryAlias == nil:
+	case currentPrimary == nil && ev.ShardInfo.PrimaryTermStartTime == nil:
 		// Case (1): no primary has been elected ever. Initialize
 		// the primary-elect tablet
 		reparentJournalPos, err = pr.performInitialPromotion(ctx, ev.NewPrimary, opts)
 		needsRefresh = true
-	case currentPrimary == nil && ev.ShardInfo.PrimaryAlias != nil:
+	case currentPrimary == nil && ev.ShardInfo.PrimaryTermStartTime != nil:
 		// Case (2): no clear current primary. Try to find a safe promotion
 		// candidate, and promote to it.
 		err = pr.performPotentialPromotion(ctx, keyspace, shard, ev.NewPrimary, tabletMap, opts)

--- a/go/vt/vtctl/reparentutil/planned_reparenter_flaky_test.go
+++ b/go/vt/vtctl/reparentutil/planned_reparenter_flaky_test.go
@@ -110,6 +110,18 @@ func TestPlannedReparenter_ReparentShard(t *testing.T) {
 				SetReadWriteResults: map[string]error{
 					"zone1-0000000100": nil,
 				},
+				// This is only needed to verify reachability, so empty results are fine.
+				PrimaryStatusResults: map[string]struct {
+					Status *replicationdatapb.PrimaryStatus
+					Error  error
+				}{
+					"zone1-0000000200": {
+						Status: &replicationdatapb.PrimaryStatus{},
+					},
+					"zone1-0000000100": {
+						Status: &replicationdatapb.PrimaryStatus{},
+					},
+				},
 			},
 			tablets: []*topodatapb.Tablet{
 				{
@@ -219,6 +231,18 @@ func TestPlannedReparenter_ReparentShard(t *testing.T) {
 				PopulateReparentJournalResults: map[string]error{
 					"zone1-0000000200": nil,
 				},
+				// This is only needed to verify reachability, so empty results are fine.
+				PrimaryStatusResults: map[string]struct {
+					Status *replicationdatapb.PrimaryStatus
+					Error  error
+				}{
+					"zone1-0000000200": {
+						Status: &replicationdatapb.PrimaryStatus{},
+					},
+					"zone1-0000000100": {
+						Status: &replicationdatapb.PrimaryStatus{},
+					},
+				},
 			},
 			tablets: []*topodatapb.Tablet{
 				{
@@ -296,6 +320,18 @@ func TestPlannedReparenter_ReparentShard(t *testing.T) {
 				SetReadWriteResults: map[string]error{
 					"zone1-0000000100": nil,
 				},
+				// This is only needed to verify reachability, so empty results are fine.
+				PrimaryStatusResults: map[string]struct {
+					Status *replicationdatapb.PrimaryStatus
+					Error  error
+				}{
+					"zone1-0000000200": {
+						Status: &replicationdatapb.PrimaryStatus{},
+					},
+					"zone1-0000000100": {
+						Status: &replicationdatapb.PrimaryStatus{},
+					},
+				},
 			},
 			tablets: []*topodatapb.Tablet{
 				{
@@ -355,7 +391,17 @@ func TestPlannedReparenter_ReparentShard(t *testing.T) {
 			// fail the preflight checks. Other functions are unit-tested
 			// thoroughly to cover all the cases.
 			name: "reparent fails",
-			tmc:  nil,
+			tmc: &testutil.TabletManagerClient{
+				// This is only needed to verify reachability, so empty results are fine.
+				PrimaryStatusResults: map[string]struct {
+					Status *replicationdatapb.PrimaryStatus
+					Error  error
+				}{
+					"zone1-0000000100": {
+						Status: &replicationdatapb.PrimaryStatus{},
+					},
+				},
+			},
 			tablets: []*topodatapb.Tablet{
 				{
 					Alias: &topodatapb.TabletAlias{
@@ -2418,6 +2464,18 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 						Error: nil,
 					},
 				},
+				// This is only needed to verify reachability, so empty results are fine.
+				PrimaryStatusResults: map[string]struct {
+					Status *replicationdatapb.PrimaryStatus
+					Error  error
+				}{
+					"zone1-0000000200": {
+						Status: &replicationdatapb.PrimaryStatus{},
+					},
+					"zone1-0000000100": {
+						Status: &replicationdatapb.PrimaryStatus{},
+					},
+				},
 				PopulateReparentJournalResults: map[string]error{
 					"zone1-0000000200": nil, // zone1-200 gets promoted
 				},
@@ -2498,6 +2556,18 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 				SetReadWriteResults: map[string]error{
 					"zone1-0000000100": nil,
 				},
+				// This is only needed to verify reachability, so empty results are fine.
+				PrimaryStatusResults: map[string]struct {
+					Status *replicationdatapb.PrimaryStatus
+					Error  error
+				}{
+					"zone1-0000000200": {
+						Status: &replicationdatapb.PrimaryStatus{},
+					},
+					"zone1-0000000100": {
+						Status: &replicationdatapb.PrimaryStatus{},
+					},
+				},
 			},
 			tablets: []*topodatapb.Tablet{
 				{
@@ -2564,6 +2634,18 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 							Position: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-10",
 						},
 						Error: nil,
+					},
+				},
+				// This is only needed to verify reachability, so empty results are fine.
+				PrimaryStatusResults: map[string]struct {
+					Status *replicationdatapb.PrimaryStatus
+					Error  error
+				}{
+					"zone1-0000000200": {
+						Status: &replicationdatapb.PrimaryStatus{},
+					},
+					"zone1-0000000100": {
+						Status: &replicationdatapb.PrimaryStatus{},
 					},
 				},
 				PrimaryPositionResults: map[string]struct {
@@ -2666,6 +2748,18 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000100": nil, // called during reparentTablets to make this tablet a replica of newPrimary
 				},
+				// This is only needed to verify reachability, so empty results are fine.
+				PrimaryStatusResults: map[string]struct {
+					Status *replicationdatapb.PrimaryStatus
+					Error  error
+				}{
+					"zone1-0000000200": {
+						Status: &replicationdatapb.PrimaryStatus{},
+					},
+					"zone1-0000000100": {
+						Status: &replicationdatapb.PrimaryStatus{},
+					},
+				},
 			},
 			tablets: []*topodatapb.Tablet{
 				// Shard has no current primary in the beginning.
@@ -2736,7 +2830,9 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 					Error    error
 				}{
 					"zone1-0000000200": {
-						Error: mysql.ErrNotReplica,
+						Position: &replicationdatapb.Status{
+							Position: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-2",
+						},
 					},
 					"zone1-0000000100": {
 						Error: fmt.Errorf("not providing replication status, so that 200 wins"),
@@ -2744,6 +2840,18 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 				},
 				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000100": nil, // called during reparentTablets to make this tablet a replica of newPrimary
+				},
+				// This is only needed to verify reachability, so empty results are fine.
+				PrimaryStatusResults: map[string]struct {
+					Status *replicationdatapb.PrimaryStatus
+					Error  error
+				}{
+					"zone1-0000000200": {
+						Status: &replicationdatapb.PrimaryStatus{},
+					},
+					"zone1-0000000100": {
+						Status: &replicationdatapb.PrimaryStatus{},
+					},
 				},
 			},
 			tablets: []*topodatapb.Tablet{
@@ -2791,7 +2899,20 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 		},
 		{
 			name: "preflight checks determine PRS is no-op",
-			tmc:  nil,
+			tmc: &testutil.TabletManagerClient{
+				// This is only needed to verify reachability, so empty results are fine.
+				PrimaryStatusResults: map[string]struct {
+					Status *replicationdatapb.PrimaryStatus
+					Error  error
+				}{
+					"zone1-0000000200": {
+						Status: &replicationdatapb.PrimaryStatus{},
+					},
+					"zone1-0000000100": {
+						Status: &replicationdatapb.PrimaryStatus{},
+					},
+				},
+			},
 			tablets: []*topodatapb.Tablet{
 				{
 					Alias: &topodatapb.TabletAlias{
@@ -2841,6 +2962,18 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 			tmc: &testutil.TabletManagerClient{
 				SetReadWriteResults: map[string]error{
 					"zone1-0000000100": assert.AnError,
+				},
+				// This is only needed to verify reachability, so empty results are fine.
+				PrimaryStatusResults: map[string]struct {
+					Status *replicationdatapb.PrimaryStatus
+					Error  error
+				}{
+					"zone1-0000000200": {
+						Status: &replicationdatapb.PrimaryStatus{},
+					},
+					"zone1-0000000100": {
+						Status: &replicationdatapb.PrimaryStatus{},
+					},
 				},
 			},
 			tablets: []*topodatapb.Tablet{
@@ -2909,6 +3042,18 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 				},
 				SetReadWriteResults: map[string]error{
 					"zone1-0000000100": nil,
+				},
+				// This is only needed to verify reachability, so empty results are fine.
+				PrimaryStatusResults: map[string]struct {
+					Status *replicationdatapb.PrimaryStatus
+					Error  error
+				}{
+					"zone1-0000000200": {
+						Status: &replicationdatapb.PrimaryStatus{},
+					},
+					"zone1-0000000100": {
+						Status: &replicationdatapb.PrimaryStatus{},
+					},
 				},
 			},
 			tablets: []*topodatapb.Tablet{
@@ -2982,6 +3127,18 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 				},
 				SetReadWriteResults: map[string]error{
 					"zone1-0000000100": nil,
+				},
+				// This is only needed to verify reachability, so empty results are fine.
+				PrimaryStatusResults: map[string]struct {
+					Status *replicationdatapb.PrimaryStatus
+					Error  error
+				}{
+					"zone1-0000000200": {
+						Status: &replicationdatapb.PrimaryStatus{},
+					},
+					"zone1-0000000100": {
+						Status: &replicationdatapb.PrimaryStatus{},
+					},
 				},
 			},
 			tablets: []*topodatapb.Tablet{

--- a/go/vt/vtctl/reparentutil/planned_reparenter_flaky_test.go
+++ b/go/vt/vtctl/reparentutil/planned_reparenter_flaky_test.go
@@ -110,18 +110,6 @@ func TestPlannedReparenter_ReparentShard(t *testing.T) {
 				SetReadWriteResults: map[string]error{
 					"zone1-0000000100": nil,
 				},
-				// This is only needed to verify reachability, so empty results are fine.
-				PrimaryStatusResults: map[string]struct {
-					Status *replicationdatapb.PrimaryStatus
-					Error  error
-				}{
-					"zone1-0000000200": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000100": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-				},
 			},
 			tablets: []*topodatapb.Tablet{
 				{
@@ -231,18 +219,6 @@ func TestPlannedReparenter_ReparentShard(t *testing.T) {
 				PopulateReparentJournalResults: map[string]error{
 					"zone1-0000000200": nil,
 				},
-				// This is only needed to verify reachability, so empty results are fine.
-				PrimaryStatusResults: map[string]struct {
-					Status *replicationdatapb.PrimaryStatus
-					Error  error
-				}{
-					"zone1-0000000200": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000100": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-				},
 			},
 			tablets: []*topodatapb.Tablet{
 				{
@@ -320,18 +296,6 @@ func TestPlannedReparenter_ReparentShard(t *testing.T) {
 				SetReadWriteResults: map[string]error{
 					"zone1-0000000100": nil,
 				},
-				// This is only needed to verify reachability, so empty results are fine.
-				PrimaryStatusResults: map[string]struct {
-					Status *replicationdatapb.PrimaryStatus
-					Error  error
-				}{
-					"zone1-0000000200": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000100": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-				},
 			},
 			tablets: []*topodatapb.Tablet{
 				{
@@ -391,17 +355,7 @@ func TestPlannedReparenter_ReparentShard(t *testing.T) {
 			// fail the preflight checks. Other functions are unit-tested
 			// thoroughly to cover all the cases.
 			name: "reparent fails",
-			tmc: &testutil.TabletManagerClient{
-				// This is only needed to verify reachability, so empty results are fine.
-				PrimaryStatusResults: map[string]struct {
-					Status *replicationdatapb.PrimaryStatus
-					Error  error
-				}{
-					"zone1-0000000100": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-				},
-			},
+			tmc:  nil,
 			tablets: []*topodatapb.Tablet{
 				{
 					Alias: &topodatapb.TabletAlias{
@@ -2464,18 +2418,6 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 						Error: nil,
 					},
 				},
-				// This is only needed to verify reachability, so empty results are fine.
-				PrimaryStatusResults: map[string]struct {
-					Status *replicationdatapb.PrimaryStatus
-					Error  error
-				}{
-					"zone1-0000000200": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000100": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-				},
 				PopulateReparentJournalResults: map[string]error{
 					"zone1-0000000200": nil, // zone1-200 gets promoted
 				},
@@ -2556,18 +2498,6 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 				SetReadWriteResults: map[string]error{
 					"zone1-0000000100": nil,
 				},
-				// This is only needed to verify reachability, so empty results are fine.
-				PrimaryStatusResults: map[string]struct {
-					Status *replicationdatapb.PrimaryStatus
-					Error  error
-				}{
-					"zone1-0000000200": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000100": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-				},
 			},
 			tablets: []*topodatapb.Tablet{
 				{
@@ -2634,18 +2564,6 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 							Position: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-10",
 						},
 						Error: nil,
-					},
-				},
-				// This is only needed to verify reachability, so empty results are fine.
-				PrimaryStatusResults: map[string]struct {
-					Status *replicationdatapb.PrimaryStatus
-					Error  error
-				}{
-					"zone1-0000000200": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000100": {
-						Status: &replicationdatapb.PrimaryStatus{},
 					},
 				},
 				PrimaryPositionResults: map[string]struct {
@@ -2748,18 +2666,6 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000100": nil, // called during reparentTablets to make this tablet a replica of newPrimary
 				},
-				// This is only needed to verify reachability, so empty results are fine.
-				PrimaryStatusResults: map[string]struct {
-					Status *replicationdatapb.PrimaryStatus
-					Error  error
-				}{
-					"zone1-0000000200": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000100": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-				},
 			},
 			tablets: []*topodatapb.Tablet{
 				// Shard has no current primary in the beginning.
@@ -2841,18 +2747,6 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000100": nil, // called during reparentTablets to make this tablet a replica of newPrimary
 				},
-				// This is only needed to verify reachability, so empty results are fine.
-				PrimaryStatusResults: map[string]struct {
-					Status *replicationdatapb.PrimaryStatus
-					Error  error
-				}{
-					"zone1-0000000200": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000100": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-				},
 			},
 			tablets: []*topodatapb.Tablet{
 				// Shard has no current primary in the beginning.
@@ -2899,20 +2793,7 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 		},
 		{
 			name: "preflight checks determine PRS is no-op",
-			tmc: &testutil.TabletManagerClient{
-				// This is only needed to verify reachability, so empty results are fine.
-				PrimaryStatusResults: map[string]struct {
-					Status *replicationdatapb.PrimaryStatus
-					Error  error
-				}{
-					"zone1-0000000200": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000100": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-				},
-			},
+			tmc:  nil,
 			tablets: []*topodatapb.Tablet{
 				{
 					Alias: &topodatapb.TabletAlias{
@@ -2962,18 +2843,6 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 			tmc: &testutil.TabletManagerClient{
 				SetReadWriteResults: map[string]error{
 					"zone1-0000000100": assert.AnError,
-				},
-				// This is only needed to verify reachability, so empty results are fine.
-				PrimaryStatusResults: map[string]struct {
-					Status *replicationdatapb.PrimaryStatus
-					Error  error
-				}{
-					"zone1-0000000200": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000100": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
 				},
 			},
 			tablets: []*topodatapb.Tablet{
@@ -3042,18 +2911,6 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 				},
 				SetReadWriteResults: map[string]error{
 					"zone1-0000000100": nil,
-				},
-				// This is only needed to verify reachability, so empty results are fine.
-				PrimaryStatusResults: map[string]struct {
-					Status *replicationdatapb.PrimaryStatus
-					Error  error
-				}{
-					"zone1-0000000200": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000100": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
 				},
 			},
 			tablets: []*topodatapb.Tablet{
@@ -3127,18 +2984,6 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 				},
 				SetReadWriteResults: map[string]error{
 					"zone1-0000000100": nil,
-				},
-				// This is only needed to verify reachability, so empty results are fine.
-				PrimaryStatusResults: map[string]struct {
-					Status *replicationdatapb.PrimaryStatus
-					Error  error
-				}{
-					"zone1-0000000200": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000100": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
 				},
 			},
 			tablets: []*topodatapb.Tablet{

--- a/go/vt/vtctl/reparentutil/planned_reparenter_flaky_test.go
+++ b/go/vt/vtctl/reparentutil/planned_reparenter_flaky_test.go
@@ -110,18 +110,6 @@ func TestPlannedReparenter_ReparentShard(t *testing.T) {
 				SetReadWriteResults: map[string]error{
 					"zone1-0000000100": nil,
 				},
-				// This is only needed to verify reachability, so empty results are fine.
-				PrimaryStatusResults: map[string]struct {
-					Status *replicationdatapb.PrimaryStatus
-					Error  error
-				}{
-					"zone1-0000000200": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000100": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-				},
 			},
 			tablets: []*topodatapb.Tablet{
 				{
@@ -231,18 +219,6 @@ func TestPlannedReparenter_ReparentShard(t *testing.T) {
 				PopulateReparentJournalResults: map[string]error{
 					"zone1-0000000200": nil,
 				},
-				// This is only needed to verify reachability, so empty results are fine.
-				PrimaryStatusResults: map[string]struct {
-					Status *replicationdatapb.PrimaryStatus
-					Error  error
-				}{
-					"zone1-0000000200": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000100": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-				},
 			},
 			tablets: []*topodatapb.Tablet{
 				{
@@ -320,18 +296,6 @@ func TestPlannedReparenter_ReparentShard(t *testing.T) {
 				SetReadWriteResults: map[string]error{
 					"zone1-0000000100": nil,
 				},
-				// This is only needed to verify reachability, so empty results are fine.
-				PrimaryStatusResults: map[string]struct {
-					Status *replicationdatapb.PrimaryStatus
-					Error  error
-				}{
-					"zone1-0000000200": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000100": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-				},
 			},
 			tablets: []*topodatapb.Tablet{
 				{
@@ -391,17 +355,7 @@ func TestPlannedReparenter_ReparentShard(t *testing.T) {
 			// fail the preflight checks. Other functions are unit-tested
 			// thoroughly to cover all the cases.
 			name: "reparent fails",
-			tmc: &testutil.TabletManagerClient{
-				// This is only needed to verify reachability, so empty results are fine.
-				PrimaryStatusResults: map[string]struct {
-					Status *replicationdatapb.PrimaryStatus
-					Error  error
-				}{
-					"zone1-0000000100": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-				},
-			},
+			tmc:  nil,
 			tablets: []*topodatapb.Tablet{
 				{
 					Alias: &topodatapb.TabletAlias{
@@ -2464,18 +2418,6 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 						Error: nil,
 					},
 				},
-				// This is only needed to verify reachability, so empty results are fine.
-				PrimaryStatusResults: map[string]struct {
-					Status *replicationdatapb.PrimaryStatus
-					Error  error
-				}{
-					"zone1-0000000200": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000100": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-				},
 				PopulateReparentJournalResults: map[string]error{
 					"zone1-0000000200": nil, // zone1-200 gets promoted
 				},
@@ -2556,18 +2498,6 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 				SetReadWriteResults: map[string]error{
 					"zone1-0000000100": nil,
 				},
-				// This is only needed to verify reachability, so empty results are fine.
-				PrimaryStatusResults: map[string]struct {
-					Status *replicationdatapb.PrimaryStatus
-					Error  error
-				}{
-					"zone1-0000000200": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000100": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-				},
 			},
 			tablets: []*topodatapb.Tablet{
 				{
@@ -2634,18 +2564,6 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 							Position: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-10",
 						},
 						Error: nil,
-					},
-				},
-				// This is only needed to verify reachability, so empty results are fine.
-				PrimaryStatusResults: map[string]struct {
-					Status *replicationdatapb.PrimaryStatus
-					Error  error
-				}{
-					"zone1-0000000200": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000100": {
-						Status: &replicationdatapb.PrimaryStatus{},
 					},
 				},
 				PrimaryPositionResults: map[string]struct {
@@ -2748,18 +2666,6 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000100": nil, // called during reparentTablets to make this tablet a replica of newPrimary
 				},
-				// This is only needed to verify reachability, so empty results are fine.
-				PrimaryStatusResults: map[string]struct {
-					Status *replicationdatapb.PrimaryStatus
-					Error  error
-				}{
-					"zone1-0000000200": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000100": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-				},
 			},
 			tablets: []*topodatapb.Tablet{
 				// Shard has no current primary in the beginning.
@@ -2830,28 +2736,14 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 					Error    error
 				}{
 					"zone1-0000000200": {
-						Position: &replicationdatapb.Status{
-							Position: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-2",
-						},
+						Error: mysql.ErrNotReplica,
 					},
 					"zone1-0000000100": {
-						Error: mysql.ErrNotReplica,
+						Error: fmt.Errorf("not providing replication status, so that 200 wins"),
 					},
 				},
 				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000100": nil, // called during reparentTablets to make this tablet a replica of newPrimary
-				},
-				// This is only needed to verify reachability, so empty results are fine.
-				PrimaryStatusResults: map[string]struct {
-					Status *replicationdatapb.PrimaryStatus
-					Error  error
-				}{
-					"zone1-0000000200": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000100": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
 				},
 			},
 			tablets: []*topodatapb.Tablet{
@@ -2899,20 +2791,7 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 		},
 		{
 			name: "preflight checks determine PRS is no-op",
-			tmc: &testutil.TabletManagerClient{
-				// This is only needed to verify reachability, so empty results are fine.
-				PrimaryStatusResults: map[string]struct {
-					Status *replicationdatapb.PrimaryStatus
-					Error  error
-				}{
-					"zone1-0000000200": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000100": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-				},
-			},
+			tmc:  nil,
 			tablets: []*topodatapb.Tablet{
 				{
 					Alias: &topodatapb.TabletAlias{
@@ -2962,18 +2841,6 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 			tmc: &testutil.TabletManagerClient{
 				SetReadWriteResults: map[string]error{
 					"zone1-0000000100": assert.AnError,
-				},
-				// This is only needed to verify reachability, so empty results are fine.
-				PrimaryStatusResults: map[string]struct {
-					Status *replicationdatapb.PrimaryStatus
-					Error  error
-				}{
-					"zone1-0000000200": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000100": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
 				},
 			},
 			tablets: []*topodatapb.Tablet{
@@ -3031,18 +2898,6 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 		{
 			name: "lost topology lock",
 			tmc: &testutil.TabletManagerClient{
-				// This is only needed to verify reachability, so empty results are fine.
-				PrimaryStatusResults: map[string]struct {
-					Status *replicationdatapb.PrimaryStatus
-					Error  error
-				}{
-					"zone1-0000000200": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000100": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-				},
 				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
@@ -3120,18 +2975,6 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 					"zone1-0000000100": {
 						Position: "position1",
 						Error:    nil,
-					},
-				},
-				// This is only needed to verify reachability, so empty results are fine.
-				PrimaryStatusResults: map[string]struct {
-					Status *replicationdatapb.PrimaryStatus
-					Error  error
-				}{
-					"zone1-0000000200": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000100": {
-						Status: &replicationdatapb.PrimaryStatus{},
 					},
 				},
 				PopulateReparentJournalResults: map[string]error{
@@ -3936,295 +3779,4 @@ func AssertReparentEventsEqual(t *testing.T, expected *events.Reparent, actual *
 	t.Helper()
 
 	AssertReparentEventsEqualWithMessage(t, expected, actual, "")
-}
-
-// TestPlannedReparenter_verifyAllTabletsReachable tests the functionality of verifyAllTabletsReachable.
-func TestPlannedReparenter_verifyAllTabletsReachable(t *testing.T) {
-	tests := []struct {
-		name         string
-		tmc          tmclient.TabletManagerClient
-		tabletMap    map[string]*topo.TabletInfo
-		remoteOpTime time.Duration
-		wantErr      string
-	}{
-		{
-			name: "Success",
-			tmc: &testutil.TabletManagerClient{
-				PrimaryStatusResults: map[string]struct {
-					Status *replicationdatapb.PrimaryStatus
-					Error  error
-				}{
-					"zone1-0000000200": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000201": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000100": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-				},
-			},
-			tabletMap: map[string]*topo.TabletInfo{
-				"zone1-0000000100": {
-					Tablet: &topodatapb.Tablet{
-						Alias: &topodatapb.TabletAlias{
-							Cell: "zone1",
-							Uid:  100,
-						},
-						Type: topodatapb.TabletType_PRIMARY,
-					},
-				},
-				"zone1-0000000200": {
-					Tablet: &topodatapb.Tablet{
-						Alias: &topodatapb.TabletAlias{
-							Cell: "zone1",
-							Uid:  200,
-						},
-						Type: topodatapb.TabletType_REPLICA,
-					},
-				},
-				"zone1-0000000201": {
-					Tablet: &topodatapb.Tablet{
-						Alias: &topodatapb.TabletAlias{
-							Cell: "zone1",
-							Uid:  201,
-						},
-						Type: topodatapb.TabletType_REPLICA,
-					},
-				},
-			},
-		}, {
-			name: "Failure",
-			tmc: &testutil.TabletManagerClient{
-				PrimaryStatusResults: map[string]struct {
-					Status *replicationdatapb.PrimaryStatus
-					Error  error
-				}{
-					"zone1-0000000200": {
-						Error: fmt.Errorf("primary status failed"),
-					},
-					"zone1-0000000201": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000100": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-				},
-			},
-			tabletMap: map[string]*topo.TabletInfo{
-				"zone1-0000000100": {
-					Tablet: &topodatapb.Tablet{
-						Alias: &topodatapb.TabletAlias{
-							Cell: "zone1",
-							Uid:  100,
-						},
-						Type: topodatapb.TabletType_PRIMARY,
-					},
-				},
-				"zone1-0000000200": {
-					Tablet: &topodatapb.Tablet{
-						Alias: &topodatapb.TabletAlias{
-							Cell: "zone1",
-							Uid:  200,
-						},
-						Type: topodatapb.TabletType_REPLICA,
-					},
-				},
-				"zone1-0000000201": {
-					Tablet: &topodatapb.Tablet{
-						Alias: &topodatapb.TabletAlias{
-							Cell: "zone1",
-							Uid:  201,
-						},
-						Type: topodatapb.TabletType_REPLICA,
-					},
-				},
-			},
-			wantErr: "primary status failed",
-		}, {
-			name: "Timeout",
-			tmc: &testutil.TabletManagerClient{
-				PrimaryStatusDelays: map[string]time.Duration{
-					"zone1-0000000100": 20 * time.Second,
-				},
-				PrimaryStatusResults: map[string]struct {
-					Status *replicationdatapb.PrimaryStatus
-					Error  error
-				}{
-					"zone1-0000000200": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000201": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-					"zone1-0000000100": {
-						Status: &replicationdatapb.PrimaryStatus{},
-					},
-				},
-			},
-			remoteOpTime: 100 * time.Millisecond,
-			tabletMap: map[string]*topo.TabletInfo{
-				"zone1-0000000100": {
-					Tablet: &topodatapb.Tablet{
-						Alias: &topodatapb.TabletAlias{
-							Cell: "zone1",
-							Uid:  100,
-						},
-						Type: topodatapb.TabletType_PRIMARY,
-					},
-				},
-				"zone1-0000000200": {
-					Tablet: &topodatapb.Tablet{
-						Alias: &topodatapb.TabletAlias{
-							Cell: "zone1",
-							Uid:  200,
-						},
-						Type: topodatapb.TabletType_REPLICA,
-					},
-				},
-				"zone1-0000000201": {
-					Tablet: &topodatapb.Tablet{
-						Alias: &topodatapb.TabletAlias{
-							Cell: "zone1",
-							Uid:  201,
-						},
-						Type: topodatapb.TabletType_REPLICA,
-					},
-				},
-			},
-			wantErr: "context deadline exceeded",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			ts := memorytopo.NewServer(ctx, "zone1")
-			defer ts.Close()
-
-			pr := &PlannedReparenter{
-				ts:  ts,
-				tmc: tt.tmc,
-			}
-			if tt.remoteOpTime != 0 {
-				oldTime := topo.RemoteOperationTimeout
-				topo.RemoteOperationTimeout = tt.remoteOpTime
-				defer func() {
-					topo.RemoteOperationTimeout = oldTime
-				}()
-			}
-			err := pr.verifyAllTabletsReachable(context.Background(), tt.tabletMap)
-			if tt.wantErr == "" {
-				require.NoError(t, err)
-				return
-			}
-			require.ErrorContains(t, err, tt.wantErr)
-		})
-	}
-}
-
-func TestPlannedReparenterStats(t *testing.T) {
-	prsCounter.ResetAll()
-	reparentShardOpTimings.Reset()
-
-	tmc := &testutil.TabletManagerClient{
-		PrimaryPositionResults: map[string]struct {
-			Position string
-			Error    error
-		}{
-			"zone1-0000000100": {
-				Position: "position1",
-				Error:    nil,
-			},
-		},
-		PopulateReparentJournalResults: map[string]error{
-			"zone1-0000000100": nil,
-		},
-		SetReplicationSourceResults: map[string]error{
-			"zone1-0000000101": nil,
-		},
-		SetReadWriteResults: map[string]error{
-			"zone1-0000000100": nil,
-		},
-		// This is only needed to verify reachability, so empty results are fine.
-		PrimaryStatusResults: map[string]struct {
-			Status *replicationdatapb.PrimaryStatus
-			Error  error
-		}{
-			"zone1-0000000101": {
-				Status: &replicationdatapb.PrimaryStatus{},
-			},
-			"zone1-0000000100": {
-				Status: &replicationdatapb.PrimaryStatus{},
-			},
-		},
-	}
-	shards := []*vtctldatapb.Shard{
-		{
-			Keyspace: "testkeyspace",
-			Name:     "-",
-		},
-	}
-	tablets := []*topodatapb.Tablet{
-		{
-			Alias: &topodatapb.TabletAlias{
-				Cell: "zone1",
-				Uid:  100,
-			},
-			Type:     topodatapb.TabletType_PRIMARY,
-			Keyspace: "testkeyspace",
-			Shard:    "-",
-		},
-		{
-			Alias: &topodatapb.TabletAlias{
-				Cell: "zone1",
-				Uid:  101,
-			},
-			Type:     topodatapb.TabletType_REPLICA,
-			Keyspace: "testkeyspace",
-			Shard:    "-",
-		},
-	}
-	plannedReparentOps := PlannedReparentOptions{
-		NewPrimaryAlias: &topodatapb.TabletAlias{
-			Cell: "zone1",
-			Uid:  100,
-		},
-	}
-	keyspace := "testkeyspace"
-	shard := "-"
-	ts := memorytopo.NewServer(context.Background(), "zone1")
-
-	ctx := context.Background()
-	logger := logutil.NewMemoryLogger()
-
-	testutil.AddShards(ctx, t, ts, shards...)
-	testutil.AddTablets(ctx, t, ts, &testutil.AddTabletOptions{
-		AlsoSetShardPrimary: true,
-		SkipShardCreation:   false,
-	}, tablets...)
-
-	prp := NewPlannedReparenter(ts, tmc, logger)
-	// run a successful prs
-	_, err := prp.ReparentShard(ctx, keyspace, shard, plannedReparentOps)
-	require.NoError(t, err)
-
-	// check the counter values
-	require.EqualValues(t, map[string]int64{"testkeyspace.-.success": 1}, prsCounter.Counts())
-	require.EqualValues(t, map[string]int64{"All": 1, "PlannedReparentShard": 1}, reparentShardOpTimings.Counts())
-
-	// set plannedReparentOps to request a non existent tablet
-	plannedReparentOps.NewPrimaryAlias = &topodatapb.TabletAlias{
-		Cell: "bogus",
-		Uid:  100,
-	}
-
-	// run a failing prs
-	_, err = prp.ReparentShard(ctx, keyspace, shard, plannedReparentOps)
-	require.Error(t, err)
-
-	// check the counter values
-	require.EqualValues(t, map[string]int64{"testkeyspace.-.success": 1, "testkeyspace.-.failure": 1}, prsCounter.Counts())
-	require.EqualValues(t, map[string]int64{"All": 2, "PlannedReparentShard": 2}, reparentShardOpTimings.Counts())
 }

--- a/go/vt/vtctl/reparentutil/util.go
+++ b/go/vt/vtctl/reparentutil/util.go
@@ -28,7 +28,6 @@ import (
 	"vitess.io/vitess/go/mysql/replication"
 	"vitess.io/vitess/go/mysql/sqlerror"
 	"vitess.io/vitess/go/stats"
-
 	"vitess.io/vitess/go/vt/concurrency"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"

--- a/go/vt/vtctl/reparentutil/util.go
+++ b/go/vt/vtctl/reparentutil/util.go
@@ -80,7 +80,6 @@ func ElectNewPrimary(
 	}
 
 	var (
-		wg sync.WaitGroup
 		// mutex to secure the next two fields from concurrent access
 		mu sync.Mutex
 		// tablets that are possible candidates to be the new primary and their positions
@@ -138,7 +137,10 @@ func ElectNewPrimary(
 		})
 	}
 
-	wg.Wait()
+	err := errorGroup.Wait()
+	if err != nil {
+		return nil, err
+	}
 
 	// return an error if there are no valid tablets available
 	if len(validTablets) == 0 {
@@ -146,7 +148,7 @@ func ElectNewPrimary(
 	}
 
 	// sort the tablets for finding the best primary
-	err := sortTabletsForReparent(validTablets, tabletPositions, durability)
+	err = sortTabletsForReparent(validTablets, tabletPositions, durability)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtctl/reparentutil/util.go
+++ b/go/vt/vtctl/reparentutil/util.go
@@ -28,6 +28,7 @@ import (
 	"vitess.io/vitess/go/mysql/replication"
 	"vitess.io/vitess/go/mysql/sqlerror"
 	"vitess.io/vitess/go/stats"
+
 	"vitess.io/vitess/go/vt/concurrency"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
@@ -79,6 +80,7 @@ func ElectNewPrimary(
 	}
 
 	var (
+		wg sync.WaitGroup
 		// mutex to secure the next two fields from concurrent access
 		mu sync.Mutex
 		// tablets that are possible candidates to be the new primary and their positions
@@ -136,10 +138,7 @@ func ElectNewPrimary(
 		})
 	}
 
-	err := errorGroup.Wait()
-	if err != nil {
-		return nil, err
-	}
+	wg.Wait()
 
 	// return an error if there are no valid tablets available
 	if len(validTablets) == 0 {
@@ -147,7 +146,7 @@ func ElectNewPrimary(
 	}
 
 	// sort the tablets for finding the best primary
-	err = sortTabletsForReparent(validTablets, tabletPositions, durability)
+	err := sortTabletsForReparent(validTablets, tabletPositions, durability)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

Revert `Improvements to PRS #13623`

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
