### PR TITLE
vtorc: Add configurable block time period for DeadPrimary recovery types

### DIFF
--- a/go/vt/vtorc/config/config_test.go
+++ b/go/vt/vtorc/config/config_test.go
@@ -231,4 +231,19 @@ func TestUpdateConfigValuesFromFlags(t *testing.T) {
 		UpdateConfigValuesFromFlags()
 		require.Equal(t, testConfig, Config)
 	})
+
+	t.Run("override deadPrimaryRecoveryPeriodBlockDuration", func(t *testing.T) {
+		oldDeadPrimaryRecoveryPeriodBlockDuration := deadPrimaryRecoveryPeriodBlockDuration
+		deadPrimaryRecoveryPeriodBlockDuration = 10 * time.Minute
+		// Restore the changes we make
+		defer func() {
+			Config = newConfiguration()
+			deadPrimaryRecoveryPeriodBlockDuration = oldDeadPrimaryRecoveryPeriodBlockDuration
+		}()
+
+		testConfig := newConfiguration()
+		testConfig.DeadPrimaryRecoveryPeriodBlockSeconds = 600
+		UpdateConfigValuesFromFlags()
+		require.Equal(t, testConfig, Config)
+	})
 }


### PR DESCRIPTION
This change introduces differential recovery timeout handling for DeadPrimary and DeadPrimaryAndSomeReplicas analysis types in VTOrc.

Key changes:
- Add new --dead-primary-recovery-period-block-duration flag (default: 5 minutes)
- DeadPrimary and DeadPrimaryAndSomeReplicas recoveries now use separate timeout
- Other recovery types continue to use existing --recovery-period-block-duration
- Optimize ClearActiveRecoveries to use single SQL statement with CASE expression

This prevents rapid re-recovery attempts on primary failures while maintaining faster recovery cycling for other failure types.

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
