### PR TITLE
Add memory tracking and cap to query consolidator

### DIFF
--- a/go/sync2/consolidator.go
+++ b/go/sync2/consolidator.go
@@ -30,6 +30,7 @@ type Consolidator interface {
 	Create(string) (PendingResult, bool)
 	Items() []ConsolidatorCacheItem
 	Record(query string)
+	Memory() int64
 }
 
 // PendingResult is a wrapper for result of a query.
@@ -48,6 +49,7 @@ type consolidator struct {
 
 	mu      sync.Mutex
 	queries map[string]*pendingResult
+	memory  int64
 }
 
 // NewConsolidator creates a new Consolidator
@@ -68,6 +70,7 @@ type pendingResult struct {
 	query        string
 	result       *sqltypes.Result
 	err          error
+	resultSize   int64
 }
 
 // Create adds a query to currently executing queries and acquires a
@@ -95,6 +98,9 @@ func (rs *pendingResult) Broadcast() {
 	defer rs.consolidator.mu.Unlock()
 	delete(rs.consolidator.queries, rs.query)
 	rs.executing.Unlock()
+	if rs.resultSize > 0 {
+		atomic.AddInt64(&rs.consolidator.memory, -rs.resultSize)
+	}
 }
 
 // Err returns any error returned by the query.
@@ -112,9 +118,13 @@ func (rs *pendingResult) SetErr(err error) {
 	rs.err = err
 }
 
-// SetResult sets any result returned by the query.
+// SetResult sets any result returned by the query and tracks its memory usage.
 func (rs *pendingResult) SetResult(res *sqltypes.Result) {
 	rs.result = res
+	if res != nil {
+		rs.resultSize = res.CachedSize(true)
+		atomic.AddInt64(&rs.consolidator.memory, rs.resultSize)
+	}
 }
 
 // Wait waits for the original query to complete execution. Wait should
@@ -127,6 +137,11 @@ func (rs *pendingResult) Wait() {
 func (rs *pendingResult) AddWaiterCounter(c int64) *int64 {
 	atomic.AddInt64(rs.consolidator.totalWaiterCount, c)
 	return rs.consolidator.totalWaiterCount
+}
+
+// Memory returns the current memory usage of all pending results in the consolidator.
+func (co *consolidator) Memory() int64 {
+	return atomic.LoadInt64(&co.memory)
 }
 
 // ConsolidatorCache is a thread-safe object used for counting how often recent

--- a/go/sync2/consolidator_test.go
+++ b/go/sync2/consolidator_test.go
@@ -17,9 +17,12 @@ limitations under the License.
 package sync2
 
 import (
+	"fmt"
 	"reflect"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"vitess.io/vitess/go/sqltypes"
 )
@@ -114,4 +117,71 @@ func TestConsolidator(t *testing.T) {
 		t.Fatalf("expected consolidator to have two items %v", con.Items())
 	}
 
+}
+
+func TestConsolidatorMemoryTracking(t *testing.T) {
+	con := NewConsolidator()
+
+	assert.Equal(t, int64(0), con.Memory(), "memory should start at 0")
+
+	q, created := con.Create("select 1")
+	assert.True(t, created)
+
+	result := &sqltypes.Result{
+		Rows: [][]sqltypes.Value{
+			{sqltypes.NewVarBinary("hello world")},
+		},
+	}
+	q.SetResult(result)
+
+	assert.Greater(t, con.Memory(), int64(0), "memory should increase after SetResult")
+
+	q.Broadcast()
+
+	assert.Equal(t, int64(0), con.Memory(), "memory should return to 0 after Broadcast")
+}
+
+func TestConsolidatorMemoryTrackingNilResult(t *testing.T) {
+	con := NewConsolidator()
+
+	q, created := con.Create("select 1")
+	assert.True(t, created)
+
+	q.SetResult(nil)
+
+	assert.Equal(t, int64(0), con.Memory(), "memory should remain 0 for nil result")
+
+	q.Broadcast()
+
+	assert.Equal(t, int64(0), con.Memory(), "memory should still be 0 after Broadcast with nil result")
+}
+
+func TestConsolidatorMemoryTrackingConcurrent(t *testing.T) {
+	con := NewConsolidator()
+	const numQueries = 100
+
+	result := &sqltypes.Result{
+		Rows: [][]sqltypes.Value{
+			{sqltypes.NewVarBinary("test data")},
+		},
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < numQueries; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			sql := fmt.Sprintf("select %d", i)
+			q, created := con.Create(sql)
+			if !created {
+				return
+			}
+			q.SetResult(result)
+			q.Broadcast()
+		}(i)
+	}
+
+	wg.Wait()
+
+	assert.Equal(t, int64(0), con.Memory(), "memory should be 0 after all queries complete")
 }

--- a/go/sync2/fake_consolidator.go
+++ b/go/sync2/fake_consolidator.go
@@ -31,6 +31,8 @@ type FakeConsolidator struct {
 	CreateReturn *FakeConsolidatorCreateReturn
 	// RecordCalls can be usd to inspect Record calls.
 	RecordCalls []string
+	// MemoryReturn is the value returned by Memory().
+	MemoryReturn int64
 }
 
 // FakeConsolidatorCreateReturn wraps the two return values of a call to
