### PR TITLE
Vtgateproxy rework register flags

### DIFF
--- a/go/cmd/vtgateproxy/vtgateproxy.go
+++ b/go/cmd/vtgateproxy/vtgateproxy.go
@@ -23,14 +23,24 @@ import (
 	"google.golang.org/grpc/channelz/service"
 
 	"vitess.io/vitess/go/exit"
+	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/stats/prometheusbackend"
+	"vitess.io/vitess/go/trace"
+	"vitess.io/vitess/go/vt/grpcclient"
+	"vitess.io/vitess/go/vt/grpccommon"
 	"vitess.io/vitess/go/vt/servenv"
+	"vitess.io/vitess/go/vt/vtgate/grpcvtgateconn"
 	"vitess.io/vitess/go/vt/vtgateproxy"
 )
 
 func init() {
 	servenv.RegisterDefaultFlags()
 	servenv.RegisterGRPCServerFlags()
+	servenv.OnParseFor("vtgateproxy", trace.RegisterFlags)
+	servenv.OnParseFor("vtgateproxy", stats.RegisterFlags)
+	servenv.OnParseFor("vtgateproxy", grpccommon.RegisterFlags)
+	servenv.OnParseFor("vtgateproxy", grpcclient.RegisterFlags)
+	servenv.OnParseFor("vtgateproxy", grpcvtgateconn.RegisterFlags)
 }
 
 func main() {

--- a/go/vt/grpcclient/client.go
+++ b/go/vt/grpcclient/client.go
@@ -58,7 +58,6 @@ var (
 		"vtctld",
 		"vtgate",
 		"vtgateclienttest",
-		"vtgateproxy",
 		"vtorc",
 		"vttablet",
 		"vttestserver",

--- a/go/vt/servenv/servenv.go
+++ b/go/vt/servenv/servenv.go
@@ -438,7 +438,6 @@ func init() {
 		"vtctlclient",
 		"vtctld",
 		"vtgate",
-		"vtgateproxy",
 		"vttablet",
 	} {
 		OnParseFor(cmd, trace.RegisterFlags)
@@ -454,7 +453,6 @@ func init() {
 		"vtgate",
 		"vtgateclienttest",
 		"vtorc",
-		"vtgateproxy",
 		"vttablet",
 		"vttestserver",
 	} {
@@ -467,7 +465,6 @@ func init() {
 		"vtcombo",
 		"vtctld",
 		"vtgate",
-		"vtgateproxy",
 		"vttablet",
 		"vtorc",
 	} {

--- a/go/vt/vtgate/grpcvtgateconn/conn.go
+++ b/go/vt/vtgate/grpcvtgateconn/conn.go
@@ -55,7 +55,6 @@ func init() {
 		"vtcombo",
 		"vtctl",
 		"vttestserver",
-		"vtgateproxy",
 	} {
 		servenv.OnParseFor(cmd, RegisterFlags)
 	}


### PR DESCRIPTION
## Description
As part of reducing the touch points for vtgateproxy inside the main vitess codebase, change the way that the binary registers the various command line flags so that it explicitly calls the various register functions rather than relying on having the binary name in the internal list.

IMHO this would be a better way for _all_ the vitess binaries to manage registering their flags, as I feel like the hard-coded list of strings feels somewhat odd, but that's a question for the maintainers upstream and doesn't really affect us here.

## Testing
Confirmed that the output of `vtgateproxy --help` is the same before and after the change so this registers all the same flags

## Benefits
With this patch in place, the proxy-specific diffs on this branch include:
```
[mdemmer-ltmzvnq] -> git diff --stat vtgateproxy-v19-base
 go.mod                                           |   8 +-
 go.sum                                           |   9 ++
 go/cmd/vtgateproxy/.gitignore                    |   1 +
 go/cmd/vtgateproxy/vtgateproxy                   | Bin 32493648 -> 0 bytes
 go/cmd/vtgateproxy/vtgateproxy.go                |  68 ++++++++++++++
 go/mysql/conn.go                                 |   5 ++
 go/mysql/constants.go                            |   4 +
 go/mysql/server.go                               |  46 +++++-----
 go/test/endtoend/vtgateproxy/failure_test.go     | 219 ++++++++++++++++++++++++++++++++++++++++++++
 go/test/endtoend/vtgateproxy/main_test.go        | 480 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 go/test/endtoend/vtgateproxy/rebalance_test.go   | 171 +++++++++++++++++++++++++++++++++++
 go/test/endtoend/vtgateproxy/scale_test.go       | 190 +++++++++++++++++++++++++++++++++++++++
 go/test/endtoend/vtgateproxy/vtgateproxy_test.go | 118 ++++++++++++++++++++++++
 go/vt/vtgate/grpcvtgateconn/conn.go              |  18 ++--
 go/vt/vtgate/vtgateconn/vtgateconn.go            |   7 +-
 go/vt/vtgateproxy/discovery.go                   | 519 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 go/vt/vtgateproxy/firstready_balancer.go         | 103 +++++++++++++++++++++
 go/vt/vtgateproxy/mysql_server.go                | 659 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 go/vt/vtgateproxy/sim/go.mod                     |   5 ++
 go/vt/vtgateproxy/sim/go.sum                     |   2 +
 go/vt/vtgateproxy/sim/vtgateproxysim.go          | 101 +++++++++++++++++++++
 go/vt/vtgateproxy/sticky_random_balancer.go      | 110 +++++++++++++++++++++++
 go/vt/vtgateproxy/vtgateproxy.go                 | 246 ++++++++++++++++++++++++++++++++++++++++++++++++++
 test/config.json                                 |   9 ++
```

With this diff in place, the only upstream changes are those in `go/mysql` and `go/vt/vtgate` for which I opened upstream PRs here:

https://github.com/vitessio/vitess/pull/18548
https://github.com/vitessio/vitess/pull/18551

So between those two changes and the patches in this branch, we should be better positioned to maintain the proxy outside of the main repo.
