### PR TITLE
Add ConnPoolInUse metrics for DBA  pools

### DIFF
--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -157,11 +157,14 @@ func NewMysqld(dbcfgs *dbconfigs.DBConfigs) *Mysqld {
 	}
 
 	// Create and open the connection pool for dba access.
-	result.dbaPool = dbconnpool.NewConnectionPool("DbaConnPool", nil, dbaPoolSize, DbaIdleTimeout, 0, PoolDynamicHostnameResolution)
+	exporter := servenv.NewExporter("MySQLDaemon", "")
+	result.dbaPool = dbconnpool.NewConnectionPool("DbaConnPool", exporter, dbaPoolSize, DbaIdleTimeout, 0, PoolDynamicHostnameResolution)
+	result.dbaPool.ConnPool.RegisterStats(exporter, "DbaConnPool")
 	result.dbaPool.Open(dbcfgs.DbaWithDB())
 
 	// Create and open the connection pool for app access.
-	result.appPool = dbconnpool.NewConnectionPool("AppConnPool", nil, appPoolSize, appIdleTimeout, 0, PoolDynamicHostnameResolution)
+	result.appPool = dbconnpool.NewConnectionPool("AppConnPool", exporter, appPoolSize, appIdleTimeout, 0, PoolDynamicHostnameResolution)
+	result.appPool.ConnPool.RegisterStats(exporter, "AppConnPool")
 	result.appPool.Open(dbcfgs.AppWithDB())
 
 	/*

--- a/go/vt/vttablet/tabletserver/connpool/pool.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool.go
@@ -85,6 +85,9 @@ func NewPool(env tabletenv.Env, name string, cfg tabletenv.ConnPoolConfig) *Pool
 	cp.ConnPool.RegisterStats(env.Exporter(), name)
 
 	cp.dbaPool = dbconnpool.NewConnectionPool("", env.Exporter(), 1, config.IdleTimeout, config.MaxLifetime, 0)
+	if name != "" {
+		cp.dbaPool.ConnPool.RegisterStats(env.Exporter(), name+"DbaPool")
+	}
 
 	return cp
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
  - Fixed DBA pools in TabletServer and MySQLDaemon to
  emit connection pool metrics like `ConnPoolInUse`
  - Added `RegisterStats` calls for DBA pools that were
  previously missing metrics registration

## Changes Made

  ### TabletServer DBA Pool Fix
  - Added `RegisterStats` call for the embedded DBA pool
  in `connpool/pool.go`
  - Metrics will be named like `<poolname>DbaPoolInUse`,
  `<poolname>DbaPoolCapacity`, etc.

  ### MySQLDaemon Pools Fix
  - Created proper stats exporter with
  `servenv.NewExporter("MySQLDaemon", "")`
  - Updated both DBA and App pools to use the exporter
  and register metrics
  - DBA pool metrics: `DbaConnPoolInUse`,
  `DbaConnPoolCapacity`, etc.
  - App pool metrics: `AppConnPoolInUse`,
  `AppConnPoolCapacity`, etc.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
