### PR TITLE
Revert "Improve tablet types to wait (#643)"

### DIFF
--- a/examples/region_sharding/101_initial_cluster.sh
+++ b/examples/region_sharding/101_initial_cluster.sh
@@ -30,10 +30,8 @@ fi
 CELL=zone1 ../common/scripts/vtctld-up.sh
 
 # start unsharded keyspace and tablet
-for T_UID in 100 101; do
-	CELL=zone1 TABLET_UID="${T_UID}" ../common/scripts/mysqlctl-up.sh
-	SHARD=0 CELL=zone1 KEYSPACE=main TABLET_UID="${T_UID}" ../common/scripts/vttablet-up.sh
-done
+CELL=zone1 TABLET_UID=100 ../common/scripts/mysqlctl-up.sh
+SHARD=0 CELL=zone1 KEYSPACE=main TABLET_UID=100 ../common/scripts/vttablet-up.sh
 
 # set the correct durability policy for the keyspace
 vtctldclient --server localhost:15999 SetKeyspaceDurabilityPolicy --durability-policy=none main || fail "Failed to set keyspace durability policy on the main keyspace"

--- a/go/vt/vtgate/tabletgateway.go
+++ b/go/vt/vtgate/tabletgateway.go
@@ -207,8 +207,9 @@ func (gw *TabletGateway) WaitForTablets(ctx context.Context, tabletTypesToWait [
 		case context.DeadlineExceeded:
 			// In this scenario, we were able to reach the
 			// topology service, but some tablets may not be
-			// ready.
+			// ready. We just warn and keep going.
 			log.Warningf("Timeout waiting for all keyspaces / shards to have healthy tablets of types %v, may be in degraded mode", tabletTypesToWait)
+			err = nil
 		}
 	}()
 

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -262,21 +262,8 @@ func Init(
 	// TabletGateway can create it's own healthcheck
 	gw := NewTabletGateway(ctx, hc, serv, cell)
 	gw.RegisterStats()
-
-	// Retry loop for potential time-outs waiting for all tablets.
-OuterLoop:
-	for {
-		err := gw.WaitForTablets(ctx, tabletTypesToWait)
-		switch {
-		case err == nil:
-			break OuterLoop
-		case errors.Is(err, context.DeadlineExceeded):
-			log.Warning("TabletGateway timed out waiting for tablets to become available - retrying.")
-
-			continue
-		default:
-			log.Fatalf("tabletGateway.WaitForTablets failed: %v", err)
-		}
+	if err := gw.WaitForTablets(ctx, tabletTypesToWait); err != nil {
+		log.Fatalf("tabletGateway.WaitForTablets failed: %v", err)
 	}
 
 	// If we want to filter keyspaces replace the srvtopo.Server with a


### PR DESCRIPTION
This reverts commit 24c3c26d2956c8449702e4168806f985a29e5393.

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

vtgate startup hung due to infinite wait of tablet healthchecks

revert https://github.com/slackhq/vitess/pull/644

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
