### PR TITLE
Re-apply fork-specific workflow disables after upstream sync

### DIFF
--- a/.github/workflows/error_code_docs_generate.yml
+++ b/.github/workflows/error_code_docs_generate.yml
@@ -4,6 +4,8 @@ name: Generate error code docs
 on:
   pull_request:
     types: [opened, synchronize]
+    branches-ignore:
+      - '*'  # Disabled in Slack fork
     paths:
       - "go/vt/vterrors/code.go"
 

--- a/.github/workflows/pr_opened_tasks.yml
+++ b/.github/workflows/pr_opened_tasks.yml
@@ -8,6 +8,8 @@ permissions: read-all
 on:
   pull_request_target:
     types: [opened]
+    branches-ignore:
+      - '*'  # Disabled in Slack fork - GitHub App not configured
 
 jobs:
   # Skip PRs with "Backport" or "Forwardport" labels since those are automated.


### PR DESCRIPTION
## What's this?
Re-applies workflow disables that were lost during the upstream sync:

- **`pr_opened_tasks.yml`** — `branches-ignore: '*'` (GitHub App not configured in fork)
- **`error_code_docs_generate.yml`** — `branches-ignore: '*'` (also kills the downstream `error_code_docs_update.yml` which triggers on `workflow_run`)

---
_Mostly written by Claude Code — I just provided direction._