### PR TITLE
fix: restore v19 per-shard UPDATE+LIMIT behavior

### DIFF
--- a/go/test/endtoend/vtgate/queries/dml/dml_test.go
+++ b/go/test/endtoend/vtgate/queries/dml/dml_test.go
@@ -69,9 +69,9 @@ func TestUniqueLookupDuplicateEntries(t *testing.T) {
 	utils.AssertMatches(t, mcmp.VtConn, "select num, hex(keyspace_id) from num_vdx_tbl order by num", `[[INT64(30) VARCHAR("166B40B44ABA4BD6")] [INT64(100) VARCHAR("594764E1A2B2D98E")]]`)
 
 	// update to same value on multiple row should fail.
+	// slack: with v19 per-shard LIMIT (no DMLWithInput), vindex update without ORDER BY is rejected at plan time.
 	utils.AssertContainsError(t, mcmp.VtConn, "update s_tbl set num = 40 limit 2",
-		"lookup.Create: transaction rolled back to reverse changes of partial DML execution: target: sks.80-.primary: vttablet: "+
-			"rpc error: code = AlreadyExists desc = Duplicate entry '40' for key 'num_vdx_tbl.PRIMARY'")
+		"VT12001: unsupported: Vindex update should have ORDER BY clause when using LIMIT")
 	utils.AssertMatches(t, mcmp.VtConn, "select id, num from s_tbl order by id", `[[INT64(1) INT64(30)] [INT64(10) INT64(100)]]`)
 	utils.AssertMatches(t, mcmp.VtConn, "select num, hex(keyspace_id) from num_vdx_tbl order by num", `[[INT64(30) VARCHAR("166B40B44ABA4BD6")] [INT64(100) VARCHAR("594764E1A2B2D98E")]]`)
 }
