### PR TITLE
vtorc --ers-cascade-prevention-seconds

### DIFF
--- a/.github/workflows/error_code_docs.yml
+++ b/.github/workflows/error_code_docs.yml
@@ -4,6 +4,8 @@ name: Update error code docs
 on:
   pull_request_target:
     types: [opened, synchronize]
+    branches-ignore:
+      - '*' 
     paths:
       - 'go/vt/vterrors/code.go'
 

--- a/.github/workflows/pr_opened_tasks.yml
+++ b/.github/workflows/pr_opened_tasks.yml
@@ -5,6 +5,8 @@ name: PR opened tasks
 on:
   pull_request_target:
     types: [opened]
+    branches-ignore:
+      - '*'  # Disabled in Slack fork - GitHub App not configured
 
 jobs:
   # Skip PRs with "Backport" or "Forwardport" labels since those are automated.

--- a/go/cmd/vtctldclient/command/reparents.go
+++ b/go/cmd/vtctldclient/command/reparents.go
@@ -144,6 +144,7 @@ func commandEmergencyReparentShard(cmd *cobra.Command, args []string) error {
 		WaitReplicasTimeout:       protoutil.DurationToProto(emergencyReparentShardOptions.WaitReplicasTimeout),
 		PreventCrossCellPromotion: emergencyReparentShardOptions.PreventCrossCellPromotion,
 		WaitForAllTablets:         emergencyReparentShardOptions.WaitForAllTablets,
+		Force:                     emergencyReparentShardOptions.Force,
 	})
 	if err != nil {
 		return err
@@ -310,6 +311,7 @@ func init() {
 	EmergencyReparentShard.Flags().BoolVar(&emergencyReparentShardOptions.PreventCrossCellPromotion, "prevent-cross-cell-promotion", false, "Only promotes a new primary from the same cell as the previous primary.")
 	EmergencyReparentShard.Flags().BoolVar(&emergencyReparentShardOptions.WaitForAllTablets, "wait-for-all-tablets", false, "Should ERS wait for all the tablets to respond. Useful when all the tablets are reachable.")
 	EmergencyReparentShard.Flags().StringSliceVarP(&emergencyReparentShardOptions.IgnoreReplicaAliasStrList, "ignore-replicas", "i", nil, "Comma-separated, repeated list of replica tablet aliases to ignore during the emergency reparent.")
+	EmergencyReparentShard.Flags().BoolVar(&emergencyReparentShardOptions.Force, "force", false, "Force the reparent even if PreviousERSStatus indicates the shard is in an unknown state from a prior failed ERS.")
 	Root.AddCommand(EmergencyReparentShard)
 
 	InitShardPrimary.Flags().DurationVar(&initShardPrimaryOptions.WaitReplicasTimeout, "wait-replicas-timeout", 30*time.Second, "Time to wait for replicas to catch up in reparenting.")

--- a/go/vt/proto/vtctldata/vtctldata.pb.go
+++ b/go/vt/proto/vtctldata/vtctldata.pb.go
@@ -4340,6 +4340,9 @@ type EmergencyReparentShardRequest struct {
 	// ExpectedPrimary is the optional alias we expect to be the current primary in order for
 	// the reparent operation to succeed.
 	ExpectedPrimary *topodata.TabletAlias `protobuf:"bytes,8,opt,name=expected_primary,json=expectedPrimary,proto3" json:"expected_primary,omitempty"`
+	// Force overrides ERS cascade prevention checks, including the hard block
+	// when PreviousERSStatus is errored_shard_unknown.
+	Force           bool                  `protobuf:"varint,9,opt,name=force,proto3" json:"force,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -4428,6 +4431,13 @@ func (x *EmergencyReparentShardRequest) GetExpectedPrimary() *topodata.TabletAli
 		return x.ExpectedPrimary
 	}
 	return nil
+}
+
+func (x *EmergencyReparentShardRequest) GetForce() bool {
+	if x != nil {
+		return x.Force
+	}
+	return false
 }
 
 type EmergencyReparentShardResponse struct {

--- a/go/vt/topo/ers_status.go
+++ b/go/vt/topo/ers_status.go
@@ -28,11 +28,10 @@ import (
 type ERSStatus struct {
 	Identity  string `json:"identity"`  // hostname:port of the vtorc that performed/is performing the ERS
 	Timestamp string `json:"timestamp"` // RFC3339 timestamp
-	Status    string `json:"status"`    // pending, completed, errored_shard_unchanged, errored_shard_unknown
+	Status    string `json:"status"`    // completed, errored_shard_unchanged, errored_shard_unknown
 }
 
 const (
-	ERSStatusPending              = "pending"
 	ERSStatusCompleted            = "completed"
 	ERSStatusErroredShardUnchanged = "errored_shard_unchanged"
 	ERSStatusErroredShardUnknown   = "errored_shard_unknown"

--- a/go/vt/topo/ers_status.go
+++ b/go/vt/topo/ers_status.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topo
+
+import (
+	"context"
+	"encoding/json"
+	"path"
+)
+
+// ERSStatus represents the status of the most recent EmergencyReparentShard
+// operation on a given shard. It is stored in the global topo under
+// keyspaces/{keyspace}/shards/{shard}/PreviousERSStatus.
+type ERSStatus struct {
+	Identity  string `json:"identity"`  // hostname:port of the vtorc that performed/is performing the ERS
+	Timestamp string `json:"timestamp"` // RFC3339 timestamp
+	Status    string `json:"status"`    // pending, completed, errored_shard_unchanged, errored_shard_unknown
+}
+
+const (
+	ERSStatusPending              = "pending"
+	ERSStatusCompleted            = "completed"
+	ERSStatusErroredShardUnchanged = "errored_shard_unchanged"
+	ERSStatusErroredShardUnknown   = "errored_shard_unknown"
+)
+
+func ersStatusFilePath(keyspace, shard string) string {
+	return path.Join(KeyspacesPath, keyspace, ShardsPath, shard, PreviousERSStatusFile)
+}
+
+// UpdateERSStatus writes the ERS status for the given keyspace/shard to the global topo.
+// It performs an unconditional upsert (nil version).
+func (ts *Server) UpdateERSStatus(ctx context.Context, keyspace, shard string, status *ERSStatus) error {
+	data, err := json.Marshal(status)
+	if err != nil {
+		return err
+	}
+	filePath := ersStatusFilePath(keyspace, shard)
+	_, err = ts.globalCell.Update(ctx, filePath, data, nil)
+	return err
+}
+
+// GetERSStatus reads the ERS status for the given keyspace/shard from the global topo.
+// Returns nil, nil, nil if no status has been written yet.
+func (ts *Server) GetERSStatus(ctx context.Context, keyspace, shard string) (*ERSStatus, Version, error) {
+	filePath := ersStatusFilePath(keyspace, shard)
+	data, version, err := ts.globalCell.Get(ctx, filePath)
+	if err != nil {
+		if IsErrType(err, NoNode) {
+			return nil, nil, nil
+		}
+		return nil, nil, err
+	}
+	status := &ERSStatus{}
+	if err := json.Unmarshal(data, status); err != nil {
+		return nil, nil, err
+	}
+	return status, version, nil
+}

--- a/go/vt/topo/server.go
+++ b/go/vt/topo/server.go
@@ -84,6 +84,7 @@ const (
 	ShardRoutingRulesFile  = "ShardRoutingRules"
 	CommonRoutingRulesFile = "Rules"
 	MirrorRulesFile        = "MirrorRules"
+	PreviousERSStatusFile  = "PreviousERSStatus"
 )
 
 // Path for all object types.

--- a/go/vt/vtctl/grpcvtctldserver/server.go
+++ b/go/vt/vtctl/grpcvtctldserver/server.go
@@ -1287,6 +1287,7 @@ func (s *VtctldServer) EmergencyReparentShard(ctx context.Context, req *vtctldat
 	span.Annotate("keyspace", req.Keyspace)
 	span.Annotate("shard", req.Shard)
 	span.Annotate("new_primary_alias", topoproto.TabletAliasString(req.NewPrimary))
+	span.Annotate("force", req.Force)
 
 	ignoreReplicaAliases := topoproto.TabletAliasList(req.IgnoreReplicas).ToStringSlice()
 	span.Annotate("ignore_replicas", strings.Join(ignoreReplicaAliases, ","))
@@ -1301,6 +1302,20 @@ func (s *VtctldServer) EmergencyReparentShard(ctx context.Context, req *vtctldat
 	span.Annotate("wait_replicas_timeout_sec", waitReplicasTimeout.Seconds())
 	span.Annotate("prevent_cross_cell_promotion", req.PreventCrossCellPromotion)
 	span.Annotate("wait_for_all_tablets", req.WaitForAllTablets)
+
+	// Check PreviousERSStatus: block if shard is in unknown state unless --force is set.
+	if !req.Force {
+		ersCtx, ersCancel := context.WithTimeout(ctx, topo.RemoteOperationTimeout)
+		prevStatus, _, getErr := s.ts.GetERSStatus(ersCtx, req.Keyspace, req.Shard)
+		ersCancel()
+		if getErr != nil {
+			log.Warningf("EmergencyReparentShard: failed to read PreviousERSStatus for %s/%s, proceeding: %v", req.Keyspace, req.Shard, getErr)
+		} else if prevStatus != nil && prevStatus.Status == topo.ERSStatusErroredShardUnknown {
+			return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION,
+				"EmergencyReparentShard blocked on %s/%s: previous ERS by %s at %s left the shard in an unknown state. Use --force to override.",
+				req.Keyspace, req.Shard, prevStatus.Identity, prevStatus.Timestamp)
+		}
+	}
 
 	m := sync.RWMutex{}
 	logstream := []*logutilpb.Event{}
@@ -1323,6 +1338,27 @@ func (s *VtctldServer) EmergencyReparentShard(ctx context.Context, req *vtctldat
 			ExpectedPrimaryAlias:      req.ExpectedPrimary,
 		},
 	)
+
+	// Write PreviousERSStatus so vtorc instances and future ERS calls see the outcome.
+	finalStatus := topo.ERSStatusCompleted
+	if err != nil {
+		if ev != nil && ev.NewPrimary != nil {
+			finalStatus = topo.ERSStatusErroredShardUnknown
+		} else {
+			finalStatus = topo.ERSStatusErroredShardUnchanged
+		}
+	}
+	identity, _ := netutil.FullyQualifiedHostname()
+	ersStatus := &topo.ERSStatus{
+		Identity:  fmt.Sprintf("vtctld@%s", identity),
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Status:    finalStatus,
+	}
+	writeCtx, writeCancel := context.WithTimeout(ctx, topo.RemoteOperationTimeout)
+	if writeErr := s.ts.UpdateERSStatus(writeCtx, req.Keyspace, req.Shard, ersStatus); writeErr != nil {
+		log.Warningf("EmergencyReparentShard: failed to write PreviousERSStatus (%s) for %s/%s: %v", finalStatus, req.Keyspace, req.Shard, writeErr)
+	}
+	writeCancel()
 
 	resp = &vtctldatapb.EmergencyReparentShardResponse{
 		Keyspace: req.Keyspace,

--- a/go/vt/vtorc/config/config.go
+++ b/go/vt/vtorc/config/config.go
@@ -231,6 +231,15 @@ var (
 			Dynamic:  true,
 		},
 	)
+
+	ersCascadePreventionSeconds = viperutil.Configure(
+		"ers-cascade-prevention-seconds",
+		viperutil.Options[int]{
+			FlagName: "ers-cascade-prevention-seconds",
+			Default:  0,
+			Dynamic:  true,
+		},
+	)
 )
 
 func init() {
@@ -260,6 +269,7 @@ func registerFlags(fs *pflag.FlagSet) {
 	fs.Bool("allow-recovery", allowRecovery.Default(), "Whether VTOrc should be allowed to run recovery actions")
 	fs.Bool("change-tablets-with-errant-gtid-to-drained", convertTabletsWithErrantGTIDs.Default(), "Whether VTOrc should be changing the type of tablets with errant GTIDs to DRAINED")
 	fs.Bool("enable-primary-disk-stalled-recovery", enablePrimaryDiskStalledRecovery.Default(), "Whether VTOrc should detect a stalled disk on the primary and failover")
+	fs.Int("ers-cascade-prevention-seconds", ersCascadePreventionSeconds.Default(), "If non-zero, prevents a subsequent ERS attempt on a shard if a successful ERS completed within this many seconds ago")
 
 	viperutil.BindFlags(fs,
 		cell,
@@ -283,6 +293,7 @@ func registerFlags(fs *pflag.FlagSet) {
 		allowRecovery,
 		convertTabletsWithErrantGTIDs,
 		enablePrimaryDiskStalledRecovery,
+		ersCascadePreventionSeconds,
 	)
 }
 
@@ -429,6 +440,11 @@ func SetConvertTabletWithErrantGTIDs(val bool) {
 // GetStalledDiskPrimaryRecovery reports whether VTOrc is allowed to check for and recovery stalled disk problems.
 func GetStalledDiskPrimaryRecovery() bool {
 	return enablePrimaryDiskStalledRecovery.Get()
+}
+
+// GetERSCascadePreventionSeconds is a getter function.
+func GetERSCascadePreventionSeconds() int {
+	return ersCascadePreventionSeconds.Get()
 }
 
 // MarkConfigurationLoaded is called once configuration has first been loaded.

--- a/go/vt/vtorc/logic/topology_recovery.go
+++ b/go/vt/vtorc/logic/topology_recovery.go
@@ -321,14 +321,26 @@ func runEmergencyReparentOp(ctx context.Context, analysisEntry *inst.DetectionAn
 		return false, nil, err
 	}
 
-	// Check ERS cascade prevention: if a successful ERS completed recently on this shard, skip.
-	if preventionSeconds := config.GetERSCascadePreventionSeconds(); preventionSeconds > 0 {
-		ersCtx, ersCancel := context.WithTimeout(ctx, topo.RemoteOperationTimeout)
-		prevStatus, _, getErr := ts.GetERSStatus(ersCtx, tablet.Keyspace, tablet.Shard)
-		ersCancel()
-		if getErr != nil {
-			logger.Warningf("Failed to read previous ERS status from topo, proceeding with ERS: %v", getErr)
-		} else if prevStatus != nil && prevStatus.Status == topo.ERSStatusCompleted {
+	// Check PreviousERSStatus from topo for cascade prevention and hard blocks.
+	ersCtx, ersCancel := context.WithTimeout(ctx, topo.RemoteOperationTimeout)
+	prevStatus, _, getErr := ts.GetERSStatus(ersCtx, tablet.Keyspace, tablet.Shard)
+	ersCancel()
+	if getErr != nil {
+		logger.Warningf("Failed to read previous ERS status from topo, proceeding with ERS: %v", getErr)
+	} else if prevStatus != nil {
+		// Hard block: if the shard is in an unknown state from a previous failed ERS,
+		// no vtorc can initiate another ERS. An operator must use
+		// `vtctldclient EmergencyReparentShard --force` to resolve.
+		if prevStatus.Status == topo.ERSStatusErroredShardUnknown {
+			logger.Errorf("ERS blocked on %v/%v: previous ERS by %s at %s left the shard in an unknown state. "+
+				"Use `vtctldclient EmergencyReparentShard --force %v/%v` to override.",
+				tablet.Keyspace, tablet.Shard, prevStatus.Identity, prevStatus.Timestamp,
+				tablet.Keyspace, tablet.Shard)
+			ersCascadePreventionCounter.Add([]string{tablet.Keyspace, tablet.Shard}, 1)
+			return false, nil, nil
+		}
+		// Cascade prevention: if a successful ERS completed recently, skip.
+		if preventionSeconds := config.GetERSCascadePreventionSeconds(); preventionSeconds > 0 && prevStatus.Status == topo.ERSStatusCompleted {
 			prevTime, parseErr := time.Parse(time.RFC3339, prevStatus.Timestamp)
 			if parseErr == nil && time.Since(prevTime) < time.Duration(preventionSeconds)*time.Second {
 				logger.Warningf("ERS cascade prevention: skipping %v on %v/%v - last successful ERS by %s was %v ago (prevention window: %ds)",
@@ -339,13 +351,18 @@ func runEmergencyReparentOp(ctx context.Context, analysisEntry *inst.DetectionAn
 		}
 	}
 
-	topologyRecovery, err = AttemptRecoveryRegistration(analysisEntry)
-	if topologyRecovery == nil {
-		message := fmt.Sprintf("found an active or recent recovery on %+v. Will not issue another %v.", analysisEntry.AnalyzedInstanceAlias, recoveryName)
-		logger.Warning(message)
-		_ = AuditTopologyRecovery(topologyRecovery, message)
+	// Create a recovery record for auditing (replaces AttemptRecoveryRegistration for ERS).
+	topologyRecovery = NewTopologyRecovery(*analysisEntry)
+	topologyRecovery, err = writeTopologyRecovery(topologyRecovery)
+	if err != nil {
+		logger.Errorf("Failed to write topology recovery record: %v", err)
 		return false, nil, err
 	}
+	if topologyRecovery == nil {
+		logger.Warningf("Topology recovery record already exists for %+v, skipping %v", analysisEntry.AnalyzedInstanceAlias, recoveryName)
+		return false, nil, nil
+	}
+
 	logger.Infof("Analysis: %v, %v %+v", analysisEntry.Analysis, recoveryName, analysisEntry.AnalyzedInstanceAlias)
 	var promotedReplica *inst.Instance
 	// This has to be done in the end; whether successful or not, we should mark that the recovery is done.
@@ -354,18 +371,7 @@ func runEmergencyReparentOp(ctx context.Context, analysisEntry *inst.DetectionAn
 		_ = resolveRecovery(topologyRecovery, promotedReplica)
 	}()
 
-	// Write pending ERS status to topo before executing.
 	identity := vtorcIdentity()
-	pendingStatus := &topo.ERSStatus{
-		Identity:  identity,
-		Timestamp: time.Now().UTC().Format(time.RFC3339),
-		Status:    topo.ERSStatusPending,
-	}
-	writeCtx, writeCancel := context.WithTimeout(ctx, topo.RemoteOperationTimeout)
-	if writeErr := ts.UpdateERSStatus(writeCtx, tablet.Keyspace, tablet.Shard, pendingStatus); writeErr != nil {
-		logger.Warningf("Failed to write pending ERS status to topo: %v", writeErr)
-	}
-	writeCancel()
 
 	ev, err := reparentutil.NewEmergencyReparenter(ts, tmc, logutil.NewCallbackLogger(func(event *logutilpb.Event) {
 		level := event.GetLevel()
@@ -403,14 +409,14 @@ func runEmergencyReparentOp(ctx context.Context, analysisEntry *inst.DetectionAn
 			finalStatus = topo.ERSStatusErroredShardUnchanged
 		}
 	}
-	completedStatus := &topo.ERSStatus{
+	ersStatus := &topo.ERSStatus{
 		Identity:  identity,
 		Timestamp: time.Now().UTC().Format(time.RFC3339),
 		Status:    finalStatus,
 	}
-	writeCtx, writeCancel = context.WithTimeout(ctx, topo.RemoteOperationTimeout)
-	if writeErr := ts.UpdateERSStatus(writeCtx, tablet.Keyspace, tablet.Shard, completedStatus); writeErr != nil {
-		logger.Warningf("Failed to write final ERS status (%s) to topo: %v", finalStatus, writeErr)
+	writeCtx, writeCancel := context.WithTimeout(ctx, topo.RemoteOperationTimeout)
+	if writeErr := ts.UpdateERSStatus(writeCtx, tablet.Keyspace, tablet.Shard, ersStatus); writeErr != nil {
+		logger.Warningf("Failed to write ERS status (%s) to topo: %v", finalStatus, writeErr)
 	}
 	writeCancel()
 

--- a/go/vt/vtorc/logic/topology_recovery.go
+++ b/go/vt/vtorc/logic/topology_recovery.go
@@ -22,17 +22,21 @@ import (
 	"errors"
 	"fmt"
 	"math/rand/v2"
+	"os"
 	"sync/atomic"
 	"time"
 
 	"github.com/patrickmn/go-cache"
 	"golang.org/x/sync/errgroup"
 
+	"vitess.io/vitess/go/netutil"
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
 	logutilpb "vitess.io/vitess/go/vt/proto/logutil"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/servenv"
+	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/vtctl/reparentutil"
 	"vitess.io/vitess/go/vt/vtctl/reparentutil/policy"
@@ -125,6 +129,9 @@ var (
 	// shardLockTimings measures the timing of LockShard operations.
 	shardLockTimingsActions = []string{"Lock", "Unlock"}
 	shardLockTimings        = stats.NewTimings("ShardLockTimings", "Timings of global shard locks", "Action", shardLockTimingsActions...)
+
+	// ersCascadePreventionCounter counts the number of ERS attempts skipped due to cascade prevention.
+	ersCascadePreventionCounter = stats.NewCountersWithMultiLabels("ERSCascadePreventionSkipped", "Count of ERS attempts skipped due to cascade prevention", []string{"Keyspace", "Shard"})
 )
 
 // recoveryFunction is the code of the recovery function to be used
@@ -208,6 +215,18 @@ func initializeTopologyRecoveryPostConfiguration() {
 
 func getLockAction(analysedInstance string, code inst.AnalysisCode) string {
 	return fmt.Sprintf("VTOrc Recovery for %v on %v", code, analysedInstance)
+}
+
+// vtorcIdentity returns a string identifying this vtorc instance (hostname:port).
+func vtorcIdentity() string {
+	host, err := netutil.FullyQualifiedHostname()
+	if err != nil {
+		host, err = os.Hostname()
+		if err != nil {
+			host = "unknown"
+		}
+	}
+	return fmt.Sprintf("%s:%d", host, servenv.Port())
 }
 
 // LockShard locks the keyspace-shard preventing others from performing conflicting actions.
@@ -302,6 +321,24 @@ func runEmergencyReparentOp(ctx context.Context, analysisEntry *inst.DetectionAn
 		return false, nil, err
 	}
 
+	// Check ERS cascade prevention: if a successful ERS completed recently on this shard, skip.
+	if preventionSeconds := config.GetERSCascadePreventionSeconds(); preventionSeconds > 0 {
+		ersCtx, ersCancel := context.WithTimeout(ctx, topo.RemoteOperationTimeout)
+		prevStatus, _, getErr := ts.GetERSStatus(ersCtx, tablet.Keyspace, tablet.Shard)
+		ersCancel()
+		if getErr != nil {
+			logger.Warningf("Failed to read previous ERS status from topo, proceeding with ERS: %v", getErr)
+		} else if prevStatus != nil && prevStatus.Status == topo.ERSStatusCompleted {
+			prevTime, parseErr := time.Parse(time.RFC3339, prevStatus.Timestamp)
+			if parseErr == nil && time.Since(prevTime) < time.Duration(preventionSeconds)*time.Second {
+				logger.Warningf("ERS cascade prevention: skipping %v on %v/%v - last successful ERS by %s was %v ago (prevention window: %ds)",
+					recoveryName, tablet.Keyspace, tablet.Shard, prevStatus.Identity, time.Since(prevTime), preventionSeconds)
+				ersCascadePreventionCounter.Add([]string{tablet.Keyspace, tablet.Shard}, 1)
+				return false, nil, nil
+			}
+		}
+	}
+
 	topologyRecovery, err = AttemptRecoveryRegistration(analysisEntry)
 	if topologyRecovery == nil {
 		message := fmt.Sprintf("found an active or recent recovery on %+v. Will not issue another %v.", analysisEntry.AnalyzedInstanceAlias, recoveryName)
@@ -316,6 +353,19 @@ func runEmergencyReparentOp(ctx context.Context, analysisEntry *inst.DetectionAn
 	defer func() {
 		_ = resolveRecovery(topologyRecovery, promotedReplica)
 	}()
+
+	// Write pending ERS status to topo before executing.
+	identity := vtorcIdentity()
+	pendingStatus := &topo.ERSStatus{
+		Identity:  identity,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Status:    topo.ERSStatusPending,
+	}
+	writeCtx, writeCancel := context.WithTimeout(ctx, topo.RemoteOperationTimeout)
+	if writeErr := ts.UpdateERSStatus(writeCtx, tablet.Keyspace, tablet.Shard, pendingStatus); writeErr != nil {
+		logger.Warningf("Failed to write pending ERS status to topo: %v", writeErr)
+	}
+	writeCancel()
 
 	ev, err := reparentutil.NewEmergencyReparenter(ts, tmc, logutil.NewCallbackLogger(func(event *logutilpb.Event) {
 		level := event.GetLevel()
@@ -343,6 +393,26 @@ func runEmergencyReparentOp(ctx context.Context, analysisEntry *inst.DetectionAn
 	if err != nil {
 		logger.Errorf("Error running ERS - %v", err)
 	}
+
+	// Write final ERS status to topo.
+	finalStatus := topo.ERSStatusCompleted
+	if err != nil {
+		if ev != nil && ev.NewPrimary != nil {
+			finalStatus = topo.ERSStatusErroredShardUnknown
+		} else {
+			finalStatus = topo.ERSStatusErroredShardUnchanged
+		}
+	}
+	completedStatus := &topo.ERSStatus{
+		Identity:  identity,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Status:    finalStatus,
+	}
+	writeCtx, writeCancel = context.WithTimeout(ctx, topo.RemoteOperationTimeout)
+	if writeErr := ts.UpdateERSStatus(writeCtx, tablet.Keyspace, tablet.Shard, completedStatus); writeErr != nil {
+		logger.Warningf("Failed to write final ERS status (%s) to topo: %v", finalStatus, writeErr)
+	}
+	writeCancel()
 
 	if ev != nil && ev.NewPrimary != nil {
 		promotedReplica, _, _ = inst.ReadInstance(topoproto.TabletAliasString(ev.NewPrimary.Alias))

--- a/proto/vtctldata.proto
+++ b/proto/vtctldata.proto
@@ -756,6 +756,9 @@ message EmergencyReparentShardRequest {
   // ExpectedPrimary is the optional alias we expect to be the current primary in order for
   // the reparent operation to succeed.
   topodata.TabletAlias expected_primary = 8;
+  // Force overrides ERS cascade prevention checks, including the hard block
+  // when PreviousERSStatus is errored_shard_unknown.
+  bool force = 9;
 }
 
 message EmergencyReparentShardResponse {


### PR DESCRIPTION
* add vtorc cli arg `--ers-cascade-prevention-seconds` (int, default 0 = disabled, dynamic).

* at the end of all `EmergencyReparentShard` executions (regardless of vtorc or human operator) put the status of the attempt into the key `keyspaces/{ks}/shards/{shard}/PreviousERSStatus` on the lockserver (read: globally available to all vtorcs, vtctlds). the data contains `Identity` (host:port, e.g. vtorc or vtctld), `Timestamp`, `Status` (i.e. `completed`, `errored_shard_unchanged`, `errored_shard_unknown`).

* at the beginning of all `EmergencyReparentShard` executions, look for `keyspaces/{ks}/shards/{shard}/PreviousERSStatus` on the lockserver, and if status is `completed` and the current time minus last ERS timestamp delta is less than a non-zero `--ers-cascade-prevention-seconds`, then error the ERS attempt, to prevent "cascading" (multiple ERS in rapid succession).

* if `PreviousERSStatus` is ever `errored_shard_unknown`, NO vtorc can initiate an ERS on that shard!!!

* add a `--force` arg to the `EmergencyReparentShard` grpc which will override/ignore `--ers-cascade-prevention-seconds` (and also can overwrite `errored_shard_unknown` by virtue of its ERS having a different outcome)

* remove the flawed local sqlite `AttemptRecoveryRegistration` since we now have the functionality globally across all vtorcs via `PreviousERSStatus`.