### PR TITLE
fix: consolidator waiter cap fallback to independent execution

### DIFF
--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -52,6 +52,7 @@ Flags:
       --config-persistence-min-interval duration                         minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                               Config file type (omit to infer config type from file extension).
       --consolidator-query-waiter-cap int                                Configure the maximum number of clients allowed to wait on the consolidator.
+      --consolidator-query-waiter-cap-method string                      Configure the method when consolidator waiter cap is exceeded. Options: fallthrough, reject. (default "fallthrough")
       --consolidator-stream-query-size int                               Configure the stream consolidator query size in bytes. Setting to 0 disables the stream consolidator. (default 2097152)
       --consolidator-stream-total-size int                               Configure the stream consolidator total size in bytes. Setting to 0 disables the stream consolidator. (default 134217728)
       --consul_auth_static_file string                                   JSON File to read the topos/tokens from.

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -86,6 +86,7 @@ Flags:
       --config-persistence-min-interval duration                         minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                               Config file type (omit to infer config type from file extension).
       --consolidator-query-waiter-cap int                                Configure the maximum number of clients allowed to wait on the consolidator.
+      --consolidator-query-waiter-cap-method string                      Configure the method when consolidator waiter cap is exceeded. Options: fallthrough, reject. (default "fallthrough")
       --consolidator-stream-query-size int                               Configure the stream consolidator query size in bytes. Setting to 0 disables the stream consolidator. (default 2097152)
       --consolidator-stream-total-size int                               Configure the stream consolidator total size in bytes. Setting to 0 disables the stream consolidator. (default 134217728)
       --consul_auth_static_file string                                   JSON File to read the topos/tokens from.

