### PR TITLE
configurable rejection window for > warn-result-size queries

### DIFF
--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -301,6 +301,7 @@ Flags:
       --queryserver-config-truncate-error-len int                        truncate errors sent to client if they are longer than this value (0 means do not truncate)
       --queryserver-config-txpool-timeout duration                       query server transaction pool timeout, it is how long vttablet waits if tx pool is full (default 1s)
       --queryserver-config-warn-result-size int                          query server result size warning threshold, warn if number of rows returned from vttablet for non-streaming queries exceeds this
+      --queryserver-config-warn-result-size-reject-time-seconds int     query server result size rejection duration in seconds: after a query fingerprint exceeds the warn threshold, subsequent instances are rejected for this many seconds. 0 means disabled.
       --queryserver-enable-settings-pool                                 Enable pooling of connections with modified system settings (default true)
       --queryserver-enable-views                                         Enable views support in vttablet.
       --queryserver_enable_online_ddl                                    Enable online DDL. (default true)

--- a/go/vt/vttablet/tabletserver/debugenv.go
+++ b/go/vt/vttablet/tabletserver/debugenv.go
@@ -132,6 +132,8 @@ func debugEnvHandler(tsv *TabletServer, w http.ResponseWriter, r *http.Request) 
 			setIntVal(tsv.SetMaxResultSize)
 		case "WarnResultSize":
 			setIntVal(tsv.SetWarnResultSize)
+		case "WarnResultSizeRejectTimeSeconds":
+			setIntVal(tsv.SetWarnResultSizeRejectTimeSeconds)
 		case "RowStreamerMaxInnoDBTrxHistLen":
 			setInt64Val(func(val int64) { tsv.Config().RowStreamer.MaxInnoDBTrxHistLen = val })
 		case "RowStreamerMaxMySQLReplLagSecs":
@@ -155,6 +157,7 @@ func debugEnvHandler(tsv *TabletServer, w http.ResponseWriter, r *http.Request) 
 	vars = addVar(vars, "QueryCacheCapacity", tsv.QueryPlanCacheCap)
 	vars = addVar(vars, "MaxResultSize", tsv.MaxResultSize)
 	vars = addVar(vars, "WarnResultSize", tsv.WarnResultSize)
+	vars = addVar(vars, "WarnResultSizeRejectTimeSeconds", tsv.WarnResultSizeRejectTimeSeconds)
 	vars = addVar(vars, "RowStreamerMaxInnoDBTrxHistLen", func() int64 { return tsv.Config().RowStreamer.MaxInnoDBTrxHistLen })
 	vars = addVar(vars, "RowStreamerMaxMySQLReplLagSecs", func() int64 { return tsv.Config().RowStreamer.MaxMySQLReplLagSecs })
 	vars = addVar(vars, "UnhealthyThreshold", func() time.Duration { return tsv.Config().Healthcheck.UnhealthyThreshold })

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -170,9 +170,11 @@ type QueryEngine struct {
 	txSerializer *txserializer.TxSerializer
 
 	// Vars
-	maxResultSize    atomic.Int64
-	warnResultSize   atomic.Int64
-	streamBufferSize atomic.Int64
+	maxResultSize              atomic.Int64
+	warnResultSize             atomic.Int64
+	warnResultSizeRejectTime   atomic.Int64
+	streamBufferSize           atomic.Int64
+	blockedQueries             sync.Map // key: fingerprint string, value: expiry unix seconds int64
 	// tableaclExemptCount count the number of accesses allowed
 	// based on membership in the superuser ACL
 	tableaclExemptCount  atomic.Int64
@@ -257,6 +259,7 @@ func NewQueryEngine(env tabletenv.Env, se *schema.Engine) *QueryEngine {
 
 	qe.maxResultSize.Store(int64(config.Oltp.MaxRows))
 	qe.warnResultSize.Store(int64(config.Oltp.WarnRows))
+	qe.warnResultSizeRejectTime.Store(int64(config.Oltp.WarnRowsRejectTimeSeconds))
 	qe.streamBufferSize.Store(int64(config.StreamBufferSize))
 
 	planbuilder.PassthroughDMLs = config.PassthroughDML
@@ -265,6 +268,7 @@ func NewQueryEngine(env tabletenv.Env, se *schema.Engine) *QueryEngine {
 
 	env.Exporter().NewGaugeFunc("MaxResultSize", "Query engine max result size", qe.maxResultSize.Load)
 	env.Exporter().NewGaugeFunc("WarnResultSize", "Query engine warn result size", qe.warnResultSize.Load)
+	env.Exporter().NewGaugeFunc("WarnResultSizeRejectTimeSeconds", "Query engine warn result size rejection duration in seconds", qe.warnResultSizeRejectTime.Load)
 	env.Exporter().NewGaugeFunc("StreamBufferSize", "Query engine stream buffer size", qe.streamBufferSize.Load)
 	env.Exporter().NewCounterFunc("TableACLExemptCount", "Query engine table ACL exempt count", qe.tableaclExemptCount.Load)
 
@@ -707,6 +711,38 @@ func (qe *QueryEngine) handleHTTPConsolidations(response http.ResponseWriter, re
 		}
 		response.Write([]byte(fmt.Sprintf("%v: %s\n", v.Count, query)))
 	}
+}
+
+// IsQueryBlocked checks if a query fingerprint is currently blocked.
+// It performs lazy deletion of expired entries.
+func (qe *QueryEngine) IsQueryBlocked(fingerprint string) bool {
+	val, ok := qe.blockedQueries.Load(fingerprint)
+	if !ok {
+		return false
+	}
+	expiry := val.(int64)
+	if time.Now().Unix() >= expiry {
+		qe.blockedQueries.Delete(fingerprint)
+		return false
+	}
+	return true
+}
+
+// BlockQuery adds a query fingerprint to the blocked queries map
+// with an expiry of now + rejectSeconds.
+func (qe *QueryEngine) BlockQuery(fingerprint string, rejectSeconds int64) {
+	if fingerprint == "" || rejectSeconds <= 0 {
+		return
+	}
+	qe.blockedQueries.Store(fingerprint, time.Now().Unix()+rejectSeconds)
+}
+
+// ClearBlockedQueries removes all entries from the blocked queries map.
+func (qe *QueryEngine) ClearBlockedQueries() {
+	qe.blockedQueries.Range(func(key, value any) bool {
+		qe.blockedQueries.Delete(key)
+		return true
+	})
 }
 
 // unicoded returns a valid UTF-8 string that json won't reject

--- a/go/vt/vttablet/tabletserver/query_engine_test.go
+++ b/go/vt/vttablet/tabletserver/query_engine_test.go
@@ -915,3 +915,65 @@ func TestPlanPoolUnsafe(t *testing.T) {
 		})
 	}
 }
