### PR TITLE
fix `make docker_bootstrap` to be compatible with vitess-addons

### DIFF
--- a/docker/bootstrap/Dockerfile.common
+++ b/docker/bootstrap/Dockerfile.common
@@ -25,6 +25,14 @@ ENV VTPORTSTART 15000
 ENV PATH $VTROOT/bin:$VTROOT/dist/maven/bin:$PATH
 ENV USER vitess
 
+# Allows private repo go dependencies
+ARG GH_ACCESS_TOKEN
+ENV GH_ACCESS_TOKEN=${GH_ACCESS_TOKEN}
+
+# Allow checkout of github.com/slackhq/vitess-addons (private repo)
+ENV GOPRIVATE=github.com/slackhq/vitess-addons
+RUN git config --system url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
+
 # Copy files needed for bootstrap
 COPY bootstrap.sh dev.env build.env go.mod go.sum /vt/src/vitess.io/vitess/
 COPY config /vt/src/vitess.io/vitess/config

--- a/docker/bootstrap/build.sh
+++ b/docker/bootstrap/build.sh
@@ -63,6 +63,7 @@ if [ -f "docker/bootstrap/Dockerfile.$flavor" ]; then
     docker build \
       -f docker/bootstrap/Dockerfile.$flavor \
       -t $image \
+      --build-arg GH_ACCESS_TOKEN="$GH_ACCESS_TOKEN" \
       --build-arg bootstrap_version=$version \
       --build-arg image=$base_image \
       .


### PR DESCRIPTION
## Description

allows `make docker_bootstrap` to work with GH token for slack-19.0


## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ NA] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ NA] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ NA ] Tests were added or are not required
-   [ NA ] Did the new or modified tests pass consistently locally and on CI?
-   [ NA ] Documentation was added or is not required

## Deployment Notes

utility for building, not deployment related