@@ -85,6 +87,11 @@ func (fc *FakeConsolidator) Record(sql string) {
 // Items is currently a no-op.
 func (fc *FakeConsolidator) Items() []ConsolidatorCacheItem {
 	return nil
+}
+
+// Memory returns the pre-configured memory value.
+func (fc *FakeConsolidator) Memory() int64 {
+	return fc.MemoryReturn
 }
 
 // Broadcast records the Broadcast call for later verification.

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -271,6 +271,7 @@ func NewQueryEngine(env tabletenv.Env, se *schema.Engine) *QueryEngine {
 	env.Exporter().NewGaugeFunc("WarnResultSize", "Query engine warn result size", qe.warnResultSize.Load)
 	env.Exporter().NewGaugeFunc("StreamBufferSize", "Query engine stream buffer size", qe.streamBufferSize.Load)
 	env.Exporter().NewCounterFunc("TableACLExemptCount", "Query engine table ACL exempt count", qe.tableaclExemptCount.Load)
+	env.Exporter().NewGaugeFunc("ConsolidatorMemoryUsage", "Consolidator pending result memory usage in bytes", qe.consolidator.Memory)
 
 	env.Exporter().NewGaugeFunc("QueryEnginePlanCacheLength", "Query engine query plan cache length", func() int64 {
 		return int64(qe.plans.Len())

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -708,7 +708,8 @@ func (qre *QueryExecutor) execSelect() (*sqltypes.Result, error) {
 		return nil, err
 	}
 	// Check tablet type.
-	if qre.shouldConsolidate() {
+	memoryCap := qre.tsv.config.ConsolidatorMemoryCap
+	if qre.shouldConsolidate() && (memoryCap <= 0 || qre.tsv.qe.consolidator.Memory() <= memoryCap) {
 		q, original := qre.tsv.qe.consolidator.Create(sqlWithoutComments)
 		waiterCapExceeded := false
 

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -201,6 +201,7 @@ func registerTabletEnvFlags(fs *pflag.FlagSet) {
 
 	fs.Int64Var(&currentConfig.ConsolidatorQueryWaiterCap, "consolidator-query-waiter-cap", 0, "Configure the maximum number of clients allowed to wait on the consolidator.")
 	fs.StringVar(&currentConfig.ConsolidatorQueryWaiterCapMethod, "consolidator-query-waiter-cap-method", "fallthrough", "Configure the method when consolidator waiter cap is exceeded. Options: fallthrough, reject.")
+	fs.Int64Var(&currentConfig.ConsolidatorMemoryCap, "consolidator-memory-cap", 0, "Configure the memory cap for the query consolidator in bytes. When exceeded, new queries bypass consolidation. Setting to 0 disables the memory cap.")
 	fs.DurationVar(&healthCheckInterval, "health_check_interval", defaultConfig.Healthcheck.Interval, "Interval between health checks")
 	fs.DurationVar(&degradedThreshold, "degraded_threshold", defaultConfig.Healthcheck.DegradedThreshold, "replication lag after which a replica is considered degraded")
 	fs.DurationVar(&unhealthyThreshold, "unhealthy_threshold", defaultConfig.Healthcheck.UnhealthyThreshold, "replication lag after which a replica is considered unhealthy")
@@ -341,6 +342,7 @@ type TabletConfig struct {
 	ConsolidatorStreamQuerySize      int64         `json:"consolidatorStreamQuerySize,omitempty"`
 	ConsolidatorQueryWaiterCap       int64         `json:"consolidatorMaxQueryWait,omitempty"`
 	ConsolidatorQueryWaiterCapMethod string        `json:"consolidatorQueryWaiterCapMethod,omitempty"`
+	ConsolidatorMemoryCap            int64         `json:"consolidatorMemoryCap,omitempty"`
 	QueryCacheMemory                 int64         `json:"queryCacheMemory,omitempty"`
 	QueryCacheDoorkeeper             bool          `json:"queryCacheDoorkeeper,omitempty"`
 	SchemaReloadInterval             time.Duration `json:"schemaReloadIntervalSeconds,omitempty"`


### PR DESCRIPTION
Track memory usage of pending results in the consolidator using atomic int64, and add a --consolidator-memory-cap flag to bypass consolidation when memory exceeds the configured threshold (default 0 = unlimited). Exposes a ConsolidatorMemoryUsage gauge metric for observability.

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## What's this?

Adds memory tracking to the query consolidator so we can observe and bound how much memory is held in pending results. When many distinct queries are in-flight with large results, the consolidator can cause unbounded memory growth -- this gives us a cap to gracefully degrade by bypassing consolidation.

## How it works

- Tracks memory atomically in the consolidator: `SetResult` adds the result's `CachedSize`, `Broadcast` subtracts it
- New `--consolidator-memory-cap` flag (default 0 = unlimited). When exceeded, new queries skip consolidation and execute independently (fallthrough, never rejects)
- Exposes a `ConsolidatorMemoryUsage` gauge metric for observability
- Follows the same patterns as the existing stream consolidator memory tracking

## Files changed

- `go/sync2/consolidator.go` -- core memory tracking (`memory` field, `Memory()` interface method)
- `go/sync2/fake_consolidator.go` -- updated fake to satisfy interface
- `go/sync2/consolidator_test.go` -- three new tests (basic, nil result, concurrent)
- `go/vt/vttablet/tabletserver/tabletenv/config.go` -- new config field + flag
- `go/vt/vttablet/tabletserver/query_engine.go` -- gauge metric registration
- `go/vt/vttablet/tabletserver/query_executor.go` -- memory cap check in `execSelect()`

---
_Most of this was written by Claude Code - I just provided direction._

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
