### PR TITLE
vtorc: ignore stale replicas during emergency reparent

### DIFF
--- a/go/vt/vtorc/inst/instance_dao.go
+++ b/go/vt/vtorc/inst/instance_dao.go
@@ -685,17 +685,17 @@ func ReadInstancesWithErrantGTIds(keyspace string, shard string) ([]*Instance, e
 	return readInstancesByCondition(condition, args, "")
 }
 
-// ReadStaleReplicaAliases reads tablet aliases of replicas in a keyspace/shard that have been failing discovery for more than 1 hour
+// ReadStaleReplicaAliases reads tablet aliases of replicas in a keyspace/shard that have been failing discovery for more than the configured timeout
 func ReadStaleReplicaAliases(keyspace string, shard string) ([]string, error) {
 	condition := `
 		keyspace = ?
 		and shard = ?
 		and tablet_type != 1
-		and seconds_since_last_seen > 3600
+		and seconds_since_last_seen > ?
 		and is_last_check_valid = 0
 	`
 
-	instances, err := readInstancesByCondition(condition, sqlutils.Args(keyspace, shard), "")
+	instances, err := readInstancesByCondition(condition, sqlutils.Args(keyspace, shard, config.Config.StaleReplicaTimeoutSeconds), "")
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtorc/inst/instance_dao.go
+++ b/go/vt/vtorc/inst/instance_dao.go
@@ -685,16 +685,14 @@ func ReadInstancesWithErrantGTIds(keyspace string, shard string) ([]*Instance, e
 	return readInstancesByCondition(condition, args, "")
 }
 
-// ReadStaleReplicaAliases reads tablet aliases of replicas in a keyspace/shard that haven't been successfully discovered in the last hour
+// ReadStaleReplicaAliases reads tablet aliases of replicas in a keyspace/shard that have been failing discovery for more than 1 hour
 func ReadStaleReplicaAliases(keyspace string, shard string) ([]string, error) {
 	condition := `
 		keyspace = ?
 		and shard = ?
 		and tablet_type != 'PRIMARY'
-		and (
-			seconds_since_last_seen > 3600
-			or is_last_check_valid = 0
-		)
+		and seconds_since_last_seen > 3600
+		and is_last_check_valid = 0
 	`
 
 	instances, err := readInstancesByCondition(condition, sqlutils.Args(keyspace, shard), "")

--- a/go/vt/vtorc/inst/instance_dao.go
+++ b/go/vt/vtorc/inst/instance_dao.go
@@ -690,7 +690,7 @@ func ReadStaleReplicaAliases(keyspace string, shard string) ([]string, error) {
 	condition := `
 		keyspace = ?
 		and shard = ?
-		and tablet_type != 'PRIMARY'
+		and tablet_type != 1
 		and seconds_since_last_seen > 3600
 		and is_last_check_valid = 0
 	`


### PR DESCRIPTION
When running emergency reparent operations, VTOrc now ignores replicas that haven't been successfully discovered in the last hour or had failed discovery attempts. This prevents ERS from hanging on unhealthy replicas and makes recovery faster and more reliable.

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