@@ -214,6 +214,10 @@ func TestDeleteWithLimit(t *testing.T) {
 
 // TestUpdateWithLimit executed update queries with limit
 func TestUpdateWithLimit(t *testing.T) {
+	// slack: v19 per-shard LIMIT applies LIMIT on each shard independently,
+	// so total rows affected may exceed the LIMIT value. This test validates
+	// v22 DMLWithInput total-count LIMIT behavior which our fork doesn't use.
+	t.Skip("slack: v19 per-shard LIMIT semantics differ from v22 DMLWithInput total-count LIMIT")
 	mcmp, closer := start(t)
 	defer closer()
 

--- a/go/vt/vtgate/planbuilder/operators/SQL_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/SQL_builder.go
@@ -485,6 +485,7 @@ func buildUpdate(op *Update, qb *queryBuilder) {
 	upd := &sqlparser.Update{
 		Ignore: op.Ignore,
 		Exprs:  updExprs,
+		Limit:  op.Limit,
 	}
 	qb.stmt = upd
 	qb.dmlOperator = op

--- a/go/vt/vtgate/planbuilder/operators/update.go
+++ b/go/vt/vtgate/planbuilder/operators/update.go
@@ -396,14 +396,9 @@ func createUpdateOperator(ctx *plancontext.PlanningContext, updStmt *sqlparser.U
 	}
 
 	if updStmt.Limit != nil {
-		if len(targetTbl.VTable.PrimaryKey) > 0 {
-			// v22 path: separate Limit operator enables DMLWithInput in phases
-			updOp.Source = newLimit(updOp.Source, updStmt.Limit, false)
-		} else {
-			// slack: v19 fallback - embed LIMIT on Update so it pushes under Route
-			// without requiring PrimaryKey for DMLWithInput
-			updOp.Limit = updStmt.Limit
-		}
+		// slack: v19 behavior - embed LIMIT on Update so it pushes under Route
+		// directly, avoiding the DMLWithInput phase (SELECT PKs then UPDATE).
+		updOp.Limit = updStmt.Limit
 	}
 
 	return sqc.getRootOperator(updOp, nil), targetTbl, updClone

--- a/go/vt/vtgate/planbuilder/operators/update.go
+++ b/go/vt/vtgate/planbuilder/operators/update.go
@@ -48,6 +48,10 @@ type (
 
 		VerifyAll bool
 
+		// slack: v19-compat - embed LIMIT on Update when PrimaryKey is unavailable,
+		// so the Update pushes under the Route without requiring DMLWithInput.
+		Limit *sqlparser.Limit
+
 		noColumns
 		noPredicates
 	}
@@ -392,7 +396,14 @@ func createUpdateOperator(ctx *plancontext.PlanningContext, updStmt *sqlparser.U
 	}
 
 	if updStmt.Limit != nil {
-		updOp.Source = newLimit(updOp.Source, updStmt.Limit, false)
+		if len(targetTbl.VTable.PrimaryKey) > 0 {
+			// v22 path: separate Limit operator enables DMLWithInput in phases
+			updOp.Source = newLimit(updOp.Source, updStmt.Limit, false)
+		} else {
+			// slack: v19 fallback - embed LIMIT on Update so it pushes under Route
+			// without requiring PrimaryKey for DMLWithInput
+			updOp.Limit = updStmt.Limit
+		}
 	}
 
 	return sqc.getRootOperator(updOp, nil), targetTbl, updClone

--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.json
@@ -5872,47 +5872,18 @@
     "comment": "update with limit clause",
     "query": "update user set val = 1 where (name = 'foo' or id = 1) limit 1",
     "plan": {
-      "Type": "Complex",
+      "Type": "Scatter",
       "QueryType": "UPDATE",
       "Original": "update user set val = 1 where (name = 'foo' or id = 1) limit 1",
       "Instructions": {
-        "OperatorType": "DMLWithInput",
-        "Offset": [
-          "0:[0]"
-        ],
-        "Inputs": [
-          {
-            "OperatorType": "Limit",
-            "Count": "1",
-            "Inputs": [
-              {
-                "OperatorType": "Route",
-                "Variant": "Scatter",
-                "Keyspace": {
-                  "Name": "user",
-                  "Sharded": true
-                },
-                "FieldQuery": "select `user`.id from `user` where 1 != 1",
-                "Query": "select `user`.id from `user` where `name` = 'foo' or id = 1 limit :__upper_limit lock in share mode",
-                "Table": "`user`"
-              }
-            ]
-          },
-          {
-            "OperatorType": "Update",
-            "Variant": "IN",
-            "Keyspace": {
-              "Name": "user",
-              "Sharded": true
-            },
-            "Query": "update `user` set val = 1 where `user`.id in ::dml_vals",
-            "Table": "user",
-            "Values": [
-              "::dml_vals"
-            ],
-            "Vindex": "user_index"
-          }
-        ]
+        "OperatorType": "Update",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "update `user` set val = 1 where `name` = 'foo' or id = 1 limit 1",
+        "Table": "user"
       },
       "TablesUsed": [
         "user.user"
@@ -5923,59 +5894,7 @@
   {
     "comment": "update a vindex column with limit",
     "query": "update user set name = 'abc' where id > 10 limit 1",
-    "plan": {
-      "Type": "Complex",
-      "QueryType": "UPDATE",
-      "Original": "update user set name = 'abc' where id > 10 limit 1",
-      "Instructions": {
-        "OperatorType": "DMLWithInput",
-        "Offset": [
-          "0:[0]"
-        ],
-        "Inputs": [
-          {
-            "OperatorType": "Limit",
-            "Count": "1",
-            "Inputs": [
-              {
-                "OperatorType": "Route",
-                "Variant": "Scatter",
-                "Keyspace": {
-                  "Name": "user",
-                  "Sharded": true
-                },
-                "FieldQuery": "select `user`.id from `user` where 1 != 1",
-                "Query": "select `user`.id from `user` where id > 10 limit :__upper_limit lock in share mode",
-                "Table": "`user`"
-              }
-            ]
-          },
-          {
-            "OperatorType": "Update",
-            "Variant": "IN",
-            "Keyspace": {
-              "Name": "user",
-              "Sharded": true
-            },
-            "ChangedVindexValues": [
-              "name_user_map:3"
-            ],
-            "KsidLength": 1,
-            "KsidVindex": "user_index",
-            "OwnedVindexQuery": "select Id, `Name`, Costly, `name` = 'abc' from `user` where `user`.id in ::dml_vals for update",
-            "Query": "update `user` set `name` = 'abc' where `user`.id in ::dml_vals",
-            "Table": "user",
-            "Values": [
-              "::dml_vals"
-            ],
-            "Vindex": "user_index"
-          }
-        ]
-      },
-      "TablesUsed": [
-        "user.user"
-      ]
-    },
+    "plan": "VT12001: unsupported: Vindex update should have ORDER BY clause when using LIMIT",
     "skip_e2e": true
   },
   {

--- a/go/vt/vtgate/planbuilder/testdata/unknown_schema_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/unknown_schema_cases.json
@@ -78,5 +78,57 @@
     "comment": "multi table delete with 1 sharded and 1 reference table",
     "query": "delete u, r from user u join ref_with_source r on u.col = r.col",
     "plan": "VT09015: schema tracking required"
+  },
+  {
+    "comment": "slack: update with limit on sharded table without primary key produces direct plan",
+    "query": "update music_extra set col = 1 where user_id = 1 limit 1",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "UPDATE",
+      "Original": "update music_extra set col = 1 where user_id = 1 limit 1",
+      "Instructions": {
+        "OperatorType": "Update",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "update music_extra set col = 1 where user_id = 1 limit 1",
+        "Table": "music_extra",
+        "Values": [
+          "1"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.music_extra"
+      ]
+    }
+  },
+  {
+    "comment": "slack: update with multi-column in and limit without primary key",
+    "query": "update music_extra set col = 1 where (user_id, music_id) in ((1, 2)) and col != 1 limit 10",
+    "plan": {
+      "Type": "MultiShard",
+      "QueryType": "UPDATE",
+      "Original": "update music_extra set col = 1 where (user_id, music_id) in ((1, 2)) and col != 1 limit 10",
+      "Instructions": {
+        "OperatorType": "Update",
+        "Variant": "MultiEqual",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "update music_extra set col = 1 where (user_id, music_id) in ((1, 2)) and col != 1 limit 10",
+        "Table": "music_extra",
+        "Values": [
+          "(1)"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.music_extra"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
## What's this?

Restores v19 per-shard LIMIT behavior for all `UPDATE ... LIMIT N` queries. v22 introduced a two-phase DMLWithInput plan (SELECT PKs then UPDATE by PK) for UPDATE+LIMIT, but we don't want that — v19's per-shard LIMIT is the expected behavior for our fork (with `MULTI_SHARD_AUTOCOMMIT=1` / `ALLOW_SCATTER`).

## How it works

v22 changed UPDATE+LIMIT to create a separate Limit operator above the Route, which triggers the `dmlWithInput` phase requiring PrimaryKey metadata. This change unconditionally reverts to v19's approach: embed the LIMIT directly on the Update operator so it pushes under the Route. No DMLWithInput, no PK select-then-update — LIMIT applies per-shard.

This means `UPDATE ... LIMIT 10` across 10 shards may update up to 100 rows total (10 per shard), which is the intended behavior.

## Changes

- `update.go`: Add `Limit` field to Update struct, embed LIMIT unconditionally (no separate Limit operator)
- `SQL_builder.go`: Include embedded Limit in generated SQL
- `unknown_schema_cases.json`: 2 regression tests (UPDATE+LIMIT without PK)
- `dml_cases.json`: Updated 2 existing test expectations
- `dml_test.go`: Updated e2e tests — `TestUniqueLookupDuplicateEntries` error expectation, skip `TestUpdateWithLimit` (validates v22 total-count LIMIT)

## Root cause

PR vitessio/vitess#15107 replaced Update's direct Limit field with a separate Limit operator and renamed `deleteWithInput` → `dmlWithInput` (now covering UPDATEs). The Limit operator between Update and Route prevents `tryPushUpdate` from pushing Update under Route, forcing the `dmlWithInput` phase which requires PK.

---
_Most of this was written by Claude Code — I provided direction and review._