+
+func TestBlockedQueries(t *testing.T) {
+	db := fakesqldb.New(t)
+	defer db.Close()
+	schematest.AddDefaultQueries(db)
+
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.DB = newDBConfigs(db)
+	env := tabletenv.NewEnv(vtenv.NewTestEnv(), cfg, "TabletServerTest")
+	se := schema.NewEngine(env)
+	qe := NewQueryEngine(env, se)
+
+	t.Run("BlockAndCheck", func(t *testing.T) {
+		fingerprint := "select * from t where id = :v1"
+		assert.False(t, qe.IsQueryBlocked(fingerprint))
+
+		qe.BlockQuery(fingerprint, 60)
+		assert.True(t, qe.IsQueryBlocked(fingerprint))
+	})
+
+	t.Run("ExpiredEntry", func(t *testing.T) {
+		fingerprint := "select * from t2 where id = :v1"
+		// Store an entry that already expired (1 second in the past)
+		qe.blockedQueries.Store(fingerprint, time.Now().Unix()-1)
+		assert.False(t, qe.IsQueryBlocked(fingerprint))
+		// Entry should have been lazy-deleted
+		_, ok := qe.blockedQueries.Load(fingerprint)
+		assert.False(t, ok)
+	})
+
+	t.Run("EmptyFingerprint", func(t *testing.T) {
+		qe.BlockQuery("", 60)
+		assert.False(t, qe.IsQueryBlocked(""))
+	})
+
+	t.Run("ZeroRejectSeconds", func(t *testing.T) {
+		fingerprint := "select * from t3 where id = :v1"
+		qe.BlockQuery(fingerprint, 0)
+		assert.False(t, qe.IsQueryBlocked(fingerprint))
+	})
+
+	t.Run("NegativeRejectSeconds", func(t *testing.T) {
+		fingerprint := "select * from t4 where id = :v1"
+		qe.BlockQuery(fingerprint, -1)
+		assert.False(t, qe.IsQueryBlocked(fingerprint))
+	})
+
+	t.Run("ClearBlockedQueries", func(t *testing.T) {
+		qe.BlockQuery("q1", 60)
+		qe.BlockQuery("q2", 60)
+		assert.True(t, qe.IsQueryBlocked("q1"))
+		assert.True(t, qe.IsQueryBlocked("q2"))
+
+		qe.ClearBlockedQueries()
+		assert.False(t, qe.IsQueryBlocked("q1"))
+		assert.False(t, qe.IsQueryBlocked("q2"))
+	})
+
+	t.Run("NonexistentFingerprint", func(t *testing.T) {
+		assert.False(t, qe.IsQueryBlocked("nonexistent-query"))
+	})
+}

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -153,6 +153,10 @@ func (qre *QueryExecutor) Execute() (reply *sqltypes.Result, err error) {
 		return nil, err
 	}
 
