### PR TITLE
tabletblancer: register debug endpoint to the servenv mux

### DIFF
--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -438,7 +438,7 @@ func (vtg *VTGate) registerDebugHealthHandler() {
 }
 
 func (vtg *VTGate) registerDebugBalancerHandler() {
-	http.HandleFunc("/debug/balancer", func(w http.ResponseWriter, r *http.Request) {
+	servenv.HTTPHandleFunc("/debug/balancer", func(w http.ResponseWriter, r *http.Request) {
 		vtg.Gateway().DebugBalancerHandler(w, r)
 	})
 }


### PR DESCRIPTION
## Description

Fixes a bug that makes the tabletbalancer debug page inaccessible. Debug pages should be registered on the servenv mux since https://github.com/vitessio/vitess/pull/12987

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
