### PR TITLE
locking fixes for GlobalReadLock held for logical backups

### DIFF
--- a/go/vt/mysqlctl/fakemysqldaemon.go
+++ b/go/vt/mysqlctl/fakemysqldaemon.go
@@ -750,11 +750,8 @@ func (fmd *FakeMysqlDaemon) AcquireGlobalReadLock(ctx context.Context) error {
 }
 
 // ReleaseGlobalReadLock is part of the MysqlDaemon interface.
-func (fmd *FakeMysqlDaemon) ReleaseGlobalReadLock(ctx context.Context) error {
+func (fmd *FakeMysqlDaemon) ReleaseGlobalReadLock(ctx context.Context) {
 	if fmd.GlobalReadLock {
 		fmd.GlobalReadLock = false
-		return nil
 	}
-
-	return errors.New("no read locks acquired yet")
 }

--- a/go/vt/mysqlctl/mysql_daemon.go
+++ b/go/vt/mysqlctl/mysql_daemon.go
@@ -128,7 +128,7 @@ type MysqlDaemon interface {
 	AcquireGlobalReadLock(ctx context.Context) error
 
 	// ReleaseGlobalReadLock release a lock acquired with the connection from the above function.
-	ReleaseGlobalReadLock(ctx context.Context) error
+	ReleaseGlobalReadLock(ctx context.Context)
 
 	// Close will close this instance of Mysqld. It will wait for all dba
 	// queries to be finished.

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -106,10 +106,12 @@ var (
 
 // Mysqld is the object that represents a mysqld daemon running on this server.
 type Mysqld struct {
-	dbcfgs   *dbconfigs.DBConfigs
-	dbaPool  *dbconnpool.ConnectionPool
-	appPool  *dbconnpool.ConnectionPool
-	lockConn *dbconnpool.PooledDBConnection
+	dbcfgs  *dbconfigs.DBConfigs
+	dbaPool *dbconnpool.ConnectionPool
+	appPool *dbconnpool.ConnectionPool
+
+	lockConnMutex sync.Mutex
+	lockConn      *dbconnpool.PooledDBConnection
 
 	capabilities capabilitySet
 

--- a/go/vt/mysqlctl/mysqlshellbackupengine.go
+++ b/go/vt/mysqlctl/mysqlshellbackupengine.go
@@ -157,7 +157,7 @@ func (be *MySQLShellBackupEngine) ExecuteBackup(ctx context.Context, params Back
 	// we need to release the global read lock in case the backup fails to start and
 	// the lock wasn't released by releaseReadLock() yet. context might be expired,
 	// so we pass a new one.
-	defer func() { _ = params.Mysqld.ReleaseGlobalReadLock(context.Background()) }()
+	defer func() { params.Mysqld.ReleaseGlobalReadLock(context.Background()) }()
 
 	posBeforeBackup, err := params.Mysqld.PrimaryPosition()
 	if err != nil {
@@ -524,12 +524,7 @@ func releaseReadLock(ctx context.Context, reader io.Reader, params BackupParams,
 			released = true
 
 			params.Logger.Infof("mysql shell released its global read lock, doing the same")
-
-			err := params.Mysqld.ReleaseGlobalReadLock(ctx)
-			if err != nil {
-				params.Logger.Errorf("unable to release global read lock: %v", err)
-			}
-
+			params.Mysqld.ReleaseGlobalReadLock(ctx)
 			params.Logger.Infof("global read lock released after %v", time.Since(lockAcquired))
 		}
 	}


### PR DESCRIPTION
Discussion in thread: https://slack-pde.slack.com/archives/C06CPL4HMED/p1754349003041139?thread_ts=1753901569.392899&cid=C06CPL4HMED

## Description

We are seeing dbaPool exhaustion on tablets where logical backups are enabled. This PR fixes a couple of problems with concurrent usage and locking paths used by logical backups.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
