### PR TITLE
v22.0.4 backport batch 1: critical fixes + vtgate

### DIFF
--- a/go/sqltypes/proto3.go
+++ b/go/sqltypes/proto3.go
@@ -135,7 +135,7 @@ func CustomProto3ToResult(fields []*querypb.Field, qr *querypb.QueryResult) *Res
 		return nil
 	}
 	return &Result{
-		Fields:              qr.Fields,
+		Fields:              fields,
 		RowsAffected:        qr.RowsAffected,
 		InsertID:            qr.InsertId,
 		InsertIDChanged:     qr.InsertIdChanged,

--- a/go/test/endtoend/onlineddl/vrepl_suite/testdata/fail-binary-no-default-value/alter
+++ b/go/test/endtoend/onlineddl/vrepl_suite/testdata/fail-binary-no-default-value/alter
@@ -1,0 +1,1 @@
+add column new_col bigint not null

--- a/go/test/endtoend/onlineddl/vrepl_suite/testdata/fail-binary-no-default-value/create.sql
+++ b/go/test/endtoend/onlineddl/vrepl_suite/testdata/fail-binary-no-default-value/create.sql
@@ -1,0 +1,47 @@
+drop table if exists onlineddl_test;
+create table onlineddl_test (
+  id int auto_increment,
+  bin_data varbinary(256) not null,
+  primary key(id)
+) auto_increment=1;
+
+-- Insert rows with binary data containing bytes 0x80-0xFF.
+-- These bytes are invalid standalone UTF-8. When VReplication copies these rows,
+-- the bulk INSERT query is built by encodeBytesSQLBytes2 (byte iteration, WriteByte),
+-- preserving raw high bytes. If the error message is truncated and then re-encoded
+-- by EncodeStringSQL (rune iteration, WriteRune), each invalid byte expands from
+-- 1 byte to 3 bytes (U+FFFD), causing the stored message to exceed varbinary(1000).
+insert into onlineddl_test (bin_data) values
+  (UNHEX(REPEAT('FF80FE90FD82FC83', 16))),
+  (UNHEX(REPEAT('FF80FE90FD82FC83', 16))),
+  (UNHEX(REPEAT('FF80FE90FD82FC83', 16))),
+  (UNHEX(REPEAT('FF80FE90FD82FC83', 16))),
+  (UNHEX(REPEAT('FF80FE90FD82FC83', 16))),
+  (UNHEX(REPEAT('FF80FE90FD82FC83', 16))),
+  (UNHEX(REPEAT('FF80FE90FD82FC83', 16))),
+  (UNHEX(REPEAT('FF80FE90FD82FC83', 16))),
+  (UNHEX(REPEAT('FF80FE90FD82FC83', 16))),
+  (UNHEX(REPEAT('FF80FE90FD82FC83', 16))),
+  (UNHEX(REPEAT('FF80FE90FD82FC83', 16))),
+  (UNHEX(REPEAT('FF80FE90FD82FC83', 16))),
+  (UNHEX(REPEAT('FF80FE90FD82FC83', 16))),
+  (UNHEX(REPEAT('FF80FE90FD82FC83', 16))),
+  (UNHEX(REPEAT('FF80FE90FD82FC83', 16))),
+  (UNHEX(REPEAT('FF80FE90FD82FC83', 16))),
+  (UNHEX(REPEAT('FF80FE90FD82FC83', 16))),
+  (UNHEX(REPEAT('FF80FE90FD82FC83', 16))),
+  (UNHEX(REPEAT('FF80FE90FD82FC83', 16))),
+  (UNHEX(REPEAT('FF80FE90FD82FC83', 16)));
+
+drop event if exists onlineddl_test;
+delimiter ;;
+create event onlineddl_test
+  on schedule every 1 second
+  starts current_timestamp
+  ends current_timestamp + interval 60 second
+  on completion not preserve
+  enable
+  do
+begin
+  insert into onlineddl_test values (null, UNHEX(REPEAT('FF80FE90FD82FC83', 16)));
+end ;;

--- a/go/test/endtoend/onlineddl/vrepl_suite/testdata/fail-binary-no-default-value/expect_failure
+++ b/go/test/endtoend/onlineddl/vrepl_suite/testdata/fail-binary-no-default-value/expect_failure
@@ -1,0 +1,1 @@
+doesn't have a default value

--- a/go/test/endtoend/vtgate/reservedconn/sysvar_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/sysvar_test.go
@@ -195,6 +195,35 @@ func TestSetSystemVariableAndThenSuccessfulAutocommitDML(t *testing.T) {
 	utils.AssertMatches(t, conn, `select @@sql_safe_updates`, `[[INT64(1)]]`)
 }
 
+// This test ensures that when autocommit is disabled, `SET` commands do not
+// cause an implicit transaction to be started.
+//
+// We test this via `set session transaction isolation level` because
+// changing the session transaction isolation level affects only the next
+// transaction that's started.
+func TestSetSystemVariableWithAutocommitDisabled(t *testing.T) {
+	conn1, err := mysql.Connect(context.Background(), &vtParams)
+	require.NoError(t, err)
+	defer conn1.Close()
+
+	conn2, err := mysql.Connect(context.Background(), &vtParams)
+	require.NoError(t, err)
+	defer conn2.Close()
+
+	utils.Exec(t, conn1, "delete from test")
+	utils.Exec(t, conn1, "delete from test_vdx")
+
+	utils.Exec(t, conn1, "set autocommit = 0")
+
+	utils.Exec(t, conn1, "set session transaction isolation level read uncommitted")
+	utils.AssertMatches(t, conn1, "select @@transaction_isolation", `[[VARCHAR("READ-UNCOMMITTED")]]`)
+
+	utils.Exec(t, conn2, "begin")
+	utils.Exec(t, conn2, "insert into test (id, val1) values (80, null)")
+
+	utils.AssertMatches(t, conn1, "select id from test where id = 80", `[[INT64(80)]]`)
+}
+
 func TestStartTxAndSetSystemVariableAndThenSuccessfulCommit(t *testing.T) {
 
 	conn, err := mysql.Connect(context.Background(), &vtParams)
@@ -427,6 +456,9 @@ func TestSysVarTxIsolation(t *testing.T) {
 		require.NoError(t, err)
 		defer conn.Close()
 
+		utils.Exec(t, conn, "delete from test")
+		utils.Exec(t, conn, "delete from test_vdx")
+
 		// default from mysql
 		utils.AssertMatches(t, conn, "select @@transaction_isolation", `[[VARCHAR("REPEATABLE-READ")]]`)
 		// ensuring it goes to mysql
@@ -447,6 +479,9 @@ func TestSysVarTxIsolation(t *testing.T) {
 		require.NoError(t, err)
 		defer conn.Close()
 
+		utils.Exec(t, conn, "delete from test")
+		utils.Exec(t, conn, "delete from test_vdx")
+
 		// setting to different value.
 		utils.Exec(t, conn, "set session transaction isolation level read committed")
 
@@ -466,6 +501,9 @@ func TestSysVarTxIsolation(t *testing.T) {
 		conn, err := mysql.Connect(context.Background(), &vtParams)
 		require.NoError(t, err)
 		defer conn.Close()
+
+		utils.Exec(t, conn, "delete from test")
+		utils.Exec(t, conn, "delete from test_vdx")
 
 		// setting to different value.
 		utils.Exec(t, conn, "set @@session.transaction_isolation = 'read-committed'")
@@ -513,4 +551,339 @@ func TestSysVarInnodbWaitTimeout(t *testing.T) {
 	utils.AssertContains(t, conn, "select @@innodb_lock_wait_timeout, connection_id()", `INT64(240)`)
 	// second run, to ensuring the setting is applied on the session and not just on next query after settings.
 	utils.AssertContains(t, conn, "select @@innodb_lock_wait_timeout, connection_id()", `INT64(240)`)
+}
+
+// TestImplicitTxOnAutocommitOff verifies that vtgate only starts implicit
+// transactions for statements that access real table data when autocommit=0,
+// matching MySQL's behavior.
+func TestImplicitTxOnAutocommitOff(t *testing.T) {
+	tests := []struct {
+		name     string
+		query    string
+		startsTx bool
+	}{
+		{
+			name:     "SELECT from real table starts tx",
+			query:    "select id from test where id = 1",
+			startsTx: true,
+		},
+		{
+			name:     "SELECT @@variable does not start tx",
+			query:    "select @@autocommit",
+			startsTx: false,
+		},
+		{
+			name:     "SELECT 1 does not start tx",
+			query:    "select 1",
+			startsTx: false,
+		},
+		{
+			name:     "SELECT from dual does not start tx",
+			query:    "select 1 from dual",
+			startsTx: false,
+		},
+		{
+			name:     "INSERT starts tx",
+			query:    "insert into test (id, val1) values (999, null)",
+			startsTx: true,
+		},
+		{
+			name:     "UPDATE starts tx",
+			query:    "update test set val1 = 'x' where id = 999",
+			startsTx: true,
+		},
+		{
+			name:     "DELETE starts tx",
+			query:    "delete from test where id = 999",
+			startsTx: true,
+		},
+		{
+			name:     "SET variable does not start tx",
+			query:    "set sql_safe_updates = 1",
+			startsTx: false,
+		},
+		{
+			name:     "COMMIT does not start tx",
+			query:    "commit",
+			startsTx: false,
+		},
+		{
+			name:     "ROLLBACK does not start tx",
+			query:    "rollback",
+			startsTx: false,
+		},
+		// SHOW commands that start implicit transactions (access information_schema / data dictionaries):
+		{
+			name:     "SHOW TABLES starts tx",
+			query:    "show tables",
+			startsTx: true,
+		},
+		{
+			name:     "SHOW DATABASES starts tx",
+			query:    "show databases",
+			startsTx: true,
+		},
+		{
+			name:     "SHOW COLUMNS starts tx",
+			query:    "show columns from test",
+			startsTx: true,
+		},
+		{
+			name:     "SHOW INDEX starts tx",
+			query:    "show index from test",
+			startsTx: true,
+		},
+		{
+			name:     "SHOW TABLE STATUS starts tx",
+			query:    "show table status",
+			startsTx: true,
+		},
+		{
+			name:     "SHOW TRIGGERS starts tx",
+			query:    "show triggers",
+			startsTx: true,
+		},
+		{
+			name:     "SHOW CHARSET starts tx",
+			query:    "show charset",
+			startsTx: true,
+		},
+		{
+			name:     "SHOW COLLATION starts tx",
+			query:    "show collation",
+			startsTx: true,
+		},
+		{
+			name:     "SHOW FUNCTION STATUS starts tx",
+			query:    "show function status",
+			startsTx: true,
+		},
+		{
+			name:     "SHOW PROCEDURE STATUS starts tx",
+			query:    "show procedure status",
+			startsTx: true,
+		},
+		// SHOW commands that do NOT start implicit transactions (read server state only):
+		{
+			name:     "SHOW VARIABLES does not start tx",
+			query:    "show variables like 'version'",
+			startsTx: false,
+		},
+		{
+			name:     "SHOW SESSION VARIABLES does not start tx",
+			query:    "show session variables like 'version'",
+			startsTx: false,
+		},
+		{
+			name:     "SHOW GLOBAL VARIABLES does not start tx",
+			query:    "show global variables like 'version'",
+			startsTx: false,
+		},
+		{
+			name:     "SHOW STATUS does not start tx",
+			query:    "show status like 'Uptime'",
+			startsTx: false,
+		},
+		{
+			name:     "SHOW GLOBAL STATUS does not start tx",
+			query:    "show global status like 'Uptime'",
+			startsTx: false,
+		},
+		{
+			name:     "SHOW WARNINGS does not start tx",
+			query:    "show warnings",
+			startsTx: false,
+		},
+		{
+			name:     "SHOW ENGINES does not start tx",
+			query:    "show engines",
+			startsTx: false,
+		},
+		{
+			name:     "SHOW PLUGINS does not start tx",
+			query:    "show plugins",
+			startsTx: false,
+		},
+		{
+			name:     "SHOW PRIVILEGES does not start tx",
+			query:    "show privileges",
+			startsTx: false,
+		},
+		{
+			name:     "SHOW OPEN TABLES does not start tx",
+			query:    "show open tables",
+			startsTx: false,
+		},
+		// ShowCreate commands do not start implicit transactions.
+		{
+			name:     "SHOW CREATE TABLE does not start tx",
+			query:    "show create table test",
+			startsTx: false,
+		},
+		{
+			name:     "SHOW CREATE DATABASE does not start tx",
+			query:    "show create database " + keyspaceName,
+			startsTx: false,
+		},
+		// ShowOther commands are sent to MySQL as-is and do not start implicit transactions.
+		{
+			name:     "SHOW PROCESSLIST does not start tx",
+			query:    "show processlist",
+			startsTx: false,
+		},
+		{
+			name:     "SHOW BINARY LOGS does not start tx",
+			query:    "show binary logs",
+			startsTx: false,
+		},
+		{
+			name:     "SHOW GRANTS does not start tx",
+			query:    "show grants",
+			startsTx: false,
+		},
+		{
+			name:     "SHOW ERRORS does not start tx",
+			query:    "show errors",
+			startsTx: false,
+		},
+		{
+			name:     "SHOW EVENTS does not start tx",
+			query:    "show events",
+			startsTx: false,
+		},
+		{
+			name:     "SHOW PROFILES does not start tx",
+			query:    "show profiles",
+			startsTx: false,
+		},
+		{
+			name:     "SHOW REPLICA STATUS does not start tx",
+			query:    "show replica status",
+			startsTx: false,
+		},
+		{
+			name:     "SHOW ENGINE INNODB STATUS does not start tx",
+			query:    "show engine innodb status",
+			startsTx: false,
+		},
+		// Vitess-specific SHOW commands are handled internally by vtgate
+		// and should not start implicit transactions.
+		{
+			name:     "SHOW VITESS_TABLETS does not start tx",
+			query:    "show vitess_tablets",
+			startsTx: false,
+		},
+		{
+			name:     "SHOW VITESS_SHARDS does not start tx",
+			query:    "show vitess_shards",
+			startsTx: false,
+		},
+		{
+			name:     "SHOW VITESS_TARGET does not start tx",
+			query:    "show vitess_target",
+			startsTx: false,
+		},
+		{
+			name:     "SHOW VSCHEMA TABLES does not start tx",
+			query:    "show vschema tables",
+			startsTx: false,
+		},
+		{
+			name:     "SHOW VSCHEMA KEYSPACES does not start tx",
+			query:    "show vschema keyspaces",
+			startsTx: false,
+		},
+		{
+			name:     "SHOW VSCHEMA VINDEXES does not start tx",
+			query:    "show vschema vindexes",
+			startsTx: false,
+		},
+		{
+			name:     "SHOW KEYSPACES does not start tx",
+			query:    "show keyspaces",
+			startsTx: false,
+		},
+		{
+			name:     "SHOW VITESS_MIGRATIONS does not start tx",
+			query:    "show vitess_migrations",
+			startsTx: false,
+		},
+		{
+			name:     "SHOW VITESS_REPLICATION_STATUS does not start tx",
+			query:    "show vitess_replication_status",
+			startsTx: false,
+		},
+		{
+			name:     "SHOW GLOBAL GTID_EXECUTED does not start tx",
+			query:    "show global gtid_executed",
+			startsTx: false,
+		},
+		{
+			name:     "SHOW GLOBAL VGTID_EXECUTED does not start tx",
+			query:    "show global vgtid_executed",
+			startsTx: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			conn, err := mysql.Connect(context.Background(), &vtParams)
+			require.NoError(t, err)
+			defer conn.Close()
+
+			utils.Exec(t, conn, "delete from test")
+			utils.Exec(t, conn, "delete from test_vdx")
+
+			utils.Exec(t, conn, "set autocommit = 0")
+
+			result := utils.Exec(t, conn, tc.query)
+
+			inTx := result.StatusFlags&mysql.ServerStatusInTrans != 0
+			if tc.startsTx {
+				assert.True(t, inTx, "expected %q to start an implicit transaction", tc.query)
+			} else {
+				assert.False(t, inTx, "expected %q to NOT start an implicit transaction", tc.query)
+			}
+		})
+	}
+
+	t.Run("ROLLBACK TO SAVEPOINT returns an error when no transaction has been started", func(t *testing.T) {
+		conn, err := mysql.Connect(context.Background(), &vtParams)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		utils.Exec(t, conn, "set autocommit = 0")
+
+		_, err = utils.ExecAllowError(t, conn, "ROLLBACK TO SAVEPOINT sp1")
+		require.Error(t, err)
+		sqlErr, ok := err.(*sqlerror.SQLError)
+		require.True(t, ok, "not a mysql error: %T", err)
+		assert.Equal(t, sqlerror.ERSPDoesNotExist, sqlErr.Number())
+		assert.Equal(t, sqlerror.SSClientError, sqlErr.SQLState())
+		assert.Contains(t, sqlErr.Error(), "SAVEPOINT does not exist: ROLLBACK TO SAVEPOINT sp1 (errno 1305) (sqlstate 42000)")
+
+		result := utils.Exec(t, conn, "select 1")
+		inTx := result.StatusFlags&mysql.ServerStatusInTrans != 0
+		assert.False(t, inTx, "expected ROLLBACK TO SAVEPOINT to not start a transaction")
+	})
+
+	t.Run("RELEASE SAVEPOINT returns an error when no transaction has been started", func(t *testing.T) {
+		conn, err := mysql.Connect(context.Background(), &vtParams)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		utils.Exec(t, conn, "set autocommit = 0")
+
+		_, err = utils.ExecAllowError(t, conn, "RELEASE SAVEPOINT sp1")
+		require.Error(t, err)
+		sqlErr, ok := err.(*sqlerror.SQLError)
+		require.True(t, ok, "not a mysql error: %T", err)
+		assert.Equal(t, sqlerror.ERSPDoesNotExist, sqlErr.Number())
+		assert.Equal(t, sqlerror.SSClientError, sqlErr.SQLState())
+		assert.Contains(t, sqlErr.Error(), "SAVEPOINT does not exist: RELEASE SAVEPOINT sp1 (errno 1305) (sqlstate 42000)")
+
+		result := utils.Exec(t, conn, "select 1")
+		inTx := result.StatusFlags&mysql.ServerStatusInTrans != 0
+		assert.False(t, inTx, "expected RELEASE SAVEPOINT to not start a transaction")
+	})
 }

--- a/go/test/endtoend/vtgate/reservedconn/sysvar_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/sysvar_test.go
@@ -422,42 +422,65 @@ func checkOltpAndOlapInterchangingTx(t *testing.T, conn *mysql.Conn) {
 }
 
 func TestSysVarTxIsolation(t *testing.T) {
-	conn, err := mysql.Connect(context.Background(), &vtParams)
-	require.NoError(t, err)
-	defer conn.Close()
+	t.Run("returns the default isolation level if unchanged", func(t *testing.T) {
+		conn, err := mysql.Connect(context.Background(), &vtParams)
+		require.NoError(t, err)
+		defer conn.Close()
 
-	// will run every check twice to see that the isolation level is set for all the queries in the session and
+		// default from mysql
+		utils.AssertMatches(t, conn, "select @@transaction_isolation", `[[VARCHAR("REPEATABLE-READ")]]`)
+		// ensuring it goes to mysql
+		utils.AssertContains(t, conn, "select @@transaction_isolation, connection_id()", `REPEATABLE-READ`)
+		// second run, ensuring it has the same value.
+		utils.AssertContains(t, conn, "select @@transaction_isolation, connection_id()", `REPEATABLE-READ`)
 
-	// default from mysql
-	utils.AssertMatches(t, conn, "select @@transaction_isolation", `[[VARCHAR("REPEATABLE-READ")]]`)
-	// ensuring it goes to mysql
-	utils.AssertContains(t, conn, "select @@transaction_isolation, connection_id()", `REPEATABLE-READ`)
-	// second run, ensuring it has the same value.
-	utils.AssertContains(t, conn, "select @@transaction_isolation, connection_id()", `REPEATABLE-READ`)
+		// Switch to shard targeting
+		utils.Exec(t, conn, "use `"+keyspaceName+":-80`")
 
-	// setting to different value.
-	utils.Exec(t, conn, "set @@transaction_isolation = 'read-committed'")
-	utils.AssertMatches(t, conn, "select @@transaction_isolation", `[[VARCHAR("READ-COMMITTED")]]`)
-	// ensuring it goes to mysql
-	utils.AssertContains(t, conn, "select @@transaction_isolation, connection_id()", `READ-COMMITTED`)
-	// second run, to ensuring the setting is applied on the session and not just on next query after settings.
-	utils.AssertContains(t, conn, "select @@transaction_isolation, connection_id()", `READ-COMMITTED`)
+		utils.AssertMatches(t, conn, "select @@transaction_isolation", `[[VARCHAR("REPEATABLE-READ")]]`)
+		utils.AssertContains(t, conn, "select @@transaction_isolation, connection_id()", `REPEATABLE-READ`)
+		utils.AssertContains(t, conn, "select @@transaction_isolation, connection_id()", `REPEATABLE-READ`)
+	})
 
-	// changing setting to different value.
-	utils.Exec(t, conn, "set session transaction isolation level read uncommitted")
-	utils.AssertMatches(t, conn, "select @@transaction_isolation", `[[VARCHAR("READ-UNCOMMITTED")]]`)
-	// ensuring it goes to mysql
-	utils.AssertContains(t, conn, "select @@transaction_isolation, connection_id()", `READ-UNCOMMITTED`)
-	// second run, to ensuring the setting is applied on the session and not just on next query after settings.
-	utils.AssertContains(t, conn, "select @@transaction_isolation, connection_id()", `READ-UNCOMMITTED`)
+	t.Run("allows changing the isolation level via special syntax", func(t *testing.T) {
+		conn, err := mysql.Connect(context.Background(), &vtParams)
+		require.NoError(t, err)
+		defer conn.Close()
 
-	// changing setting to different value.
-	utils.Exec(t, conn, "set transaction isolation level serializable")
-	utils.AssertMatches(t, conn, "select @@transaction_isolation", `[[VARCHAR("SERIALIZABLE")]]`)
-	// ensuring it goes to mysql
-	utils.AssertContains(t, conn, "select @@transaction_isolation, connection_id()", `SERIALIZABLE`)
-	// second run, to ensuring the setting is applied on the session and not just on next query after settings.
-	utils.AssertContains(t, conn, "select @@transaction_isolation, connection_id()", `SERIALIZABLE`)
+		// setting to different value.
+		utils.Exec(t, conn, "set session transaction isolation level read committed")
+
+		utils.AssertMatches(t, conn, "select @@transaction_isolation", `[[VARCHAR("READ-COMMITTED")]]`)
+		utils.AssertContains(t, conn, "select @@transaction_isolation, connection_id()", `READ-COMMITTED`)
+		utils.AssertContains(t, conn, "select @@transaction_isolation, connection_id()", `READ-COMMITTED`)
+
+		// Switch to shard targeting
+		utils.Exec(t, conn, "use `"+keyspaceName+":-80`")
+		utils.AssertMatches(t, conn, "select @@transaction_isolation", `[[VARCHAR("READ-COMMITTED")]]`)
+
+		utils.Exec(t, conn, "set session transaction isolation level read uncommitted")
+		utils.AssertMatches(t, conn, "select @@transaction_isolation", `[[VARCHAR("READ-UNCOMMITTED")]]`)
+	})
+
+	t.Run("allows changing the isolation level via session variable", func(t *testing.T) {
+		conn, err := mysql.Connect(context.Background(), &vtParams)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		// setting to different value.
+		utils.Exec(t, conn, "set @@session.transaction_isolation = 'read-committed'")
+
+		utils.AssertMatches(t, conn, "select @@transaction_isolation", `[[VARCHAR("READ-COMMITTED")]]`)
+		utils.AssertContains(t, conn, "select @@transaction_isolation, connection_id()", `READ-COMMITTED`)
+		utils.AssertContains(t, conn, "select @@transaction_isolation, connection_id()", `READ-COMMITTED`)
+
+		// Switch to shard targeting
+		utils.Exec(t, conn, "use `"+keyspaceName+":-80`")
+		utils.AssertMatches(t, conn, "select @@transaction_isolation", `[[VARCHAR("READ-COMMITTED")]]`)
+
+		utils.Exec(t, conn, "set @@session.transaction_isolation = 'read-uncommitted'")
+		utils.AssertMatches(t, conn, "select @@transaction_isolation", `[[VARCHAR("READ-UNCOMMITTED")]]`)
+	})
 }
 
 // TestSysVarInnodbWaitTimeout tests the innodb_lock_wait_timeout system variable

--- a/go/vt/binlog/binlogplayer/message_truncate_test.go
+++ b/go/vt/binlog/binlogplayer/message_truncate_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package binlogplayer
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/sqltypes"
+)
+
+// TestMessageTruncateWithBinaryData documents a known encoding asymmetry
+// between how binary data is encoded into INSERT queries vs how error messages
+// are re-encoded for storage in _vt.vreplication.message (varbinary(1000)).
+//
+// The INSERT query is built using encodeBytesSQLBytes2 which iterates over
+// []byte (byte-by-byte) and uses WriteByte, preserving raw high bytes (128-255)
+// as single bytes in the Go string. But when the error message is re-encoded by
+// EncodeStringSQL for the UPDATE, it iterates over string (rune-by-rune with
+// UTF-8 decoding) and uses WriteRune. Invalid UTF-8 bytes get expanded to
+// 3-byte U+FFFD replacement characters, causing the stored value to potentially
+// exceed the column limit.
+//
+// The controller's runBlp() handles this by falling back to a simplified error
+// message when setState() fails, preventing an infinite retry loop.
+// See: controller.go runBlp() and the fail-binary-no-default-value e2e test.
+func TestMessageTruncateWithBinaryData(t *testing.T) {
+	// Build a realistic error message. The binary data in the INSERT query
+	// was encoded by encodeBytesSQLBytes2 which preserves raw bytes. So the
+	// Go string contains raw high bytes (0x80-0xFF) that are NOT valid UTF-8.
+	var msg strings.Builder
+
+	msg.WriteString("task error: failed inserting rows: Field 'workspace_id' doesn't have a default value (errno 1364) (sqlstate HY000) during query: insert into _vt_vrp_2354fd5f43b850e8a66b2375d6c09642_20260218201401_(chunk,type,`name`,`data`,environment_id) values ")
+
+	// Simulate how encodeBytesSQLBytes2 writes binary values: raw bytes are
+	// preserved as-is (not re-encoded as UTF-8 runes). Build values that
+	// contain raw high bytes, similar to bitmap data.
+	for i := range 30 {
+		if i > 0 {
+			msg.WriteString(", ")
+		}
+		msg.WriteString(fmt.Sprintf("(0,%d,_binary'", i%4))
+		msg.WriteString("id")
+		msg.WriteString("',_binary'")
+		// Write raw binary data the way encodeBytesSQLBytes2 does: raw bytes
+		// including invalid UTF-8 sequences.
+		msg.WriteByte(0x00) // null byte
+		msg.WriteByte(0x80) // invalid UTF-8 standalone
+		msg.WriteByte(0x0d) // carriage return
+		msg.WriteByte(0xc2) // start of 2-byte UTF-8 sequence...
+		msg.WriteByte(0xa6) // ...valid pair (U+00A6)
+		msg.WriteByte(0xff) // invalid UTF-8
+		msg.WriteByte(0x80) // invalid UTF-8 standalone
+		msg.WriteByte(0xfe) // invalid UTF-8
+		msg.WriteByte(0x90) // invalid UTF-8 standalone
+		msg.WriteString("',0)")
+	}
+
+	fullMessage := msg.String()
+	require.Greater(t, len(fullMessage), 950, "message should be longer than truncation limit")
+
+	// MessageTruncate correctly limits the raw string to 950 bytes.
+	truncated := MessageTruncate(fullMessage)
+	assert.LessOrEqual(t, len(truncated), 950, "MessageTruncate should limit to 950 bytes")
+
+	// Encode for SQL (as setState/setMessage does via encodeString).
+	encoded := sqltypes.EncodeStringSQL(truncated)
+
+	// Decode (simulating what MySQL stores after processing the UPDATE).
+	decoded, err := sqltypes.DecodeStringSQL(encoded)
+	require.NoError(t, err, "DecodeStringSQL should not error")
+
+	// Document the known asymmetry: EncodeStringSQL iterates the string by
+	// rune (UTF-8 decoding), producing U+FFFD for each invalid byte. WriteRune
+	// then re-encodes U+FFFD as 3 bytes. The round-trip is NOT symmetric for
+	// strings containing invalid UTF-8, so the decoded value is larger than
+	// the input. This can cause the stored value to exceed varbinary(1000).
+	//
+	// The controller handles this gracefully by falling back to a simplified
+	// error message when setState() fails. See controller.go runBlp().
+	assert.Greater(t, len(decoded), len(truncated),
+		"encoding round-trip should expand invalid UTF-8 bytes (known asymmetry)")
+	assert.Greater(t, len(decoded), 1000,
+		"decoded value should exceed varbinary(1000) limit (known asymmetry that controller.runBlp handles)")
+}

--- a/go/vt/vtgate/engine/set.go
+++ b/go/vt/vtgate/engine/set.go
@@ -277,6 +277,7 @@ func (svs *SysVarReservedConn) Execute(ctx context.Context, vcursor VCursor, env
 			return err
 		}
 		vcursor.Session().NeedsReservedConn()
+		vcursor.Session().SetSysVar(svs.Name, svs.Expr)
 		return svs.execSetStatement(ctx, vcursor, rss, env)
 	}
 	needReservedConn, err := svs.checkAndUpdateSysVar(ctx, vcursor, env)
@@ -292,22 +293,14 @@ func (svs *SysVarReservedConn) Execute(ctx context.Context, vcursor VCursor, env
 	if len(rss) == 0 {
 		return nil
 	}
-	queries := make([]*querypb.BoundQuery, len(rss))
-	for i := 0; i < len(rss); i++ {
-		queries[i] = &querypb.BoundQuery{
-			Sql:           fmt.Sprintf("set %s = %s", svs.Name, svs.Expr),
-			BindVariables: env.BindVars,
-		}
-	}
-	_, errs := vcursor.ExecuteMultiShard(ctx, nil /*primitive*/, rss, queries, false /*rollbackOnError*/, false /*canAutocommit*/, false /*fetchLastInsertID*/)
-	return vterrors.Aggregate(errs)
+	return svs.execSetStatement(ctx, vcursor, rss, env)
 }
 
 func (svs *SysVarReservedConn) execSetStatement(ctx context.Context, vcursor VCursor, rss []*srvtopo.ResolvedShard, env *evalengine.ExpressionEnv) error {
 	queries := make([]*querypb.BoundQuery, len(rss))
 	for i := 0; i < len(rss); i++ {
 		queries[i] = &querypb.BoundQuery{
-			Sql:           fmt.Sprintf("set @@%s = %s", svs.Name, svs.Expr),
+			Sql:           fmt.Sprintf("set %s = %s", svs.Name, svs.Expr),
 			BindVariables: env.BindVars,
 		}
 	}

--- a/go/vt/vtgate/engine/set_test.go
+++ b/go/vt/vtgate/engine/set_test.go
@@ -243,7 +243,8 @@ func TestSetTable(t *testing.T) {
 		expectedQueryLog: []string{
 			`ResolveDestinations ks [] Destinations:DestinationAnyShard()`,
 			`Needs Reserved Conn`,
-			`ExecuteMultiShard ks.-20: set @@x = dummy_expr {} false false`,
+			`SysVar set with (x,dummy_expr)`,
+			`ExecuteMultiShard ks.-20: set x = dummy_expr {} false false`,
 		},
 	}, {
 		testName: "sysvar set not modifying setting",
@@ -609,7 +610,8 @@ func TestSysVarSetErr(t *testing.T) {
 	expectedQueryLog := []string{
 		`ResolveDestinations ks [] Destinations:DestinationAnyShard()`,
 		"Needs Reserved Conn",
-		`ExecuteMultiShard ks.-20: set @@x = dummy_expr {} false false`,
+		"SysVar set with (x,dummy_expr)",
+		`ExecuteMultiShard ks.-20: set x = dummy_expr {} false false`,
 	}
 
 	set := &Set{

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -326,6 +326,7 @@ func (e *Executor) StreamExecute(
 				// the framework currently sends all results as one packet.
 				byteCount := 0
 				if len(qr.Fields) > 0 {
+					result.Fields = qr.Fields
 					if err := callback(qr.Metadata()); err != nil {
 						return err
 					}

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -673,6 +673,10 @@ func TestStreamBuffering(t *testing.T) {
 			{Name: "col", Type: sqltypes.VarChar, Charset: uint32(collations.MySQL8().DefaultConnectionCharset())},
 		},
 	}, {
+		Fields: []*querypb.Field{
+			{Name: "id", Type: sqltypes.Int32, Charset: collations.CollationBinaryID, Flags: uint32(querypb.MySqlFlag_NUM_FLAG)},
+			{Name: "col", Type: sqltypes.VarChar, Charset: uint32(collations.MySQL8().DefaultConnectionCharset())},
+		},
 		Rows: [][]sqltypes.Value{{
 			sqltypes.NewInt32(1),
 			sqltypes.NewVarChar("01234567890123456789"),

--- a/go/vt/vtgate/grpcvtgateconn/conn.go
+++ b/go/vt/vtgate/grpcvtgateconn/conn.go
@@ -240,6 +240,13 @@ func (a *streamExecuteMultiAdapter) Recv() (*sqltypes.Result, bool, error) {
 		// we reach here, only when it is the last packet.
 		// as in the last packet we receive the session and there is no result
 	}
+
+	// When a new result set starts, clear cached fields from the previous
+	// result set.
+	if newResult {
+		a.fields = nil
+	}
+
 	if err != nil {
 		return nil, newResult, err
 	}

--- a/go/vt/vtgate/plan_execute.go
+++ b/go/vt/vtgate/plan_execute.go
@@ -19,6 +19,7 @@ package vtgate
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -70,12 +71,6 @@ func (e *Executor) newExecute(
 	execPlan planExec, // used when there is a plan to execute
 	recResult txResult, // used when it's something simple like begin/commit/rollback/savepoint
 ) (err error) {
-	// Start an implicit transaction if necessary.
-	err = e.startTxIfNecessary(ctx, safeSession)
-	if err != nil {
-		return err
-	}
-
 	if bindVars == nil {
 		bindVars = make(map[string]*querypb.BindVariable)
 	}
@@ -127,6 +122,14 @@ func (e *Executor) newExecute(
 
 		if err != nil {
 			safeSession.ClearWarnings()
+			return err
+		}
+
+		// Start an implicit transaction if necessary. This is done after plan
+		// creation so we can check whether the plan actually accesses real table
+		// data, matching MySQL's behavior where only data-accessing statements
+		// start implicit transactions when autocommit=0.
+		if err = e.startTxIfNecessary(ctx, plan, stmt, safeSession); err != nil {
 			return err
 		}
 
@@ -264,13 +267,82 @@ func (e *Executor) handleTransactions(
 	return nil, nil
 }
 
-func (e *Executor) startTxIfNecessary(ctx context.Context, safeSession *econtext.SafeSession) error {
-	if !safeSession.Autocommit && !safeSession.InTransaction() {
+func (e *Executor) startTxIfNecessary(ctx context.Context, plan *engine.Plan, stmt sqlparser.Statement, safeSession *econtext.SafeSession) error {
+	if !safeSession.Autocommit && !safeSession.InTransaction() && planStartsImplicitTx(plan, stmt) {
 		if err := e.txConn.Begin(ctx, safeSession, nil); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// planStartsImplicitTx returns true if the given plan should start an implicit
+// transaction when autocommit is disabled. This matches MySQL's behavior where
+// only statements that access real table data start implicit transactions.
+//
+// The default is to start a transaction (matching the previous behavior),
+// and we opt out for specific statement types we've verified against MySQL
+// that don't start implicit transactions.
+func planStartsImplicitTx(plan *engine.Plan, stmt sqlparser.Statement) bool {
+	switch plan.QueryType {
+	case sqlparser.StmtSelect:
+		// Only start an implicit tx if the plan accesses real tables, not just dual.
+		return slices.ContainsFunc(plan.TablesUsed, func(table string) bool {
+			return !strings.HasSuffix(table, ".dual")
+		})
+	case sqlparser.StmtSet, sqlparser.StmtUse:
+		return false
+	case sqlparser.StmtShow:
+		return showStartsImplicitTx(stmt)
+	case sqlparser.StmtBegin, sqlparser.StmtCommit, sqlparser.StmtRollback, sqlparser.StmtSRollback, sqlparser.StmtRelease:
+		// Transaction control statements are handled by handleTransactions and should not
+		// trigger an implicit transaction start.
+		return false
+	default:
+		return true
+	}
+}
+
+// showStartsImplicitTx returns true for SHOW commands that start implicit
+// transactions in MySQL when autocommit=0. Verified experimentally against
+// MySQL 8.0. Commands that only read server state (variables, status,
+// warnings, engines, plugins, privileges) do not start transactions.
+//
+// The default is true (start a transaction) for safety — we only return
+// false for commands we've explicitly verified against MySQL.
+func showStartsImplicitTx(stmt sqlparser.Statement) bool {
+	show, ok := stmt.(*sqlparser.Show)
+	if !ok {
+		return true
+	}
+	switch internal := show.Internal.(type) {
+	case *sqlparser.ShowCreate:
+		// SHOW CREATE TABLE/DATABASE/etc. do not start implicit transactions in MySQL.
+		return false
+	case *sqlparser.ShowOther:
+		// ShowOther covers SHOW PROCESSLIST, SHOW ENGINE STATUS, SHOW BINARY LOGS,
+		// SHOW GRANTS, SHOW REPLICA STATUS, etc. These are server-state commands
+		// that don't start implicit transactions in MySQL.
+		return false
+	case *sqlparser.ShowBasic:
+		// Some SHOW commands do not start implicit transactions in MySQL, but we need to look at the command to determine which ones.
+		switch internal.Command {
+		case sqlparser.VariableSession, sqlparser.VariableGlobal,
+			sqlparser.StatusSession, sqlparser.StatusGlobal,
+			sqlparser.Warnings, sqlparser.Engines, sqlparser.Plugins, sqlparser.Privilege,
+			sqlparser.OpenTable,
+			// Vitess-specific SHOW commands are handled internally by vtgate and don't access InnoDB data.
+			sqlparser.GtidExecGlobal, sqlparser.VGtidExecGlobal,
+			sqlparser.VitessMigrations, sqlparser.VitessReplicationStatus,
+			sqlparser.VitessShards, sqlparser.VitessTablets, sqlparser.VitessTarget, sqlparser.VitessVariables,
+			sqlparser.VschemaTables, sqlparser.VschemaKeyspaces, sqlparser.VschemaVindexes, sqlparser.Keyspace:
+			return false
+		default:
+			return true
+		}
+	default:
+		return true
+	}
 }
 
 func (e *Executor) insideTransaction(ctx context.Context, safeSession *econtext.SafeSession, logStats *logstats.LogStats, execPlan func() error) error {

--- a/go/vt/vtgate/plugin_mysql_server_test.go
+++ b/go/vt/vtgate/plugin_mysql_server_test.go
@@ -565,6 +565,14 @@ func TestComQueryMulti(t *testing.T) {
 				},
 				{
 					QueryResult: &sqltypes.Result{
+						Fields: []*querypb.Field{
+							{
+								Name:    "1",
+								Type:    sqltypes.Int64,
+								Flags:   uint32(querypb.MySqlFlag_NUM_FLAG | querypb.MySqlFlag_NOT_NULL_FLAG),
+								Charset: collations.CollationBinaryID,
+							},
+						},
 						Rows: [][]sqltypes.Value{
 							{
 								sqltypes.NewInt64(1),
@@ -610,6 +618,14 @@ func TestComQueryMulti(t *testing.T) {
 				},
 				{
 					QueryResult: &sqltypes.Result{
+						Fields: []*querypb.Field{
+							{
+								Name:    "1",
+								Type:    sqltypes.Int64,
+								Flags:   uint32(querypb.MySqlFlag_NUM_FLAG | querypb.MySqlFlag_NOT_NULL_FLAG),
+								Charset: collations.CollationBinaryID,
+							},
+						},
 						Rows: [][]sqltypes.Value{
 							{
 								sqltypes.NewInt64(1),
@@ -646,6 +662,14 @@ func TestComQueryMulti(t *testing.T) {
 				},
 				{
 					QueryResult: &sqltypes.Result{
+						Fields: []*querypb.Field{
+							{
+								Name:    "2",
+								Type:    sqltypes.Int64,
+								Flags:   uint32(querypb.MySqlFlag_NUM_FLAG | querypb.MySqlFlag_NOT_NULL_FLAG),
+								Charset: collations.CollationBinaryID,
+							},
+						},
 						Rows: [][]sqltypes.Value{
 							{
 								sqltypes.NewInt64(2),
@@ -682,6 +706,14 @@ func TestComQueryMulti(t *testing.T) {
 				},
 				{
 					QueryResult: &sqltypes.Result{
+						Fields: []*querypb.Field{
+							{
+								Name:    "3",
+								Type:    sqltypes.Int64,
+								Flags:   uint32(querypb.MySqlFlag_NUM_FLAG | querypb.MySqlFlag_NOT_NULL_FLAG),
+								Charset: collations.CollationBinaryID,
+							},
+						},
 						Rows: [][]sqltypes.Value{
 							{
 								sqltypes.NewInt64(3),
@@ -727,6 +759,14 @@ func TestComQueryMulti(t *testing.T) {
 				},
 				{
 					QueryResult: &sqltypes.Result{
+						Fields: []*querypb.Field{
+							{
+								Name:    "1",
+								Type:    sqltypes.Int64,
+								Flags:   uint32(querypb.MySqlFlag_NUM_FLAG | querypb.MySqlFlag_NOT_NULL_FLAG),
+								Charset: collations.CollationBinaryID,
+							},
+						},
 						Rows: [][]sqltypes.Value{
 							{
 								sqltypes.NewInt64(1),
@@ -763,6 +803,14 @@ func TestComQueryMulti(t *testing.T) {
 				},
 				{
 					QueryResult: &sqltypes.Result{
+						Fields: []*querypb.Field{
+							{
+								Name:    "2",
+								Type:    sqltypes.Int64,
+								Flags:   uint32(querypb.MySqlFlag_NUM_FLAG | querypb.MySqlFlag_NOT_NULL_FLAG),
+								Charset: collations.CollationBinaryID,
+							},
+						},
 						Rows: [][]sqltypes.Value{
 							{
 								sqltypes.NewInt64(2),

--- a/go/vt/vtgate/semantics/analyzer_test.go
+++ b/go/vt/vtgate/semantics/analyzer_test.go
@@ -941,6 +941,9 @@ func TestInvalidQueries(t *testing.T) {
 		err:  &UnionWithSQLCalcFoundRowsError{},
 		serr: "VT12001: unsupported: SQL_CALC_FOUND_ROWS not supported with union",
 	}, {
+		sql: "select 1 union select *, m from t1",
+		err: &UnionColumnsDoNotMatchError{FirstProj: 1, SecondProj: 2},
+	}, {
 		sql:  "select * from (select sql_calc_found_rows id from a) as t",
 		serr: "Incorrect usage/placement of 'SQL_CALC_FOUND_ROWS'",
 	}, {

--- a/go/vt/vtgate/semantics/table_collector.go
+++ b/go/vt/vtgate/semantics/table_collector.go
@@ -175,6 +175,9 @@ func (tc *tableCollector) visitUnion(union *sqlparser.Union) error {
 
 	err = sqlparser.VisitAllSelects(union, func(s *sqlparser.Select, idx int) error {
 		for i, expr := range s.GetColumns() {
+			if i >= size {
+				return &UnionColumnsDoNotMatchError{FirstProj: size, SecondProj: len(s.GetColumns())}
+			}
 			ae, ok := expr.(*sqlparser.AliasedExpr)
 			if !ok {
 				continue

--- a/go/vt/vtgate/vtgate_test.go
+++ b/go/vt/vtgate/vtgate_test.go
@@ -271,7 +271,8 @@ func TestVTGateStreamExecute(t *testing.T) {
 	want := []*sqltypes.Result{{
 		Fields: sandboxconn.StreamRowResult.Fields,
 	}, {
-		Rows: sandboxconn.StreamRowResult.Rows,
+		Fields: sandboxconn.StreamRowResult.Fields,
+		Rows:   sandboxconn.StreamRowResult.Rows,
 	}}
 	utils.MustMatch(t, want, qrs)
 	if !proto.Equal(sbc.Options[0], executeOptions) {

--- a/go/vt/vttablet/tabletconntest/fakequeryservice.go
+++ b/go/vt/vttablet/tabletconntest/fakequeryservice.go
@@ -459,6 +459,16 @@ var StreamExecuteQueryResult1 = sqltypes.Result{
 
 // StreamExecuteQueryResult2 is the second packet of a streaming result.
 var StreamExecuteQueryResult2 = sqltypes.Result{
+	Fields: []*querypb.Field{
+		{
+			Name: "field1",
+			Type: sqltypes.Int8,
+		},
+		{
+			Name: "field2",
+			Type: sqltypes.Char,
+		},
+	},
 	Rows: [][]sqltypes.Value{
 		{
 			sqltypes.TestValue(sqltypes.Int8, "1"),

--- a/go/vt/vttablet/tabletmanager/vreplication/journal_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/journal_test.go
@@ -74,7 +74,7 @@ func TestJournalOneToOne(t *testing.T) {
 		fmt.Sprintf("delete from _vt.vreplication where id=%d", firstID),
 		"commit",
 		"/update _vt.vreplication set message='Picked source tablet.*",
-		"/update _vt.vreplication set state='Running', message='' where id.*",
+		"/update _vt.vreplication set state='Running', message=left\\('', 1000\\) where id.*",
 	))
 
 	// Delete all vreplication streams. There should be only one, but we don't know its id.
@@ -139,8 +139,8 @@ func TestJournalOneToMany(t *testing.T) {
 		"commit",
 		"/update _vt.vreplication set message='Picked source tablet.*",
 		"/update _vt.vreplication set message='Picked source tablet.*",
-		"/update _vt.vreplication set state='Running', message='' where id.*",
-		"/update _vt.vreplication set state='Running', message='' where id.*",
+		"/update _vt.vreplication set state='Running', message=left\\('', 1000\\) where id.*",
+		"/update _vt.vreplication set state='Running', message=left\\('', 1000\\) where id.*",
 	))
 
 	// Delete all vreplication streams. There should be only one, but we don't know its id.
@@ -198,7 +198,7 @@ func TestJournalTablePresent(t *testing.T) {
 		fmt.Sprintf("delete from _vt.vreplication where id=%d", firstID),
 		"commit",
 		"/update _vt.vreplication set message='Picked source tablet.*",
-		"/update _vt.vreplication set state='Running', message='' where id.*",
+		"/update _vt.vreplication set state='Running', message=left\\('', 1000\\) where id.*",
 	))
 
 	// Delete all vreplication streams. There should be only one, but we don't know its id.
@@ -307,7 +307,7 @@ func TestJournalTableMixed(t *testing.T) {
 	defer execStatements(t, []string{"delete from _vt.resharding_journal"})
 
 	expectDBClientQueries(t, qh.Expect(
-		"/update _vt.vreplication set state='Stopped', message='unable to handle journal event: tables were partially matched' where id",
+		"/update _vt.vreplication set state='Stopped', message=left\\('unable to handle journal event: tables were partially matched', 1000\\) where id",
 	))
 
 	// Delete all vreplication streams. There should be only one, but we don't know its id.

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -2086,7 +2086,7 @@ func TestPlayerDDL(t *testing.T) {
 	expectDBClientQueries(t, qh.Expect(
 		"alter table t1 add column val2 varchar(128)",
 		"/update _vt.vreplication set message='error applying event: Duplicate",
-		"/update _vt.vreplication set state='Error', message='terminal error: error applying event: Duplicate",
+		"/update _vt.vreplication set state='Error', message=left\\('terminal error: error applying event: Duplicate",
 	))
 	cancel()
 

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -508,7 +508,7 @@ func (vr *vreplicator) setState(state binlogdatapb.VReplicationWorkflowState, me
 		})
 	}
 	vr.stats.State.Store(state.String())
-	query := fmt.Sprintf("update _vt.vreplication set state=%v, message=%v where id=%v", encodeString(state.String()), encodeString(binlogplayer.MessageTruncate(message)), vr.id)
+	query := fmt.Sprintf("update _vt.vreplication set state=%v, message=left(%v, 1000) where id=%v", encodeString(state.String()), encodeString(binlogplayer.MessageTruncate(message)), vr.id)
 	// If we're batching a transaction, then include the state update
 	// in the current transaction batch.
 	if vr.dbClient.InTransaction && vr.dbClient.maxBatchSize > 0 {


### PR DESCRIPTION
## What's this?

Batch 1 of 4 for the v22.0.4 upstream backport. These are the highest-priority commits — critical bug fixes and vtgate correctness issues.

## Commits (in order)

| PR | Score | Description |
|----|:-----:|-------------|
| #19381 | 10 | fix streaming binary row corruption in prepared statements |
| #19318 | 9 | vtgate: fix handling of session variables on targeted connections |
| #19277 | 9 | vtgate: defer implicit transaction start until after query planning |
| #19476 | 8 | vtgate: Add bounds check in visitUnion for mismatched column counts |
| #19423 | 8 | vreplication: fix infinite retry loop when terminal error has binary data |

## Notes

- All cherry-picks applied cleanly (no conflicts)
- #19318 was applied before #19277 as they share a test file and have a dependency
- Local `go build ./go/...` passes clean
- Upstream comparison: https://github.com/vitessio/vitess/compare/v22.0.3...v22.0.4

## Full upgrade plan

https://gist.github.com/sbaker617/4abb0e0c1856cce1b297b64e6353ec3d

---
_Cherry-picked by Claude Code_