### PR TITLE
v22.0.4 backport batch 3: VDiff + medium priority

### DIFF
--- a/go/cmd/vtctldclient/command/vreplication/common/utils.go
+++ b/go/cmd/vtctldclient/command/vreplication/common/utils.go
@@ -190,9 +190,11 @@ func ParseTableMaterializeSettings(tableSettings string, parser *sqlparser.Parse
 }
 
 func validateOnDDL(cmd *cobra.Command) error {
-	if _, ok := binlogdatapb.OnDDLAction_value[strings.ToUpper(CreateOptions.OnDDL)]; !ok {
+	normalized := strings.ToUpper(CreateOptions.OnDDL)
+	if _, ok := binlogdatapb.OnDDLAction_value[normalized]; !ok {
 		return fmt.Errorf("invalid on-ddl value: %s", CreateOptions.OnDDL)
 	}
+	CreateOptions.OnDDL = normalized
 	return nil
 }
 

--- a/go/cmd/vtctldclient/command/vreplication/common/utils_test.go
+++ b/go/cmd/vtctldclient/command/vreplication/common/utils_test.go
@@ -110,6 +110,48 @@ func TestParseAndValidateCreateOptions(t *testing.T) {
 				require.Equal(t, cells, common.CreateOptions.Cells)
 			},
 		},
+		{
+			name: "invalid on-ddl value",
+			setFunc: func(cmd *cobra.Command) error {
+				onDDLFlag := cmd.Flags().Lookup("on-ddl")
+				if err := onDDLFlag.Value.Set("INVALID"); err != nil {
+					return err
+				}
+				onDDLFlag.Changed = true
+				return nil
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid on-ddl normalizes to uppercase",
+			setFunc: func(cmd *cobra.Command) error {
+				onDDLFlag := cmd.Flags().Lookup("on-ddl")
+				if err := onDDLFlag.Value.Set("exec"); err != nil {
+					return err
+				}
+				onDDLFlag.Changed = true
+				return nil
+			},
+			wantErr: false,
+			checkFunc: func() {
+				require.Equal(t, "EXEC", common.CreateOptions.OnDDL)
+			},
+		},
+		{
+			name: "valid on-ddl EXEC_IGNORE",
+			setFunc: func(cmd *cobra.Command) error {
+				onDDLFlag := cmd.Flags().Lookup("on-ddl")
+				if err := onDDLFlag.Value.Set("exec_ignore"); err != nil {
+					return err
+				}
+				onDDLFlag.Changed = true
+				return nil
+			},
+			wantErr: false,
+			checkFunc: func() {
+				require.Equal(t, "EXEC_IGNORE", common.CreateOptions.OnDDL)
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/go/vt/sidecardb/schema/vdiff/vdiff.sql
+++ b/go/vt/sidecardb/schema/vdiff/vdiff.sql
@@ -30,7 +30,7 @@ CREATE TABLE IF NOT EXISTS vdiff
     `completed_at`       timestamp    NULL     DEFAULT NULL,
     `last_error`         varbinary(1024)      DEFAULT NULL,
     PRIMARY KEY (`id`),
-    UNIQUE KEY `uuid_idx` (`vdiff_uuid`),
+    UNIQUE KEY `uuid_idx` (`vdiff_uuid`, `db_name`),
     KEY `state` (`state`),
     KEY `ks_wf_idx` (`keyspace`(64), `workflow`(64))
 ) ENGINE = InnoDB CHARSET = utf8mb4

--- a/go/vt/vtgate/planbuilder/operators/route_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/route_planning.go
@@ -44,7 +44,7 @@ func pushDerived(ctx *plancontext.PlanningContext, op *Horizon) (Operator, *Appl
 		return op, NoRewrite
 	}
 
-	if !(innerRoute.Routing.OpCode() == engine.EqualUnique) && !op.IsMergeable(ctx) {
+	if !innerRoute.Routing.OpCode().IsSingleShard() && !op.IsMergeable(ctx) {
 		// no need to check anything if we are sure that we will only hit a single shard
 		return op, NoRewrite
 	}

--- a/go/vt/vtgate/planbuilder/testdata/reference_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/reference_cases.json
@@ -934,5 +934,28 @@
         "user.music"
       ]
     }
+  },
+  {
+    "comment": "Derived table pushdown optimization",
+    "query": "SELECT * FROM (SELECT DISTINCT col FROM user.ref WHERE col = 1 LIMIT 10) as sub",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "SELECT * FROM (SELECT DISTINCT col FROM user.ref WHERE col = 1 LIMIT 10) as sub",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Reference",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select col from (select col from ref where 1 != 1) as sub where 1 != 1",
+        "Query": "select col from (select distinct col from ref where col = 1 limit 10) as sub",
+        "Table": "ref"
+      },
+      "TablesUsed": [
+        "user.ref"
+      ]
+    }
   }
 ]