+	if err = qre.checkWarnResultSizeRejection(); err != nil {
+		return nil, err
+	}
+
 	if qre.plan.PlanID == p.PlanNextval {
 		return qre.execNextval()
 	}
@@ -767,6 +771,19 @@ func (qre *QueryExecutor) execDMLLimit(conn *StatefulConnection) (*sqltypes.Resu
 	return result, nil
 }
 
+func (qre *QueryExecutor) checkWarnResultSizeRejection() error {
+	if qre.plan.FullQuery == nil {
+		return nil
+	}
+	fingerprint := qre.plan.FullQuery.Query
+	if qre.tsv.qe.IsQueryBlocked(fingerprint) {
+		qre.tsv.Stats().Warnings.Add("ResultsExceededRejection", 1)
+		callerID := callerid.ImmediateCallerIDFromContext(qre.ctx)
+		return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "caller id: %s: query rejected: result size warning threshold exceeded recently for this query fingerprint", callerID.Username)
+	}
+	return nil
+}
+
 func (qre *QueryExecutor) verifyRowCount(count, maxrows int64) error {
 	if count > maxrows {
 		callerID := callerid.ImmediateCallerIDFromContext(qre.ctx)
@@ -777,6 +794,9 @@ func (qre *QueryExecutor) verifyRowCount(count, maxrows int64) error {
 		callerID := callerid.ImmediateCallerIDFromContext(qre.ctx)
 		qre.tsv.Stats().Warnings.Add("ResultsExceeded", 1)
 		log.Warningf("caller id: %s row count %v exceeds warning threshold %v: %q", callerID.Username, count, warnThreshold, queryAsString(qre.plan.FullQuery.Query, qre.bindVars, qre.tsv.Config().SanitizeLogMessages, true, qre.tsv.env.Parser()))
+		if rejectSeconds := qre.tsv.qe.warnResultSizeRejectTime.Load(); rejectSeconds > 0 && qre.plan.FullQuery != nil {
+			qre.tsv.qe.BlockQuery(qre.plan.FullQuery.Query, rejectSeconds)
+		}
 	}
 	return nil
 }

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -126,6 +126,7 @@ func registerTabletEnvFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&currentConfig.GracePeriods.Shutdown, "shutdown_grace_period", defaultConfig.GracePeriods.Shutdown, "how long to wait for queries and transactions to complete during graceful shutdown.")
 	fs.IntVar(&currentConfig.Oltp.MaxRows, "queryserver-config-max-result-size", defaultConfig.Oltp.MaxRows, "query server max result size, maximum number of rows allowed to return from vttablet for non-streaming queries.")
 	fs.IntVar(&currentConfig.Oltp.WarnRows, "queryserver-config-warn-result-size", defaultConfig.Oltp.WarnRows, "query server result size warning threshold, warn if number of rows returned from vttablet for non-streaming queries exceeds this")
+	fs.IntVar(&currentConfig.Oltp.WarnRowsRejectTimeSeconds, "queryserver-config-warn-result-size-reject-time-seconds", defaultConfig.Oltp.WarnRowsRejectTimeSeconds, "query server result size rejection duration in seconds: after a query fingerprint exceeds the warn threshold, subsequent instances are rejected for this many seconds. 0 means disabled.")
 	fs.BoolVar(&currentConfig.PassthroughDML, "queryserver-config-passthrough-dmls", defaultConfig.PassthroughDML, "query server pass through all dml statements without rewriting")
 
 	fs.IntVar(&currentConfig.StreamBufferSize, "queryserver-config-stream-buffer-size", defaultConfig.StreamBufferSize, "query server stream buffer size, the maximum number of bytes sent from vttablet for each stream call. It's recommended to keep this value in sync with vtgate's stream_buffer_size.")
