### PR TITLE
Add debug logging for MULTI_SHARD_AUTOCOMMIT transaction path

### DIFF
--- a/go/vt/vtgate/engine/dml.go
+++ b/go/vt/vtgate/engine/dml.go
@@ -24,6 +24,7 @@ import (
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
+	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/vterrors"
@@ -133,7 +134,10 @@ func allowOnlyPrimary(rss ...*srvtopo.ResolvedShard) error {
 }
 
 func (dml *DML) execMultiShard(ctx context.Context, primitive Primitive, vcursor VCursor, rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery) (*sqltypes.Result, error) {
-	autocommit := (len(rss) == 1 || dml.MultiShardAutocommit) && vcursor.AutocommitApproval()
+	autocommitApproval := vcursor.AutocommitApproval()
+	autocommit := (len(rss) == 1 || dml.MultiShardAutocommit) && autocommitApproval
+	log.Infof("execMultiShard: numShards=%d, MultiShardAutocommit=%v, autocommitApproval=%v, autocommit=%v, query=%s",
+		len(rss), dml.MultiShardAutocommit, autocommitApproval, autocommit, dml.Query)
 	result, errs := vcursor.ExecuteMultiShard(ctx, primitive, rss, queries, true /*rollbackOnError*/, autocommit, dml.FetchLastInsertID)
 	return result, vterrors.Aggregate(errs)
 }

--- a/go/vt/vtgate/scatter_conn.go
+++ b/go/vt/vtgate/scatter_conn.go
@@ -880,6 +880,9 @@ func actionInfo(ctx context.Context, target *querypb.Target, session *econtext.S
 	shouldReserve := session.InReservedConn() && (shardSession == nil || shardSession.ReservedId == 0)
 	shouldBegin := session.InTransaction() && (shardSession == nil || shardSession.TransactionId == 0) && !autocommit
 
+	log.Infof("actionInfo: target=%s/%s, inTransaction=%v, inReservedConn=%v, autocommit=%v, shouldBegin=%v, shouldReserve=%v",
+		target.Keyspace, target.Shard, session.InTransaction(), session.InReservedConn(), autocommit, shouldBegin, shouldReserve)
+
 	var act = nothing
 	switch {
 	case shouldBegin && shouldReserve:

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -882,6 +882,8 @@ func (tsv *TabletServer) Execute(ctx context.Context, target *querypb.Target, sq
 	trace.AnnotateSQL(span, sqlparser.Preview(sql))
 	defer span.Finish()
 
+	log.Infof("TabletServer.Execute: transactionID=%d, reservedID=%d, sql=%s", transactionID, reservedID, sql)
+
 	if transactionID != 0 && reservedID != 0 && transactionID != reservedID {
 		return nil, vterrors.New(vtrpcpb.Code_INTERNAL, "[BUG] transactionID and reserveID must match if both are non-zero")
 	}
@@ -1050,6 +1052,7 @@ func (tsv *TabletServer) streamExecute(ctx context.Context, target *querypb.Targ
 
 // BeginExecute combines Begin and Execute.
 func (tsv *TabletServer) BeginExecute(ctx context.Context, target *querypb.Target, postBeginQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, reservedID int64, options *querypb.ExecuteOptions) (queryservice.TransactionState, *sqltypes.Result, error) {
+	log.Infof("TabletServer.BeginExecute: reservedID=%d, sql=%s", reservedID, sql)
 
 	// Disable hot row protection in case of reserve connection.
 	if tsv.enableHotRowProtection && reservedID == 0 {


### PR DESCRIPTION
Adds log lines at three decision points to diagnose whether vtgate uses autocommit or explicit BEGIN for multi-shard DMLs:

- vtgate execMultiShard: logs autocommit decision inputs and result
- vtgate actionInfo: logs per-shard transaction/begin decision
- vttablet Execute vs BeginExecute: confirms which RPC path is taken

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