--- a/go/vt/vttablet/tabletmanager/rpc_vreplication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_vreplication.go
@@ -59,7 +59,7 @@ const (
 	// Delete VReplication records for the given workflow.
 	sqlDeleteVReplicationWorkflow = "delete from %s.vreplication where workflow = %a and db_name = %a"
 	// Retrieve the current configuration values for a workflow's vreplication stream(s).
-	sqlSelectVReplicationWorkflowConfig = "select id, source, cell, tablet_types, state, message from %s.vreplication where workflow = %a"
+	sqlSelectVReplicationWorkflowConfig = "select id, source, cell, tablet_types, state, message from %s.vreplication where workflow = %a and db_name = %a"
 	// Update the configuration values for a workflow's vreplication stream.
 	sqlUpdateVReplicationWorkflowStreamConfig = "update %s.vreplication set state = %a, source = %a, cell = %a, tablet_types = %a, message = %a %s where id = %a"
 	// Update field values for multiple workflows. The final format specifier is
@@ -524,8 +524,9 @@ func isStreamCopying(tm *TabletManager, id int64) (bool, error) {
 func (tm *TabletManager) UpdateVReplicationWorkflow(ctx context.Context, req *tabletmanagerdatapb.UpdateVReplicationWorkflowRequest) (*tabletmanagerdatapb.UpdateVReplicationWorkflowResponse, error) {
 	bindVars := map[string]*querypb.BindVariable{
 		"wf": sqltypes.StringBindVariable(req.Workflow),
+		"db": sqltypes.StringBindVariable(tm.DBConfigs.DBName),
 	}
-	parsed := sqlparser.BuildParsedQuery(sqlSelectVReplicationWorkflowConfig, sidecar.GetIdentifier(), ":wf")
+	parsed := sqlparser.BuildParsedQuery(sqlSelectVReplicationWorkflowConfig, sidecar.GetIdentifier(), ":wf", ":db")
 	stmt, err := parsed.GenerateQuery(bindVars, nil)
 	if err != nil {
 		return nil, err

--- a/go/vt/vttablet/tabletmanager/rpc_vreplication_test.go
+++ b/go/vt/vttablet/tabletmanager/rpc_vreplication_test.go
@@ -80,7 +80,7 @@ const (
 	readAllWorkflows         = "select workflow, id, source, pos, stop_pos, max_tps, max_replication_lag, cell, tablet_types, time_updated, transaction_timestamp, state, message, db_name, rows_copied, tags, time_heartbeat, workflow_type, time_throttled, component_throttled, workflow_sub_type, defer_secondary_keys, options from _vt.vreplication where db_name = '%s'%s order by workflow, id"
 	readWorkflowsLimited     = "select workflow, id, source, pos, stop_pos, max_tps, max_replication_lag, cell, tablet_types, time_updated, transaction_timestamp, state, message, db_name, rows_copied, tags, time_heartbeat, workflow_type, time_throttled, component_throttled, workflow_sub_type, defer_secondary_keys, options from _vt.vreplication where db_name = '%s' and workflow in ('%s') order by workflow, id"
 	readWorkflow             = "select id, source, pos, stop_pos, max_tps, max_replication_lag, cell, tablet_types, time_updated, transaction_timestamp, state, message, db_name, rows_copied, tags, time_heartbeat, workflow_type, time_throttled, component_throttled, workflow_sub_type, defer_secondary_keys, options from _vt.vreplication where workflow = '%s' and db_name = '%s'"
-	readWorkflowConfig       = "select id, source, cell, tablet_types, state, message from _vt.vreplication where workflow = '%s'"
+	readWorkflowConfig       = "select id, source, cell, tablet_types, state, message from _vt.vreplication where workflow = '%s' and db_name = '%s'"
 	updateWorkflow           = "update _vt.vreplication set state = '%s', source = '%s', cell = '%s', tablet_types = '%s', message = '%s' where id in (%d)"
 	getNonEmptyTableQuery    = "select 1 from `%s` limit 1"
 )
@@ -438,7 +438,7 @@ func TestMoveTablesUnsharded(t *testing.T) {
 			),
 			fmt.Sprintf("%d|%s|%s|NULL|0|0|||1686577659|0|Stopped||%s|1||0|0|0||0|1|{}", vreplID, bls, position, targetKs),
 		))
-		ftc.vrdbClient.ExpectRequest(fmt.Sprintf(readWorkflowConfig, wf), sqltypes.MakeTestResult(
+		ftc.vrdbClient.ExpectRequest(fmt.Sprintf(readWorkflowConfig, wf, tenv.dbName), sqltypes.MakeTestResult(
 			sqltypes.MakeTestFields(
 				"id|source|cell|tablet_types|state|message",
 				"int64|blob|varchar|varchar|varchar|varchar",
@@ -707,7 +707,7 @@ func TestMoveTablesSharded(t *testing.T) {
 			),
 			fmt.Sprintf("%d|%s|%s|NULL|0|0|||1686577659|0|Stopped||%s|1||0|0|0||0|1|{}", vreplID, bls, position, targetKs),
 		))
-		ftc.vrdbClient.ExpectRequest(fmt.Sprintf(readWorkflowConfig, wf), sqltypes.MakeTestResult(
+		ftc.vrdbClient.ExpectRequest(fmt.Sprintf(readWorkflowConfig, wf, tenv.dbName), sqltypes.MakeTestResult(
 			sqltypes.MakeTestFields(
 				"id|source|cell|tablet_types|state|message",
 				"int64|blob|varchar|varchar|varchar|varchar",
@@ -890,9 +890,10 @@ func TestUpdateVReplicationWorkflow(t *testing.T) {
 	tablet := tenv.addTablet(t, tabletUID, keyspace, shard)
 	defer tenv.deleteTablet(tablet.tablet)
 
-	parsed := sqlparser.BuildParsedQuery(sqlSelectVReplicationWorkflowConfig, sidecar.GetIdentifier(), ":wf")
+	parsed := sqlparser.BuildParsedQuery(sqlSelectVReplicationWorkflowConfig, sidecar.GetIdentifier(), ":wf", ":db")
 	bindVars := map[string]*querypb.BindVariable{
 		"wf": sqltypes.StringBindVariable(workflow),
+		"db": sqltypes.StringBindVariable(tenv.dbName),
 	}
 	selectQuery, err := parsed.GenerateQuery(bindVars, nil)
 	require.NoError(t, err)
@@ -2155,7 +2156,7 @@ func TestExternalizeLookupVindex(t *testing.T) {
 				targetTablet.vrdbClient.ExpectRequest(fmt.Sprintf(readWorkflow, tcase.request.Name, tenv.dbName), tcase.vrResponse, nil)
 				// Update queries are required only if the Vindex is owned.
 				if tcase.expectStopped && len(tcase.expectedVschema.Vindexes) > 0 && tcase.expectedVschema.Vindexes[tcase.request.Name].Owner != "" {
-					targetTablet.vrdbClient.ExpectRequest(fmt.Sprintf(readWorkflowConfig, tcase.request.Name), sqltypes.MakeTestResult(
+					targetTablet.vrdbClient.ExpectRequest(fmt.Sprintf(readWorkflowConfig, tcase.request.Name, tenv.dbName), sqltypes.MakeTestResult(
 						sqltypes.MakeTestFields(
 							"id|source|cell|tablet_types|state|message",
 							"int64|blob|varchar|varchar|varchar|varchar",

--- a/go/vt/vttablet/tabletmanager/vdiff/action.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/action.go
@@ -118,7 +118,7 @@ func (vde *Engine) getVDiffSummary(vdiffID int64, dbClient binlogplayer.DBClient
 	var qr *sqltypes.Result
 	var err error
 
-	query, err := sqlparser.ParseAndBind(sqlVDiffSummary, sqltypes.Int64BindVariable(vdiffID))
+	query, err := sqlparser.ParseAndBind(sqlVDiffSummary, sqltypes.Int64BindVariable(vdiffID), sqltypes.StringBindVariable(vde.dbName))
 	if err != nil {
 		return nil, err
 	}
@@ -176,7 +176,7 @@ func (vde *Engine) handleCreateResumeAction(ctx context.Context, dbClient binlog
 	var qr *sqltypes.Result
 	options := req.GetOptions()
 
-	query, err := sqlparser.ParseAndBind(sqlGetVDiffID, sqltypes.StringBindVariable(req.VdiffUuid))
+	query, err := sqlparser.ParseAndBind(sqlGetVDiffID, sqltypes.StringBindVariable(req.VdiffUuid), sqltypes.StringBindVariable(vde.dbName))
 	if err != nil {
 		return err
 	}
@@ -235,6 +235,7 @@ func (vde *Engine) handleCreateResumeAction(ctx context.Context, dbClient binlog
 		execResume := func(query string) (rowsAffected uint64, err error) {
 			query, err = sqlparser.ParseAndBind(query,
 				sqltypes.StringBindVariable(req.VdiffUuid),
+				sqltypes.StringBindVariable(vde.dbName),
 			)
 			if err != nil {
 				return 0, err
@@ -296,6 +297,7 @@ func (vde *Engine) handleShowAction(ctx context.Context, dbClient binlogplayer.D
 		query, err := sqlparser.ParseAndBind(sqlGetMostRecentVDiffByKeyspaceWorkflow,
 			sqltypes.StringBindVariable(req.Keyspace),
 			sqltypes.StringBindVariable(req.Workflow),
+			sqltypes.StringBindVariable(vde.dbName),
 			sqltypes.Int64BindVariable(1),
 		)
 		if err != nil {
@@ -319,6 +321,7 @@ func (vde *Engine) handleShowAction(ctx context.Context, dbClient binlogplayer.D
 			sqltypes.StringBindVariable(req.Keyspace),
 			sqltypes.StringBindVariable(req.Workflow),
 			sqltypes.StringBindVariable(vdiffUUID),
+			sqltypes.StringBindVariable(vde.dbName),
 		)
 		if err != nil {
 			return err
@@ -348,6 +351,7 @@ func (vde *Engine) handleShowAction(ctx context.Context, dbClient binlogplayer.D
 		query, err := sqlparser.ParseAndBind(sqlGetMostRecentVDiffByKeyspaceWorkflow,
 			sqltypes.StringBindVariable(req.Keyspace),
 			sqltypes.StringBindVariable(req.Workflow),
+			sqltypes.StringBindVariable(vde.dbName),
 			sqltypes.Int64BindVariable(maxVDiffsToReport),
 		)
 		if err != nil {
@@ -404,6 +408,7 @@ func (vde *Engine) handleDeleteAction(ctx context.Context, dbClient binlogplayer
 		query, err := sqlparser.ParseAndBind(sqlGetVDiffIDsByKeyspaceWorkflow,
 			sqltypes.StringBindVariable(req.Keyspace),
 			sqltypes.StringBindVariable(req.Workflow),
+			sqltypes.StringBindVariable(vde.dbName),
 		)
 		if err != nil {
 			return err
@@ -418,6 +423,7 @@ func (vde *Engine) handleDeleteAction(ctx context.Context, dbClient binlogplayer
 		deleteQuery, err = sqlparser.ParseAndBind(sqlDeleteVDiffs,
 			sqltypes.StringBindVariable(req.Keyspace),
 			sqltypes.StringBindVariable(req.Workflow),
+			sqltypes.StringBindVariable(vde.dbName),
 		)
 		if err != nil {
 			return err
@@ -431,6 +437,7 @@ func (vde *Engine) handleDeleteAction(ctx context.Context, dbClient binlogplayer
 		// it's still running, before we delete the vdiff record.
 		query, err := sqlparser.ParseAndBind(sqlGetVDiffID,
 			sqltypes.StringBindVariable(uuid.String()),
+			sqltypes.StringBindVariable(vde.dbName),
 		)
 		if err != nil {
 			return err
@@ -447,6 +454,7 @@ func (vde *Engine) handleDeleteAction(ctx context.Context, dbClient binlogplayer
 		cleanupController(vde.controllers[row.AsInt64("id", -1)])
 		deleteQuery, err = sqlparser.ParseAndBind(sqlDeleteVDiffByUUID,
 			sqltypes.StringBindVariable(uuid.String()),
+			sqltypes.StringBindVariable(vde.dbName),
 		)
 		if err != nil {
 			return err

--- a/go/vt/vttablet/tabletmanager/vdiff/action_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/action_test.go
@@ -85,7 +85,7 @@ func TestPerformVDiffAction(t *testing.T) {
 			},
 			expectQueries: []queryAndResult{
 				{
-					query: fmt.Sprintf("select id as id from _vt.vdiff where vdiff_uuid = %s", encodeString(uuid)),
+					query: "select id as id from _vt.vdiff where vdiff_uuid = " + encodeString(uuid) + " and db_name = " + encodeString(vdiffDBName),
 				},
 				{
 					query: fmt.Sprintf(`insert into _vt.vdiff(keyspace, workflow, state, options, shard, db_name, vdiff_uuid) values('', '', 'pending', '{"picker_options":{"source_cell":"cell1,zone100_test","target_cell":"cell1,zone100_test"}}', '0', 'vt_vttest', %s)`, encodeString(uuid)),
@@ -109,7 +109,7 @@ func TestPerformVDiffAction(t *testing.T) {
 			},
 			expectQueries: []queryAndResult{
 				{
-					query: fmt.Sprintf("select id as id from _vt.vdiff where vdiff_uuid = %s", encodeString(uuid)),
+					query: "select id as id from _vt.vdiff where vdiff_uuid = " + encodeString(uuid) + " and db_name = " + encodeString(vdiffDBName),
 				},
 				{
 					query: fmt.Sprintf(`insert into _vt.vdiff(keyspace, workflow, state, options, shard, db_name, vdiff_uuid) values('', '', 'stopped', '{"picker_options":{"source_cell":"cell1","target_cell":"cell1"},"core_options":{"auto_start":false}}', '0', 'vt_vttest', %s)`, encodeString(uuid)),
@@ -140,7 +140,7 @@ func TestPerformVDiffAction(t *testing.T) {
 			},
 			expectQueries: []queryAndResult{
 				{
-					query: fmt.Sprintf("select id as id from _vt.vdiff where vdiff_uuid = %s", encodeString(uuid)),
+					query: "select id as id from _vt.vdiff where vdiff_uuid = " + encodeString(uuid) + " and db_name = " + encodeString(vdiffDBName),
 				},
 				{
 					query: fmt.Sprintf(`insert into _vt.vdiff(keyspace, workflow, state, options, shard, db_name, vdiff_uuid) values('', '', 'pending', '{"picker_options":{"source_cell":"all","target_cell":"all"}}', '0', 'vt_vttest', %s)`, encodeString(uuid)),
@@ -163,7 +163,7 @@ func TestPerformVDiffAction(t *testing.T) {
 			},
 			expectQueries: []queryAndResult{
 				{
-					query: fmt.Sprintf("select id as id from _vt.vdiff where vdiff_uuid = %s", encodeString(uuid)),
+					query: "select id as id from _vt.vdiff where vdiff_uuid = " + encodeString(uuid) + " and db_name = " + encodeString(vdiffDBName),
 					result: sqltypes.MakeTestResult(
 						sqltypes.MakeTestFields(
 							"id",
@@ -174,23 +174,23 @@ func TestPerformVDiffAction(t *testing.T) {
 				},
 				{
 					query: fmt.Sprintf(`update _vt.vdiff as vd, _vt.vdiff_table as vdt set vd.started_at = NULL, vd.completed_at = NULL, vd.state = 'pending',
-					vdt.state = 'pending' where vd.vdiff_uuid = %s and vd.id = vdt.vdiff_id and vd.state in ('completed', 'stopped')
-					and vdt.state in ('completed', 'stopped')`, encodeString(uuid)),
+					vdt.state = 'pending' where vd.vdiff_uuid = %s and vd.db_name = %s and vd.id = vdt.vdiff_id and vd.state in ('completed', 'stopped')
+					and vdt.state in ('completed', 'stopped')`, encodeString(uuid), encodeString(vdiffDBName)),
 					result: &sqltypes.Result{
 						RowsAffected: 0, // No _vt.vdiff_table records
 					},
 				},
 				{
-					query: fmt.Sprintf(`update _vt.vdiff as vd set vd.state = 'pending' where vd.vdiff_uuid = %s and vd.state = 'stopped' and
+					query: fmt.Sprintf(`update _vt.vdiff as vd set vd.state = 'pending' where vd.vdiff_uuid = %s and vd.db_name = %s and vd.state = 'stopped' and
 					vd.started_at is NULL and vd.completed_at is NULL and
 					(select count(*) as cnt from _vt.vdiff_table as vdt where vd.id = vdt.vdiff_id) = 0`,
-						encodeString(uuid)),
+						encodeString(uuid), encodeString(vdiffDBName)),
 					result: &sqltypes.Result{
 						RowsAffected: 1,
 					},
 				},
 				{
-					query: "select * from _vt.vdiff where id = 1",
+					query: "select * from _vt.vdiff where id = 1 and db_name = " + encodeString(vdiffDBName),
 				},
 			},
 		},
@@ -204,7 +204,7 @@ func TestPerformVDiffAction(t *testing.T) {
 			},
 			expectQueries: []queryAndResult{
 				{
-					query: fmt.Sprintf("select id as id from _vt.vdiff where vdiff_uuid = %s", encodeString(uuid)),
+					query: "select id as id from _vt.vdiff where vdiff_uuid = " + encodeString(uuid) + " and db_name = " + encodeString(vdiffDBName),
 					result: sqltypes.MakeTestResult(
 						sqltypes.MakeTestFields(
 							"id",
@@ -215,14 +215,14 @@ func TestPerformVDiffAction(t *testing.T) {
 				},
 				{
 					query: fmt.Sprintf(`update _vt.vdiff as vd, _vt.vdiff_table as vdt set vd.started_at = NULL, vd.completed_at = NULL, vd.state = 'pending',
-					vdt.state = 'pending' where vd.vdiff_uuid = %s and vd.id = vdt.vdiff_id and vd.state in ('completed', 'stopped')
-					and vdt.state in ('completed', 'stopped')`, encodeString(uuid)),
+					vdt.state = 'pending' where vd.vdiff_uuid = %s and vd.db_name = %s and vd.id = vdt.vdiff_id and vd.state in ('completed', 'stopped')
+					and vdt.state in ('completed', 'stopped')`, encodeString(uuid), encodeString(vdiffDBName)),
 					result: &sqltypes.Result{
 						RowsAffected: 1,
 					},
 				},
 				{
-					query: "select * from _vt.vdiff where id = 1",
+					query: "select * from _vt.vdiff where id = 1 and db_name = " + encodeString(vdiffDBName),
 				},
 			},
 		},
@@ -234,7 +234,7 @@ func TestPerformVDiffAction(t *testing.T) {
 			},
 			expectQueries: []queryAndResult{
 				{
-					query: fmt.Sprintf("select id as id from _vt.vdiff where vdiff_uuid = %s", encodeString(uuid)),
+					query: "select id as id from _vt.vdiff where vdiff_uuid = " + encodeString(uuid) + " and db_name = " + encodeString(vdiffDBName),
 					result: sqltypes.MakeTestResult(
 						sqltypes.MakeTestFields(
 							"id",
@@ -244,8 +244,7 @@ func TestPerformVDiffAction(t *testing.T) {
 					),
 				},
 				{
-					query: fmt.Sprintf(`delete from vd, vdt using _vt.vdiff as vd left join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
-							where vd.vdiff_uuid = %s`, encodeString(uuid)),
+					query: "delete from vd, vdt using _vt.vdiff as vd left join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)\n\t\t\t\t\t\t\twhere vd.vdiff_uuid = " + encodeString(uuid) + " and vd.db_name = " + encodeString(vdiffDBName),
 				},
 			},
 		},
@@ -259,7 +258,7 @@ func TestPerformVDiffAction(t *testing.T) {
 			},
 			expectQueries: []queryAndResult{
 				{
-					query: fmt.Sprintf("select id as id from _vt.vdiff where keyspace = %s and workflow = %s", encodeString(keyspace), encodeString(workflow)),
+					query: fmt.Sprintf("select id as id from _vt.vdiff where keyspace = %s and workflow = %s and db_name = %s", encodeString(keyspace), encodeString(workflow), encodeString(vdiffDBName)),
 					result: sqltypes.MakeTestResult(
 						sqltypes.MakeTestFields(
 							"id",
@@ -272,7 +271,7 @@ func TestPerformVDiffAction(t *testing.T) {
 				{
 					query: fmt.Sprintf(`delete from vd, vdt, vdl using _vt.vdiff as vd left join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
 										left join _vt.vdiff_log as vdl on (vd.id = vdl.vdiff_id)
-										where vd.keyspace = %s and vd.workflow = %s`, encodeString(keyspace), encodeString(workflow)),
+										where vd.keyspace = %s and vd.workflow = %s and vd.db_name = %s`, encodeString(keyspace), encodeString(workflow), encodeString(vdiffDBName)),
 				},
 			},
 		},
@@ -286,8 +285,8 @@ func TestPerformVDiffAction(t *testing.T) {
 			},
 			expectQueries: []queryAndResult{
 				{
-					query: fmt.Sprintf("select * from _vt.vdiff where keyspace = %s and workflow = %s order by id desc limit %d",
-						encodeString(keyspace), encodeString(workflow), 1),
+					query: fmt.Sprintf("select * from _vt.vdiff where keyspace = %s and workflow = %s and db_name = %s order by id desc limit %d",
+						encodeString(keyspace), encodeString(workflow), encodeString(vdiffDBName), 1),
 					result: noResults,
 				},
 			},
@@ -302,8 +301,8 @@ func TestPerformVDiffAction(t *testing.T) {
 			},
 			expectQueries: []queryAndResult{
 				{
-					query: fmt.Sprintf("select * from _vt.vdiff where keyspace = %s and workflow = %s order by id desc limit %d",
-						encodeString(keyspace), encodeString(workflow), maxVDiffsToReport),
+					query: fmt.Sprintf("select * from _vt.vdiff where keyspace = %s and workflow = %s and db_name = %s order by id desc limit %d",
+						encodeString(keyspace), encodeString(workflow), encodeString(vdiffDBName), maxVDiffsToReport),
 					result: noResults,
 				},
 			},

--- a/go/vt/vttablet/tabletmanager/vdiff/controller.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/controller.go
@@ -176,6 +176,7 @@ func (ct *controller) updateState(dbClient binlogplayer.DBClient, state VDiffSta
 		encodeString(err.Error()),
 		extraCols,
 		ct.id,
+		encodeString(ct.vde.dbName),
 	)
 	if _, err := dbClient.ExecuteFetch(query.Query, 1); err != nil {
 		return err
@@ -274,7 +275,7 @@ func (ct *controller) markStoppedByRequest() error {
 	}
 	defer dbClient.Close()
 
-	query, err := sqlparser.ParseAndBind(sqlUpdateVDiffStopped, sqltypes.Int64BindVariable(ct.id))
+	query, err := sqlparser.ParseAndBind(sqlUpdateVDiffStopped, sqltypes.Int64BindVariable(ct.id), sqltypes.StringBindVariable(ct.vde.dbName))
 	if err != nil {
 		return err
 	}

--- a/go/vt/vttablet/tabletmanager/vdiff/controller.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/controller.go
@@ -114,8 +114,11 @@ func (ct *controller) Stop() {
 
 func (ct *controller) run(ctx context.Context) {
 	defer func() {
-		log.Infof("Run finished for vdiff %s", ct.uuid)
+		log.Info("Run finished for vdiff " + ct.uuid)
+		// Unblock Stop() callers waiting on <-ct.done.
 		close(ct.done)
+		// Release gRPC connections held by this controller's tablet manager client.
+		ct.tmc.Close()
 	}()
 
 	dbClient := ct.vde.dbClientFactoryFiltered()

--- a/go/vt/vttablet/tabletmanager/vdiff/engine_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/engine_test.go
@@ -69,8 +69,8 @@ func TestEngineOpen(t *testing.T) {
 				fmt.Sprintf("1|%s|%s|%s|%s|%s|%s|%s|", UUID, vdenv.workflow, tstenv.KeyspaceName, tstenv.ShardName, vdiffDBName, tt.state, optionsJS),
 			)
 
-			vdenv.dbClient.ExpectRequest("select * from _vt.vdiff where state in ('started','pending')", initialQR, nil)
-			vdenv.dbClient.ExpectRequest("select * from _vt.vdiff where id = 1", sqltypes.MakeTestResult(sqltypes.MakeTestFields(
+			vdenv.dbClient.ExpectRequest("select * from _vt.vdiff where state in ('started','pending') and db_name = "+encodeString(vdiffDBName), initialQR, nil)
+			vdenv.dbClient.ExpectRequest("select * from _vt.vdiff where id = 1 and db_name = "+encodeString(vdiffDBName), sqltypes.MakeTestResult(sqltypes.MakeTestFields(
 				vdiffTestCols,
 				vdiffTestColTypes,
 			),
@@ -84,7 +84,7 @@ func TestEngineOpen(t *testing.T) {
 			), nil)
 
 			// Now let's short circuit the vdiff as we know that the open has worked as expected.
-			shortCircuitTestAfterQuery("update _vt.vdiff set state = 'started', last_error = left('', 1024) , started_at = utc_timestamp() where id = 1", vdiffenv.dbClient)
+			shortCircuitTestAfterQuery("update _vt.vdiff set state = 'started', last_error = left('', 1024) , started_at = utc_timestamp() where id = 1 and db_name = 'vttest'", vdiffenv.dbClient)
 
 			vdenv.vde.Open(context.Background(), vdiffenv.vre)
 			defer vdenv.vde.Close()
@@ -124,14 +124,14 @@ func TestVDiff(t *testing.T) {
 		fmt.Sprintf("1|%s|%s|%s|%s|%s|pending|%s|", UUID, vdenv.workflow, tstenv.KeyspaceName, tstenv.ShardName, vdiffDBName, optionsJS),
 	)
 
-	vdenv.dbClient.ExpectRequest("select * from _vt.vdiff where id = 1", controllerQR, nil)
+	vdenv.dbClient.ExpectRequest("select * from _vt.vdiff where id = 1 and db_name = "+encodeString(vdiffDBName), controllerQR, nil)
 	vdenv.dbClient.ExpectRequest(fmt.Sprintf("select * from _vt.vreplication where workflow = '%s' and db_name = '%s'", vdiffenv.workflow, vdiffDBName), sqltypes.MakeTestResult(sqltypes.MakeTestFields(
 		"id|workflow|source|pos|stop_pos|max_tps|max_replication_lag|cell|tablet_types|time_updated|transaction_timestamp|state|message|db_name|rows_copied|tags|time_heartbeat|workflow_type|time_throttled|component_throttled|workflow_sub_type|options",
 		"int64|varbinary|blob|varbinary|varbinary|int64|int64|varbinary|varbinary|int64|int64|varbinary|varbinary|varbinary|int64|varbinary|int64|int64|int64|varchar|int64|varchar",
 	),
 		fmt.Sprintf("1|%s|%s|%s||9223372036854775807|9223372036854775807||PRIMARY,REPLICA|1669511347|0|Running||%s|200||1669511347|1|0||1|{}", vdiffenv.workflow, vreplSource, vdiffSourceGtid, vdiffDBName),
 	), nil)
-	vdenv.dbClient.ExpectRequest("update _vt.vdiff set state = 'started', last_error = left('', 1024) , started_at = utc_timestamp() where id = 1", singleRowAffected, nil)
+	vdenv.dbClient.ExpectRequest("update _vt.vdiff set state = 'started', last_error = left('', 1024) , started_at = utc_timestamp() where id = 1 and db_name = 'vttest'", singleRowAffected, nil)
 	vdenv.dbClient.ExpectRequest("insert into _vt.vdiff_log(vdiff_id, message) values (1, 'State changed to: started')", singleRowAffected, nil)
 	vdenv.dbClient.ExpectRequest(`select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
 						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
@@ -193,7 +193,7 @@ func TestVDiff(t *testing.T) {
 	vdenv.dbClient.ExpectRequest("update _vt.vdiff_table set state = 'completed' where vdiff_id = 1 and table_name = 't1'", singleRowAffected, nil)
 	vdenv.dbClient.ExpectRequest(`insert into _vt.vdiff_log(vdiff_id, message) values (1, 'completed: table \'t1\'')`, singleRowAffected, nil)
 	vdenv.dbClient.ExpectRequest("select table_name as table_name from _vt.vdiff_table where vdiff_id = 1 and state != 'completed' order by table_name", singleRowAffected, nil)
-	vdenv.dbClient.ExpectRequest("update _vt.vdiff set state = 'completed', last_error = left('', 1024) , completed_at = utc_timestamp() where id = 1", singleRowAffected, nil)
+	vdenv.dbClient.ExpectRequest("update _vt.vdiff set state = 'completed', last_error = left('', 1024) , completed_at = utc_timestamp() where id = 1 and db_name = 'vttest'", singleRowAffected, nil)
 	vdenv.dbClient.ExpectRequest("insert into _vt.vdiff_log(vdiff_id, message) values (1, 'State changed to: completed')", singleRowAffected, nil)
 
 	vdenv.vde.mu.Lock()
@@ -243,7 +243,7 @@ func TestEngineRetryErroredVDiffs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			vdiffenv.dbClient.ExpectRequest("select * from _vt.vdiff where state = 'error' and json_unquote(json_extract(options, '$.core_options.auto_retry')) = 'true'", tt.retryQueryResults, nil)
+			vdiffenv.dbClient.ExpectRequest("select * from _vt.vdiff where state = 'error' and json_unquote(json_extract(options, '$.core_options.auto_retry')) = 'true' and db_name = "+encodeString(vdiffDBName), tt.retryQueryResults, nil)
 
 			// Right now this only supports a single row as with multiple rows we have
 			// multiple controllers in separate goroutines and the order is not
@@ -255,8 +255,8 @@ func TestEngineRetryErroredVDiffs(t *testing.T) {
 			for _, row := range tt.retryQueryResults.Rows {
 				id := row[0].ToString()
 				if tt.expectRetry {
-					vdiffenv.dbClient.ExpectRequestRE("update _vt.vdiff as vd left join _vt.vdiff_table as vdt on \\(vd.id = vdt.vdiff_id\\) set vd.state = 'pending'.*", singleRowAffected, nil)
-					vdiffenv.dbClient.ExpectRequest(fmt.Sprintf("select * from _vt.vdiff where id = %s", id), sqltypes.MakeTestResult(sqltypes.MakeTestFields(
+					vdiffenv.dbClient.ExpectRequestRE("update _vt.vdiff as vd left join _vt.vdiff_table as vdt on \\(vd.id = vdt.vdiff_id\\) set vd.state = 'pending'[\\s\\S]*vd.db_name[\\s\\S]*", singleRowAffected, nil)
+					vdiffenv.dbClient.ExpectRequest("select * from _vt.vdiff where id = "+id+" and db_name = "+encodeString(vdiffDBName), sqltypes.MakeTestResult(sqltypes.MakeTestFields(
 						vdiffTestCols,
 						vdiffTestColTypes,
 					),
@@ -270,12 +270,10 @@ func TestEngineRetryErroredVDiffs(t *testing.T) {
 					), nil)
 
 					// At this point we know that we kicked off the expected retry so we can short circuit the vdiff.
-					shortCircuitTestAfterQuery(fmt.Sprintf("update _vt.vdiff set state = 'started', last_error = left('', 1024) , started_at = utc_timestamp() where id = %s", id), vdiffenv.dbClient)
-
+					shortCircuitTestAfterQuery("update _vt.vdiff set state = 'started', last_error = left('', 1024) , started_at = utc_timestamp() where id = "+id+" and db_name = 'vttest'", vdiffenv.dbClient)
 					expectedControllerCnt++
 				}
 			}
-
 			err := vdiffenv.vde.retryVDiffs(vdiffenv.vde.ctx)
 			assert.NoError(t, err)
 			assert.Equal(t, expectedControllerCnt, len(vdiffenv.vde.controllers))

--- a/go/vt/vttablet/tabletmanager/vdiff/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/framework_test.go
@@ -456,6 +456,9 @@ func newFakeTMClient() *fakeTMClient {
 	}
 }
 
+// Close satisfies the TabletManagerClient interface.
+func (tmc *fakeTMClient) Close() {}
+
 func (tmc *fakeTMClient) GetSchema(ctx context.Context, tablet *topodatapb.Tablet, request *tabletmanagerdatapb.GetSchemaRequest) (*tabletmanagerdatapb.SchemaDefinition, error) {
 	return tmc.schema, nil
 }

--- a/go/vt/vttablet/tabletmanager/vdiff/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/framework_test.go
@@ -18,6 +18,7 @@ package vdiff
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -210,8 +211,8 @@ func resetBinlogClient() {
 // This can be used to end a vdiff, by returning an error from the specified query, once the test
 // has verified the necessary behavior.
 func shortCircuitTestAfterQuery(query string, dbClient *binlogplayer.MockDBClient) {
-	dbClient.ExpectRequest(query, singleRowAffected, fmt.Errorf("Short circuiting test"))
-	dbClient.ExpectRequest("update _vt.vdiff set state = 'error', last_error = left('Short circuiting test', 1024)  where id = 1", singleRowAffected, nil)
+	dbClient.ExpectRequest(query, singleRowAffected, errors.New("Short circuiting test"))
+	dbClient.ExpectRequest("update _vt.vdiff set state = 'error', last_error = left('Short circuiting test', 1024)  where id = 1 and db_name = "+encodeString(vdiffDBName), singleRowAffected, nil)
 	dbClient.ExpectRequest("insert into _vt.vdiff_log(vdiff_id, message) values (1, 'State changed to: error')", singleRowAffected, nil)
 	dbClient.ExpectRequest("insert into _vt.vdiff_log(vdiff_id, message) values (1, 'Error: Short circuiting test')", singleRowAffected, nil)
 }
@@ -610,7 +611,7 @@ func newTestVDiffEnv(t *testing.T) *testVDiffEnv {
 	// vdiff.restartTargets
 	vdiffenv.tmc.setVRResults(primary.tablet, fmt.Sprintf("update _vt.vreplication set state='Running', message='', stop_pos='' where db_name='%s' and workflow='%s'", vdiffDBName, vdiffenv.workflow), singleRowAffected)
 
-	vdiffenv.dbClient.ExpectRequest("select * from _vt.vdiff where state in ('started','pending')", noResults, nil)
+	vdiffenv.dbClient.ExpectRequest("select * from _vt.vdiff where state in ('started','pending') and db_name = "+encodeString(vdiffDBName), noResults, nil)
 	vdiffenv.vde.Open(context.Background(), vdiffenv.vre)
 	assert.True(t, vdiffenv.vde.IsOpen())
 	assert.Equal(t, 0, len(vdiffenv.vde.controllers))
@@ -675,7 +676,7 @@ func (tvde *testVDiffEnv) createController(t *testing.T, id int) *controller {
 	),
 		fmt.Sprintf("%d|%s|%s|%s|%s|%s|%s|%s|", id, uuid.New(), tvde.workflow, tstenv.KeyspaceName, tstenv.ShardName, vdiffDBName, PendingState, optionsJS),
 	)
-	tvde.dbClient.ExpectRequest(fmt.Sprintf("select * from _vt.vdiff where id = %d", id), noResults, nil)
+	tvde.dbClient.ExpectRequest(fmt.Sprintf("select * from _vt.vdiff where id = %d and db_name = %s", id, encodeString(vdiffDBName)), noResults, nil)
 	ct := tvde.newController(t, controllerQR)
 	ct.sources = map[string]*migrationSource{
 		tstenv.ShardName: {

--- a/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
@@ -58,7 +58,7 @@ func TestReconcileExtraRows(t *testing.T) {
 		fmt.Sprintf("1|%s|%s|%s|%s|%s|%s|%s|", UUID, vdiffenv.workflow, tstenv.KeyspaceName, tstenv.ShardName, vdiffDBName, PendingState, optionsJS),
 	)
 
-	vdiffenv.dbClient.ExpectRequest("select * from _vt.vdiff where id = 1", noResults, nil)
+	vdiffenv.dbClient.ExpectRequest("select * from _vt.vdiff where id = 1 and db_name = "+encodeString(vdiffDBName), noResults, nil)
 	ct := vdenv.newController(t, controllerQR)
 	wd, err := newWorkflowDiffer(ct, vdiffenv.opts, collations.MySQL8())
 	require.NoError(t, err)
@@ -316,7 +316,7 @@ func TestReconcileReferenceTables(t *testing.T) {
 		fmt.Sprintf("1|%s|%s|%s|%s|%s|%s|%s|", UUID, vdiffenv.workflow, tstenv.KeyspaceName, tstenv.ShardName, vdiffDBName, PendingState, optionsJS),
 	)
 
-	vdiffenv.dbClient.ExpectRequest("select * from _vt.vdiff where id = 1", noResults, nil)
+	vdiffenv.dbClient.ExpectRequest("select * from _vt.vdiff where id = 1 and db_name = "+encodeString(vdiffDBName), noResults, nil)
 	ct := vdenv.newController(t, controllerQR)
 	ct.sourceKeyspace = tstenv.KeyspaceName
 	wd, err := newWorkflowDiffer(ct, vdiffenv.opts, collations.MySQL8())
@@ -427,7 +427,7 @@ func TestBuildPlanSuccess(t *testing.T) {
 		fmt.Sprintf("1|%s|%s|%s|%s|%s|%s|%s|", UUID, vdiffenv.workflow, tstenv.KeyspaceName, tstenv.ShardName, vdiffDBName, PendingState, optionsJS),
 	)
 
-	vdiffenv.dbClient.ExpectRequest("select * from _vt.vdiff where id = 1", noResults, nil)
+	vdiffenv.dbClient.ExpectRequest("select * from _vt.vdiff where id = 1 and db_name = "+encodeString(vdiffDBName), noResults, nil)
 	ct := vdenv.newController(t, controllerQR)
 	ct.sources = map[string]*migrationSource{
 		tstenv.ShardName: {
@@ -1075,7 +1075,7 @@ func TestBuildPlanFailure(t *testing.T) {
 	),
 		fmt.Sprintf("1|%s|%s|%s|%s|%s|%s|%s|", UUID, vdiffenv.workflow, tstenv.KeyspaceName, tstenv.ShardName, vdiffDBName, PendingState, optionsJS),
 	)
-	vdiffenv.dbClient.ExpectRequest("select * from _vt.vdiff where id = 1", noResults, nil)
+	vdiffenv.dbClient.ExpectRequest("select * from _vt.vdiff where id = 1 and db_name = "+encodeString(vdiffDBName), noResults, nil)
 	ct := vdenv.newController(t, controllerQR)
 	testcases := []struct {
 		input *binlogdatapb.Rule

--- a/go/vt/vttablet/tabletserver/vstreamer/snapshot_conn.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/snapshot_conn.go
@@ -36,6 +36,9 @@ import (
 	vttablet "vitess.io/vitess/go/vt/vttablet/common"
 )
 
+// snapshotLockWaitTimeout is the lock_wait_timeout to use when attempting to start a snapshot.
+var snapshotLockWaitTimeout = 30 * time.Second
+
 // snapshotConn is wrapper on mysql.Conn capable of
 // reading a table along with a GTID snapshot.
 type snapshotConn struct {
@@ -108,6 +111,12 @@ func (conn *snapshotConn) startSnapshot(ctx context.Context, table string) (gtid
 	}()
 
 	tableName := sqlparser.String(sqlparser.NewIdentifierCS(table))
+
+	// Avoid waiting indefinitely when table metadata locks are held by another transaction.
+	lockWaitTimeoutSeconds := int(snapshotLockWaitTimeout.Seconds())
+	if _, err := lockConn.ExecuteFetch(fmt.Sprintf("set session lock_wait_timeout = %d", lockWaitTimeoutSeconds), 1, false); err != nil {
+		return "", vterrors.Wrapf(err, "startSnapshot: failed to set session lock_wait_timeout = %d for table %s", lockWaitTimeoutSeconds, tableName)
+	}
 
 	if _, err := lockConn.ExecuteFetch(fmt.Sprintf("lock tables %s read", tableName), 1, false); err != nil {
 		log.Warningf("Error locking table %s to read: %v", tableName, err)


### PR DESCRIPTION
## What's this?

Batch 3 of 4 for the v22.0.4 upstream backport. VDiff fixes, sidecardb compatibility, and a query planning optimization.

**Note:** This PR currently targets `slack-22_0_4-batch-02`. Once batch 2 is merged into `slack-22_0_4-wip`, this will be rebased and retargeted to `slack-22_0_4-wip`.

## Commits (in order)

| PR | Score | Description |
|----|:-----:|-------------|
| #19378 | 8 | Bug fix: Add missing db_name filters to vreplication and vdiff queries |
| #19413 | 7 | Address a few VDiff concerns |
| #19358 | 7 | sidecardb: make ALTER TABLE algorithm version-aware |
| #19445 | 5 | Normalize the --on-ddl param for MoveTables |
| #18974 | 4 | Performance: use IsSingleShard() check in pushDerived |

## Notes

- All cherry-picks applied cleanly — #19378 applied before #19413 (shared vdiff files)
- Local `go build ./go/...` passes clean
- Upstream comparison: https://github.com/vitessio/vitess/compare/v22.0.3...v22.0.4

## Full upgrade plan

https://gist.github.com/sbaker617/4abb0e0c1856cce1b297b64e6353ec3d

---
_Cherry-picked by Claude Code_