### PR TITLE
`slack-21.0` backport: fix version issue when using --mysql-shell-speedup-restore=true (#18310)

### DIFF
--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -166,6 +166,7 @@ func LaunchCluster(setupType int, streamMode string, stripes int, cDetails *Comp
 		mysqlShellArgs := []string{
 			"--backup_engine_implementation", "mysqlshell",
 			"--mysql-shell-backup-location", mysqlShellBackupLocation,
+			"--mysql-shell-speedup-restore=true",
 		}
 		commonTabletArg = append(commonTabletArg, mysqlShellArgs...)
 	}

--- a/go/vt/mysqlctl/mysqlshellbackupengine.go
+++ b/go/vt/mysqlctl/mysqlshellbackupengine.go
@@ -458,14 +458,21 @@ func (be *MySQLShellBackupEngine) restorePreCheck(ctx context.Context, params Re
 			return false, fmt.Errorf("%w: failed to fetch MySQL version: %v", MySQLShellPreCheckError, err)
 		}
 
-		capableOf := mysql.ServerVersionCapableOf(version)
+		_, sv, err := ParseVersionString(version)
+		if err != nil {
+			return false, fmt.Errorf("%w: failed to parse MySQL version (version: %s): %v", MySQLShellPreCheckError, version, err)
+		}
+
+		versionStr := fmt.Sprintf("%d.%d.%d", sv.Major, sv.Minor, sv.Patch)
+
+		capableOf := mysql.ServerVersionCapableOf(versionStr)
 		capable, err := capableOf(capabilities.DisableRedoLogFlavorCapability)
 		if err != nil {
 			return false, fmt.Errorf("%w: error checking if server supports disabling redo log: %v", MySQLShellPreCheckError, err)
 		}
 
 		if !capable {
-			return false, fmt.Errorf("%w: MySQL version doesn't support disabling the redo log (must be >=8.0.21)", MySQLShellPreCheckError)
+			return false, fmt.Errorf("%w: MySQL version doesn't support disabling the redo log (must be >=8.0.21, current version: %s)", MySQLShellPreCheckError, versionStr)
 		}
 	}
 

--- a/go/vt/mysqlctl/mysqlshellbackupengine_test.go
+++ b/go/vt/mysqlctl/mysqlshellbackupengine_test.go
@@ -159,25 +159,58 @@ func TestMySQLShellBackupRestorePreCheckDisableRedolog(t *testing.T) {
 	mysqlShellSpeedUpRestore = true
 	engine := MySQLShellBackupEngine{}
 
+	tests := []struct {
+		version string
+		err     error
+	}{
+		{
+			version: "mysqld  Ver 5.7.27-0ubuntu0.19.04.1 for Linux on x86_64 ((Ubuntu))",
+			err:     MySQLShellPreCheckError,
+		},
+		{
+			version: "mysqld  Ver 5.7.26 for linux-glibc2.12 on x86_64 (MySQL Community Server (GPL))",
+			err:     MySQLShellPreCheckError,
+		},
+		{
+			version: "mysqld  Ver 5.7.26-29 for Linux on x86_64 (Percona Server (GPL), Release 29, Revision 11ad961)",
+			err:     MySQLShellPreCheckError,
+		},
+		{
+			version: "mysqld  Ver 8.0.16 for linux-glibc2.12 on x86_64 (MySQL Community Server - GPL)",
+			err:     MySQLShellPreCheckError,
+		},
+		{
+			version: "mysqld  Ver 8.0.15-6 for Linux on x86_64 (Percona Server (GPL), Release 6, Revision 63abd08)",
+			err:     MySQLShellPreCheckError,
+		},
+		{
+			version: "mysqld  Ver 8.0.42-0ubuntu0.22.04.1 for Linux on x86_64 ((Ubuntu))",
+			err:     nil,
+		},
+		{
+			version: "mysqld  Ver 8.0.42-33 for Linux on x86_64 (Percona Server (GPL), Release '33', Revision '9dc49998')",
+			err:     nil,
+		},
+	}
+
 	fakedb := fakesqldb.New(t)
 	defer fakedb.Close()
-	fakeMysqld := NewFakeMysqlDaemon(fakedb) // defaults to 8.0.32
+	fakeMysqld := NewFakeMysqlDaemon(fakedb)
 	defer fakeMysqld.Close()
 
 	params := RestoreParams{
 		Mysqld: fakeMysqld,
 	}
 
-	// this should work as it is supported since 8.0.21
-	_, err := engine.restorePreCheck(context.Background(), params)
-	require.NoError(t, err, params)
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			fakeMysqld.Version = tt.version
 
-	// it should error out if we change to an older version
-	fakeMysqld.Version = "8.0.20"
+			_, err := engine.restorePreCheck(context.Background(), params)
+			require.ErrorIs(t, err, tt.err)
+		})
+	}
 
-	_, err = engine.restorePreCheck(context.Background(), params)
-	require.ErrorIs(t, err, MySQLShellPreCheckError)
-	require.ErrorContains(t, err, "doesn't support disabling the redo log")
 }
 
 func TestShouldDrainForBackupMySQLShell(t *testing.T) {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->



<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This is a backport of https://github.com/vitessio/vitess/pull/18310

it has already been backported to v19 in https://github.com/slackhq/vitess/pull/666, but doing the same so it is not missed in v21.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
https://github.com/vitessio/vitess/issues/18309
## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