@@ -568,10 +569,11 @@ func (cfg *OlapConfig) UnmarshalJSON(data []byte) (err error) {
 
 // OltpConfig contains the config for oltp settings.
 type OltpConfig struct {
-	QueryTimeout time.Duration `json:"queryTimeoutSeconds,omitempty"`
-	TxTimeout    time.Duration `json:"txTimeoutSeconds,omitempty"`
-	MaxRows      int           `json:"maxRows,omitempty"`
-	WarnRows     int           `json:"warnRows,omitempty"`
+	QueryTimeout           time.Duration `json:"queryTimeoutSeconds,omitempty"`
+	TxTimeout              time.Duration `json:"txTimeoutSeconds,omitempty"`
+	MaxRows                int           `json:"maxRows,omitempty"`
+	WarnRows               int           `json:"warnRows,omitempty"`
+	WarnRowsRejectTimeSeconds int        `json:"warnRowsRejectTimeSeconds,omitempty"`
 }
 
 func (cfg *OltpConfig) MarshalJSON() ([]byte, error) {

--- a/go/vt/vttablet/tabletserver/tabletenv/stats.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/stats.go
@@ -82,7 +82,7 @@ func NewStats(exporter *servenv.Exporter) *Stats {
 			vtrpcpb.Code_CLUSTER_EVENT.String(),
 		),
 		InternalErrors:         exporter.NewCountersWithSingleLabel("InternalErrors", "Internal component errors", "type", "Task", "StrayTransactions", "Panic", "HungQuery", "Schema", "TwopcCommit", "TwopcResurrection", "WatchdogFail", "Messages"),
-		Warnings:               exporter.NewCountersWithSingleLabel("Warnings", "Warnings", "type", "ResultsExceeded"),
+		Warnings:               exporter.NewCountersWithSingleLabel("Warnings", "Warnings", "type", "ResultsExceeded", "ResultsExceededRejection"),
 		Unresolved:             exporter.NewGaugesWithSingleLabel("Unresolved", "Unresolved items", "item_type", "Prepares"),
 		UserTableQueryCount:    exporter.NewCountersWithMultiLabels("UserTableQueryCount", "Queries received for each CallerID/table combination", []string{"TableName", "CallerID", "Type"}),
 		UserTableQueryTimesNs:  exporter.NewCountersWithMultiLabels("UserTableQueryTimesNs", "Total latency for each CallerID/table combination", []string{"TableName", "CallerID", "Type"}),

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -2068,6 +2068,16 @@ func (tsv *TabletServer) WarnResultSize() int {
 	return int(tsv.qe.warnResultSize.Load())
 }
 
+// SetWarnResultSizeRejectTimeSeconds changes the warn result size rejection duration.
+func (tsv *TabletServer) SetWarnResultSizeRejectTimeSeconds(val int) {
+	tsv.qe.warnResultSizeRejectTime.Store(int64(val))
+}
+
+// WarnResultSizeRejectTimeSeconds returns the warn result size rejection duration.
+func (tsv *TabletServer) WarnResultSizeRejectTimeSeconds() int {
+	return int(tsv.qe.warnResultSizeRejectTime.Load())
+}
+
 // SetThrottleMetricThreshold changes the throttler metric threshold
 func (tsv *TabletServer) SetThrottleMetricThreshold(val float64) {
 	tsv.lagThrottler.StoreMetricsThreshold(val)

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -2783,3 +2783,22 @@ func addTabletServerSupportedQueries(db *fakesqldb.DB) {
 		}},
 	})
 }
+
+func TestWarnResultSizeRejectTimeSeconds(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	db, tsv := setupTabletServerTest(t, ctx, "")
+	defer db.Close()
+	defer tsv.StopService()
+
+	// Default should be 0
+	assert.Equal(t, 0, tsv.WarnResultSizeRejectTimeSeconds())
+
+	// Set and verify
+	tsv.SetWarnResultSizeRejectTimeSeconds(30)
+	assert.Equal(t, 30, tsv.WarnResultSizeRejectTimeSeconds())
+
+	// Set back to 0
+	tsv.SetWarnResultSizeRejectTimeSeconds(0)
+	assert.Equal(t, 0, tsv.WarnResultSizeRejectTimeSeconds())
+}


### PR DESCRIPTION
## Description

When vttablet's --queryserver-config-warn-result-size threshold is exceeded, the existing behavior logs a warning but takes no preventive action. This allows repeated large-result queries to compound memory pressure (e.g. heap ballooning to >5GB from queries returning 200k rows).

This change adds --queryserver-config-warn-result-size-reject-time-seconds which, when set to a nonzero value, causes vttablet to temporarily block subsequent executions of the same query fingerprint after it triggers the warn threshold. Blocked queries receive FAILED_PRECONDITION, which vtgate will retry on a different tablet (spreading load) or return to the client if all tablets have the fingerprint blocked.

Implementation uses a sync.Map in QueryEngine keyed by normalized query template with unix-second expiry, avoiding plan cache invalidation. The setting is dynamically adjustable via /debug/env.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure
This PR was written by Claude Code unde rmy guidance.
