### PR TITLE
modify version info to make buildsystem variable

### DIFF
--- a/go/vt/servenv/buildinfo.go
+++ b/go/vt/servenv/buildinfo.go
@@ -34,7 +34,8 @@ var (
 	buildGitRev           = ""
 	buildGitBranch        = ""
 	statsBuildVersion     *stats.String
-	jenkinsBuildNumberStr = ""
+	buildNumberStr        = ""
+	buildSystem           = ""
 
 	// version registers the command line flag to expose build info.
 	version bool
@@ -54,7 +55,8 @@ type versionInfo struct {
 	buildTimePretty    string
 	buildGitRev        string
 	buildGitBranch     string
-	jenkinsBuildNumber int64
+	buildNumber        int64
+	buildSystem        string
 	goVersion          string
 	goOS               string
 	goArch             string
@@ -83,12 +85,16 @@ func (v *versionInfo) Print() {
 }
 
 func (v *versionInfo) String() string {
-	jenkins := ""
-	if v.jenkinsBuildNumber != 0 {
-		jenkins = fmt.Sprintf(" (Jenkins build %d)", v.jenkinsBuildNumber)
+	buildInfo := ""
+	if v.buildNumber != 0 {
+		if v.buildSystem != "" {
+			buildInfo = fmt.Sprintf(" (%s build %d)", v.buildSystem, v.buildNumber)
+		} else {
+			buildInfo = fmt.Sprintf(" (Jenkins build %d)", v.buildNumber)
+		}
 	}
 	return fmt.Sprintf("Version: %s%s (Git revision %s branch '%s') built on %s by %s@%s using %s %s/%s",
-		v.version, jenkins, v.buildGitRev, v.buildGitBranch, v.buildTimePretty, v.buildUser, v.buildHost, v.goVersion, v.goOS, v.goArch)
+		v.version, buildInfo, v.buildGitRev, v.buildGitBranch, v.buildTimePretty, v.buildUser, v.buildHost, v.goVersion, v.goOS, v.goArch)
 }
 
 func (v *versionInfo) MySQLVersion() string {
@@ -101,9 +107,9 @@ func init() {
 		panic(fmt.Sprintf("Couldn't parse build timestamp %q: %v", buildTime, err))
 	}
 
-	jenkinsBuildNumber, err := strconv.ParseInt(jenkinsBuildNumberStr, 10, 64)
+	buildNumber, err := strconv.ParseInt(buildNumberStr, 10, 64)
 	if err != nil {
-		jenkinsBuildNumber = 0
+		buildNumber = 0
 	}
 
 	AppVersion = versionInfo{
@@ -113,7 +119,8 @@ func init() {
 		buildTimePretty:    buildTime,
 		buildGitRev:        buildGitRev,
 		buildGitBranch:     buildGitBranch,
-		jenkinsBuildNumber: jenkinsBuildNumber,
+		buildNumber:        buildNumber,
+		buildSystem:        buildSystem,
 		goVersion:          runtime.Version(),
 		goOS:               runtime.GOOS,
 		goArch:             runtime.GOARCH,
@@ -126,7 +133,7 @@ func init() {
 	statsBuildVersion.Set(AppVersion.version)
 	stats.NewString("BuildGitRev").Set(AppVersion.buildGitRev)
 	stats.NewString("BuildGitBranch").Set(AppVersion.buildGitBranch)
-	stats.NewGauge("BuildNumber", "build number").Set(AppVersion.jenkinsBuildNumber)
+	stats.NewGauge("BuildNumber", "build number").Set(AppVersion.buildNumber)
 	stats.NewString("GoVersion").Set(AppVersion.goVersion)
 	stats.NewString("GoOS").Set(AppVersion.goOS)
 	stats.NewString("GoArch").Set(AppVersion.goArch)
@@ -138,7 +145,7 @@ func init() {
 		fmt.Sprintf("%v", AppVersion.buildTime),
 		AppVersion.buildGitRev,
 		AppVersion.buildGitBranch,
-		fmt.Sprintf("%v", AppVersion.jenkinsBuildNumber),
+		fmt.Sprintf("%v", AppVersion.buildNumber),
 	}
 	stats.NewGaugesWithMultiLabels("BuildInformation", "build information exposed via label", buildLabels).Set(buildValues, 1)
 

--- a/go/vt/servenv/buildinfo.go
+++ b/go/vt/servenv/buildinfo.go
@@ -28,14 +28,14 @@ import (
 )
 
 var (
-	buildHost             = ""
-	buildUser             = ""
-	buildTime             = ""
-	buildGitRev           = ""
-	buildGitBranch        = ""
-	statsBuildVersion     *stats.String
-	buildNumberStr        = ""
-	buildSystem           = ""
+	buildHost         = ""
+	buildUser         = ""
+	buildTime         = ""
+	buildGitRev       = ""
+	buildGitBranch    = ""
+	statsBuildVersion *stats.String
+	buildNumberStr    = ""
+	buildSystem       = ""
 
 	// version registers the command line flag to expose build info.
 	version bool
@@ -49,18 +49,18 @@ func registerVersionFlag(fs *pflag.FlagSet) {
 var AppVersion versionInfo
 
 type versionInfo struct {
-	buildHost          string
-	buildUser          string
-	buildTime          int64
-	buildTimePretty    string
-	buildGitRev        string
-	buildGitBranch     string
-	buildNumber        int64
-	buildSystem        string
-	goVersion          string
-	goOS               string
-	goArch             string
-	version            string
+	buildHost       string
+	buildUser       string
+	buildTime       int64
+	buildTimePretty string
+	buildGitRev     string
+	buildGitBranch  string
+	buildNumber     int64
+	buildSystem     string
+	goVersion       string
+	goOS            string
+	goArch          string
+	version         string
 }
 
 // ToStringMap returns the version info as a map[string]string, allowing version
@@ -113,18 +113,18 @@ func init() {
 	}
 
 	AppVersion = versionInfo{
-		buildHost:          buildHost,
-		buildUser:          buildUser,
-		buildTime:          t.Unix(),
-		buildTimePretty:    buildTime,
-		buildGitRev:        buildGitRev,
-		buildGitBranch:     buildGitBranch,
-		buildNumber:        buildNumber,
-		buildSystem:        buildSystem,
-		goVersion:          runtime.Version(),
-		goOS:               runtime.GOOS,
-		goArch:             runtime.GOARCH,
-		version:            versionName,
+		buildHost:       buildHost,
+		buildUser:       buildUser,
+		buildTime:       t.Unix(),
+		buildTimePretty: buildTime,
+		buildGitRev:     buildGitRev,
+		buildGitBranch:  buildGitBranch,
+		buildNumber:     buildNumber,
+		buildSystem:     buildSystem,
+		goVersion:       runtime.Version(),
+		goOS:            runtime.GOOS,
+		goArch:          runtime.GOARCH,
+		version:         versionName,
 	}
 	stats.NewString("BuildHost").Set(AppVersion.buildHost)
 	stats.NewString("BuildUser").Set(AppVersion.buildUser)

--- a/go/vt/servenv/buildinfo_test.go
+++ b/go/vt/servenv/buildinfo_test.go
@@ -39,11 +39,16 @@ func TestVersionString(t *testing.T) {
 		version:         "v1.2.3-SNAPSHOT",
 	}
 
+	// Test case 1: No build number or system
 	assert.Equal(t, "Version: v1.2.3-SNAPSHOT (Git revision d54b87ca0be09b678bb4490060e8f23f890ddb92 branch 'gitBranch') built on time is now by user@host using 1.20.2 amiga/amd64", v.String())
 
-	v.jenkinsBuildNumber = 422
-
+	// Test case 2: With build number but no build system (defaults to Jenkins)
+	v.buildNumber = 422
 	assert.Equal(t, "Version: v1.2.3-SNAPSHOT (Jenkins build 422) (Git revision d54b87ca0be09b678bb4490060e8f23f890ddb92 branch 'gitBranch') built on time is now by user@host using 1.20.2 amiga/amd64", v.String())
+	
+	// Test case 3: With build number and custom build system
+	v.buildSystem = "GHA"
+	assert.Equal(t, "Version: v1.2.3-SNAPSHOT (GHA build 422) (Git revision d54b87ca0be09b678bb4490060e8f23f890ddb92 branch 'gitBranch') built on time is now by user@host using 1.20.2 amiga/amd64", v.String())
 
 	assert.Equal(t, "8.0.30-Vitess", v.MySQLVersion())
 }

--- a/go/vt/servenv/buildinfo_test.go
+++ b/go/vt/servenv/buildinfo_test.go
@@ -45,7 +45,7 @@ func TestVersionString(t *testing.T) {
 	// Test case 2: With build number but no build system (defaults to Jenkins)
 	v.buildNumber = 422
 	assert.Equal(t, "Version: v1.2.3-SNAPSHOT (Jenkins build 422) (Git revision d54b87ca0be09b678bb4490060e8f23f890ddb92 branch 'gitBranch') built on time is now by user@host using 1.20.2 amiga/amd64", v.String())
-	
+
 	// Test case 3: With build number and custom build system
 	v.buildSystem = "GHA"
 	assert.Equal(t, "Version: v1.2.3-SNAPSHOT (GHA build 422) (Git revision d54b87ca0be09b678bb4490060e8f23f890ddb92 branch 'gitBranch') built on time is now by user@host using 1.20.2 amiga/amd64", v.String())

--- a/tools/build_version_flags.sh
+++ b/tools/build_version_flags.sh
@@ -31,5 +31,6 @@ echo "\
   -X 'vitess.io/vitess/go/vt/servenv.buildGitRev=${BUILD_GIT_REV:-$DEFAULT_BUILD_GIT_REV}' \
   -X 'vitess.io/vitess/go/vt/servenv.buildGitBranch=${BUILD_GIT_BRANCH:-$DEFAULT_BUILD_GIT_BRANCH}' \
   -X 'vitess.io/vitess/go/vt/servenv.buildTime=${BUILD_TIME:-$DEFAULT_BUILD_TIME}' \
-  -X 'vitess.io/vitess/go/vt/servenv.jenkinsBuildNumberStr=${BUILD_NUMBER}' \
+  -X 'vitess.io/vitess/go/vt/servenv.buildNumberStr=${BUILD_NUMBER}' \
+  -X 'vitess.io/vitess/go/vt/servenv.buildSystem=${BUILD_SYSTEM}' \
 "


### PR DESCRIPTION
## Description

Modifies the version info so build system can be passed in

currently labes anything with a build number as being built in Jenkins

## Checklist

-   [X] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [X] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [X] Tests were added or are not required
-   [X] Did the new or modified tests pass consistently locally and on CI?
-   [X] Documentation was added or is not required

## Deployment Notes
none