--- a/go/sync2/fake_consolidator.go
+++ b/go/sync2/fake_consolidator.go
@@ -51,8 +51,12 @@ type FakePendingResult struct {
 	BroadcastCalls int
 	// WaitCalls can be used to inspect Wait calls.
 	WaitCalls int
-	err       error
-	result    *sqltypes.Result
+	// AddWaiterCounterCalls can be used to inspect AddWaiterCounter calls.
+	AddWaiterCounterCalls []int64
+	// WaiterCount simulates the current waiter count
+	WaiterCount int64
+	err         error
+	result      *sqltypes.Result
 }
 
 var (
@@ -113,7 +117,9 @@ func (fr *FakePendingResult) Wait() {
 	fr.WaitCalls++
 }
 
-// AddWaiterCounter is currently a no-op.
-func (fr *FakePendingResult) AddWaiterCounter(int64) *int64 {
-	return new(int64)
+// AddWaiterCounter records the call and simulates waiter count changes.
+func (fr *FakePendingResult) AddWaiterCounter(delta int64) *int64 {
+	fr.AddWaiterCounterCalls = append(fr.AddWaiterCounterCalls, delta)
+	fr.WaiterCount += delta
+	return &fr.WaiterCount
 }

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -719,16 +719,16 @@ func (qre *QueryExecutor) execSelect() (*sqltypes.Result, error) {
 				startTime := time.Now()
 				q.Wait()
 				qre.tsv.stats.WaitTimings.Record("Consolidations", startTime)
+				q.AddWaiterCounter(-1)
 			} else {
 				// Waiter cap exceeded, handle based on configured method
-
+				q.AddWaiterCounter(-1)
 				if qre.tsv.config.ConsolidatorQueryWaiterCapMethod == "reject" {
 					return nil, vterrors.Errorf(vtrpcpb.Code_RESOURCE_EXHAUSTED, "consolidator waiter cap (%d) exceeded", waiterCap)
 				}
 				// Default to fallback to independent query execution
 				waiterCapExceeded = true
 			}
-			q.AddWaiterCounter(-1)
 		}
 
 		// Return consolidation results unless waiter cap was exceeded

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -719,16 +719,16 @@ func (qre *QueryExecutor) execSelect() (*sqltypes.Result, error) {
 				startTime := time.Now()
 				q.Wait()
 				qre.tsv.stats.WaitTimings.Record("Consolidations", startTime)
-				q.AddWaiterCounter(-1)
 			} else {
 				// Waiter cap exceeded, handle based on configured method
-				q.AddWaiterCounter(-1)
+
 				if qre.tsv.config.ConsolidatorQueryWaiterCapMethod == "reject" {
 					return nil, vterrors.Errorf(vtrpcpb.Code_RESOURCE_EXHAUSTED, "consolidator waiter cap (%d) exceeded", waiterCap)
 				}
 				// Default to fallback to independent query execution
 				waiterCapExceeded = true
 			}
+			q.AddWaiterCounter(-1)
 		}
 
 		// Return consolidation results unless waiter cap was exceeded

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -721,9 +721,13 @@ func (qre *QueryExecutor) execSelect() (*sqltypes.Result, error) {
 				qre.tsv.stats.WaitTimings.Record("Consolidations", startTime)
 				q.AddWaiterCounter(-1)
 			} else {
-				// Waiter cap exceeded, fall back to independent query execution
-				waiterCapExceeded = true
+				// Waiter cap exceeded, handle based on configured method
 				q.AddWaiterCounter(-1)
+				if qre.tsv.config.ConsolidatorQueryWaiterCapMethod == "reject" {
+					return nil, vterrors.Errorf(vtrpcpb.Code_RESOURCE_EXHAUSTED, "consolidator waiter cap (%d) exceeded", waiterCap)
+				}
+				// Default to fallback to independent query execution
+				waiterCapExceeded = true
 			}
 		}
 

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -698,6 +698,8 @@ func (qre *QueryExecutor) execSelect() (*sqltypes.Result, error) {
 	// Check tablet type.
 	if qre.shouldConsolidate() {
 		q, original := qre.tsv.qe.consolidator.Create(sqlWithoutComments)
+		waiterCapExceeded := false
+
 		if original {
 			defer q.Broadcast()
 			conn, err := qre.getConn()
@@ -717,13 +719,22 @@ func (qre *QueryExecutor) execSelect() (*sqltypes.Result, error) {
 				startTime := time.Now()
 				q.Wait()
 				qre.tsv.stats.WaitTimings.Record("Consolidations", startTime)
+				q.AddWaiterCounter(-1)
+			} else {
+				// Waiter cap exceeded, fall back to independent query execution
+				waiterCapExceeded = true
+				q.AddWaiterCounter(-1)
 			}
-			q.AddWaiterCounter(-1)
 		}
-		if q.Err() != nil {
-			return nil, q.Err()
+
+		// Return consolidation results unless waiter cap was exceeded
+		if !waiterCapExceeded {
+			if q.Err() != nil {
+				return nil, q.Err()
+			}
+			return q.Result(), nil
 		}
-		return q.Result(), nil
+		// If waiter cap exceeded, fall through to independent execution
 	}
 	conn, err := qre.getConn()
 	if err != nil {

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1437,6 +1437,79 @@ func TestQueryExecutorShouldConsolidate(t *testing.T) {
 	}
 }
 
+func TestQueryExecutorConsolidatorWaiterCapFallback(t *testing.T) {
+	// Test that when the consolidator waiter cap is reached, queries fall back
+	// to independent execution instead of returning empty results.
+
+	db := setUpQueryExecutorTest(t)
+	defer db.Close()
+
+	ctx := context.Background()
+	tsv := newTestTabletServer(ctx, enableConsolidator, db)
+	defer tsv.StopService()
+
+	// Set a waiter cap of 1
+	tsv.config.ConsolidatorQueryWaiterCap = 1
+
+	fakeConsolidator := sync2.NewFakeConsolidator()
+	tsv.qe.consolidator = fakeConsolidator
+
+	input := "select * from t limit 10001"
+	result := &sqltypes.Result{
+		Fields: getTestTableFields(),
+		Rows: [][]sqltypes.Value{{
+			sqltypes.NewInt32(1),   // pk
+			sqltypes.NewInt32(100), // name
+			sqltypes.NewInt32(200), // addr
+		}},
+	}
+
+	// Set up consolidator to simulate an identical query already running (Created=false)
+	fakePendingResult := &sync2.FakePendingResult{}
+	fakePendingResult.SetResult(result)
+	// Start with waiter count above the cap (2 > 1), so the condition fails
+	fakePendingResult.WaiterCount = 2
+
+	fakeConsolidator.CreateReturn = &sync2.FakeConsolidatorCreateReturn{
+		Created:       false, // Simulate identical query already running
+		PendingResult: fakePendingResult,
+	}
+
+	// Set up database query/response for fallback execution
+	db.AddQuery(input, result)
+
+	qre := newTestQueryExecutor(context.Background(), tsv, input, 0)
+	qre.options = &querypb.ExecuteOptions{Consolidator: querypb.ExecuteOptions_CONSOLIDATOR_ENABLED}
+
+	// Execute query
+	actualResult, err := qre.Execute()
+	require.NoError(t, err)
+	require.NotNil(t, actualResult)
+
+	// Verify we got the correct result (not empty)
+	require.Equal(t, result.Fields, actualResult.Fields)
+	require.Equal(t, result.Rows, actualResult.Rows)
+
+	// Verify consolidator was attempted
+	require.Len(t, fakeConsolidator.CreateCalls, 1)
+
+	// Verify we did NOT wait (because waiter cap was exceeded)
+	require.Equal(t, 0, fakePendingResult.WaitCalls)
+
+	// Verify we did NOT broadcast (because we're not the original)
+	require.Equal(t, 0, fakePendingResult.BroadcastCalls)
+
+	// Verify AddWaiterCounter was called: once with 0 (to check count), once with -1 (cleanup)
+	require.Len(t, fakePendingResult.AddWaiterCounterCalls, 2)
+	require.Equal(t, int64(0), fakePendingResult.AddWaiterCounterCalls[0])  // Check current count
+	require.Equal(t, int64(-1), fakePendingResult.AddWaiterCounterCalls[1]) // Decrement
+
+	// Verify fallback executed the query independently
+	require.Equal(t, 1, db.GetQueryCalledNum(input))
+
+	db.VerifyAllExecutedOrFail()
+}
+
 func TestGetConnectionLogStats(t *testing.T) {
 	db := setUpQueryExecutorTest(t)
 	defer db.Close()

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1510,6 +1510,77 @@ func TestQueryExecutorConsolidatorWaiterCapFallback(t *testing.T) {
 	db.VerifyAllExecutedOrFail()
 }
 
+func TestQueryExecutorConsolidatorWaiterCapReject(t *testing.T) {
+	// Test that when the consolidator waiter cap is reached and method is "reject",
+	// queries are rejected with RESOURCE_EXHAUSTED error.
+
+	db := setUpQueryExecutorTest(t)
+	defer db.Close()
+
+	ctx := context.Background()
+	tsv := newTestTabletServer(ctx, enableConsolidator, db)
+	defer tsv.StopService()
+
+	// Set waiter cap of 1 and method to "reject"
+	tsv.config.ConsolidatorQueryWaiterCap = 1
+	tsv.config.ConsolidatorQueryWaiterCapMethod = "reject"
+
+	fakeConsolidator := sync2.NewFakeConsolidator()
+	tsv.qe.consolidator = fakeConsolidator
+
+	input := "select * from t limit 10001"
+	result := &sqltypes.Result{
+		Fields: getTestTableFields(),
+		Rows: [][]sqltypes.Value{{
+			sqltypes.NewInt32(1),   // pk
+			sqltypes.NewInt32(100), // name
+			sqltypes.NewInt32(200), // addr
+		}},
+	}
+
+	// Set up consolidator to simulate an identical query already running (Created=false)
+	fakePendingResult := &sync2.FakePendingResult{}
+	fakePendingResult.SetResult(result)
+
+	// Start with waiter count above the cap (2 > 1), so the condition fails
+	fakePendingResult.WaiterCount = 2
+
+	fakeConsolidator.CreateReturn = &sync2.FakeConsolidatorCreateReturn{
+		Created:       false, // Simulate identical query already running
+		PendingResult: fakePendingResult,
+	}
+
+	qre := newTestQueryExecutor(context.Background(), tsv, input, 0)
+	qre.options = &querypb.ExecuteOptions{Consolidator: querypb.ExecuteOptions_CONSOLIDATOR_ENABLED}
+
+	// Execute query - should get RESOURCE_EXHAUSTED error
+	actualResult, err := qre.Execute()
+	require.Error(t, err)
+	require.Nil(t, actualResult)
+
+	// Verify error is RESOURCE_EXHAUSTED
+	require.Contains(t, err.Error(), "consolidator waiter cap")
+	require.Contains(t, err.Error(), "exceeded")
+	require.Equal(t, vtrpcpb.Code_RESOURCE_EXHAUSTED, vterrors.Code(err))
+
+	// Verify consolidator was attempted
+	require.Len(t, fakeConsolidator.CreateCalls, 1)
+
+	// Verify we did NOT wait (because waiter cap was exceeded and method is reject)
+	require.Equal(t, 0, fakePendingResult.WaitCalls)
+
+	// Verify we did NOT broadcast (because we're not the original)
+	require.Equal(t, 0, fakePendingResult.BroadcastCalls)
+
+	// Verify AddWaiterCounter was called: once with 0 (to check count), once with -1 (cleanup)
+	require.Len(t, fakePendingResult.AddWaiterCounterCalls, 2)
+	require.Equal(t, int64(0), fakePendingResult.AddWaiterCounterCalls[0])  // Check current count
+	require.Equal(t, int64(-1), fakePendingResult.AddWaiterCounterCalls[1]) // Decrement
+
+	// Verify no database query was executed (rejected before fallback)
+	require.Equal(t, 0, db.GetQueryCalledNum(input))
+}
+
 func TestGetConnectionLogStats(t *testing.T) {
 	db := setUpQueryExecutorTest(t)
 	defer db.Close()

--- a/go/vt/vttablet/tabletserver/tabletenv/config_test.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config_test.go
@@ -125,6 +125,7 @@ func TestDefaultConfig(t *testing.T) {
 	gotBytes, err := yaml2.Marshal(NewDefaultConfig())
 	require.NoError(t, err)
 	want := `consolidator: enable
+consolidatorQueryWaiterCapMethod: fallthrough
 consolidatorStreamQuerySize: 2097152
 consolidatorStreamTotalSize: 134217728
 gracePeriods: {}


### PR DESCRIPTION
Fix bug introduced by https://github.com/vitessio/vitess/pull/17244

When the consolidator waiter cap is reached, queries should fall back to independent execution instead of returning empty results.

Before this fix:
- Queries exceeding waiter cap would skip waiting for consolidation
- They would immediately try to access q.Result() before completion
- This resulted in empty/incomplete results being returned

After this fix:
- Queries exceeding waiter cap fall back to regular execution path
- All queries return correct results regardless of consolidation status
- Waiter cap configuration still controls resource usage as intended

Changes:
- Modified execSelect() in query_executor.go to implement fallback logic
- Enhanced FakePendingResult to properly simulate waiter count behavior
- Added comprehensive test TestQueryExecutorConsolidatorWaiterCapFallback

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
