### PR TITLE
Prototype automatic IN-clause batching at the VTGate level

### DIFF
--- a/.github/workflows/error_code_docs.yml
+++ b/.github/workflows/error_code_docs.yml
@@ -4,6 +4,8 @@ name: Update error code docs
 on:
   pull_request_target:
     types: [opened, synchronize]
+    branches-ignore:
+      - '*' 
     paths:
       - 'go/vt/vterrors/code.go'
 

--- a/.github/workflows/error_code_docs.yml
+++ b/.github/workflows/error_code_docs.yml
@@ -4,8 +4,6 @@ name: Update error code docs
 on:
   pull_request_target:
     types: [opened, synchronize]
-    branches-ignore:
-      - '*' 
     paths:
       - 'go/vt/vterrors/code.go'
 

--- a/.github/workflows/pr_opened_tasks.yml
+++ b/.github/workflows/pr_opened_tasks.yml
@@ -5,6 +5,8 @@ name: PR opened tasks
 on:
   pull_request_target:
     types: [opened]
+    branches-ignore:
+      - '*'  # Disabled in Slack fork - GitHub App not configured
 
 jobs:
   # Skip PRs with "Backport" or "Forwardport" labels since those are automated.

--- a/.github/workflows/pr_opened_tasks.yml
+++ b/.github/workflows/pr_opened_tasks.yml
@@ -5,8 +5,6 @@ name: PR opened tasks
 on:
   pull_request_target:
     types: [opened]
-    branches-ignore:
-      - '*'  # Disabled in Slack fork - GitHub App not configured
 
 jobs:
   # Skip PRs with "Backport" or "Forwardport" labels since those are automated.

--- a/go/vt/vtgate/engine/fake_vcursor_test.go
+++ b/go/vt/vtgate/engine/fake_vcursor_test.go
@@ -116,6 +116,10 @@ func (t *noopVCursor) GetWarmingReadsPercent() int {
 	panic("implement me")
 }
 
+func (t *noopVCursor) GetInClauseBatchSize() int {
+	return 0
+}
+
 func (t *noopVCursor) GetWarmingReadsChannel() chan bool {
 	panic("implement me")
 }
@@ -475,6 +479,8 @@ type loggingVCursor struct {
 	onStreamExecuteMultiFn func(context.Context, Primitive, string, []*srvtopo.ResolvedShard, []map[string]*querypb.BindVariable, bool, bool, func(*sqltypes.Result) error)
 	onRecordMirrorStatsFn  func(time.Duration, time.Duration, error)
 
+	inClauseBatchSize int
+
 	metrics *Metrics
 }
 
@@ -589,6 +595,10 @@ func (f *loggingVCursor) RecordWarning(warning *querypb.QueryWarning) {
 
 func (f *loggingVCursor) GetWarmingReadsPercent() int {
 	return 0
+}
+
+func (f *loggingVCursor) GetInClauseBatchSize() int {
+	return f.inClauseBatchSize
 }
 
 func (f *loggingVCursor) GetWarmingReadsChannel() chan bool {

--- a/go/vt/vtgate/engine/in_clause_batch.go
+++ b/go/vt/vtgate/engine/in_clause_batch.go
@@ -17,6 +17,7 @@ limitations under the License.
 package engine
 
 import (
+	"maps"
 	"sort"
 	"strings"
 
@@ -98,10 +99,7 @@ func chunkTupleValues(values []*querypb.Value, batchSize int) [][]*querypb.Value
 	chunks := make([][]*querypb.Value, 0, numChunks)
 
 	for i := 0; i < len(values); i += batchSize {
-		end := i + batchSize
-		if end > len(values) {
-			end = len(values)
-		}
+		end := min(i+batchSize, len(values))
 		chunks = append(chunks, values[i:end])
 	}
 
@@ -113,9 +111,7 @@ func chunkTupleValues(values []*querypb.Value, batchSize int) [][]*querypb.Value
 // provided chunk of values.
 func cloneBindVarsWithTuple(original map[string]*querypb.BindVariable, tupleName string, chunk []*querypb.Value) map[string]*querypb.BindVariable {
 	out := make(map[string]*querypb.BindVariable, len(original))
-	for k, v := range original {
-		out[k] = v
-	}
+	maps.Copy(out, original)
 	out[tupleName] = &querypb.BindVariable{
 		Type:   querypb.Type_TUPLE,
 		Values: chunk,
@@ -128,9 +124,7 @@ func cloneBindVarsWithTuple(original map[string]*querypb.BindVariable, tupleName
 // the provided chunk values.
 func cloneBindVarsWithTuples(original map[string]*querypb.BindVariable, replacements []tupleReplacement) map[string]*querypb.BindVariable {
 	out := make(map[string]*querypb.BindVariable, len(original))
-	for k, v := range original {
-		out[k] = v
-	}
+	maps.Copy(out, original)
 	for _, r := range replacements {
 		out[r.name] = &querypb.BindVariable{
 			Type:   querypb.Type_TUPLE,

--- a/go/vt/vtgate/engine/in_clause_batch.go
+++ b/go/vt/vtgate/engine/in_clause_batch.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"strings"
+
+	"vitess.io/vitess/go/stats"
+
+	querypb "vitess.io/vitess/go/vt/proto/query"
+)
+
+var inClauseBatchCount = stats.NewCounter("InClauseBatchCount", "Number of queries where IN-clause batching was applied")
+
+// findLargestTupleBV scans a bind variable map and returns the name of the
+// TUPLE-type bind variable with the most values that exceeds the given
+// threshold. It skips bind vars used for vindex routing (__vals, __vals0, etc.).
+// Returns ("", nil) if no tuple exceeds the threshold.
+func findLargestTupleBV(bvs map[string]*querypb.BindVariable, threshold int) (string, *querypb.BindVariable) {
+	var bestName string
+	var bestBV *querypb.BindVariable
+	bestLen := threshold
+
+	for name, bv := range bvs {
+		if bv.Type != querypb.Type_TUPLE {
+			continue
+		}
+		if strings.HasPrefix(name, ListVarName) {
+			continue
+		}
+		if len(bv.Values) > bestLen {
+			bestName = name
+			bestBV = bv
+			bestLen = len(bv.Values)
+		}
+	}
+
+	return bestName, bestBV
+}
+
+// chunkTupleValues splits a slice of bind variable values into chunks of at
+// most batchSize elements. The returned slices share the underlying pointers
+// with the input (no deep copy).
+func chunkTupleValues(values []*querypb.Value, batchSize int) [][]*querypb.Value {
+	if batchSize <= 0 || len(values) == 0 {
+		return [][]*querypb.Value{values}
+	}
+
+	numChunks := (len(values) + batchSize - 1) / batchSize
+	chunks := make([][]*querypb.Value, 0, numChunks)
+
+	for i := 0; i < len(values); i += batchSize {
+		end := i + batchSize
+		if end > len(values) {
+			end = len(values)
+		}
+		chunks = append(chunks, values[i:end])
+	}
+
+	return chunks
+}
+
+// cloneBindVarsWithTuple creates a shallow copy of the bind var map,
+// replacing the named tuple bind variable with a new one containing the
+// provided chunk of values.
+func cloneBindVarsWithTuple(original map[string]*querypb.BindVariable, tupleName string, chunk []*querypb.Value) map[string]*querypb.BindVariable {
+	out := make(map[string]*querypb.BindVariable, len(original))
+	for k, v := range original {
+		out[k] = v
+	}
+	out[tupleName] = &querypb.BindVariable{
+		Type:   querypb.Type_TUPLE,
+		Values: chunk,
+	}
+	return out
+}

--- a/go/vt/vtgate/engine/in_clause_batch.go
+++ b/go/vt/vtgate/engine/in_clause_batch.go
@@ -17,6 +17,7 @@ limitations under the License.
 package engine
 
 import (
+	"sort"
 	"strings"
 
 	"vitess.io/vitess/go/stats"
@@ -25,6 +26,39 @@ import (
 )
 
 var inClauseBatchCount = stats.NewCounter("InClauseBatchCount", "Number of queries where IN-clause batching was applied")
+
+// oversizedTuple holds the name and bind variable of a tuple that exceeds the
+// batch size threshold, along with its pre-computed chunks.
+type oversizedTuple struct {
+	name   string
+	chunks [][]*querypb.Value
+}
+
+// findOversizedTuples scans a bind variable map and returns all TUPLE-type
+// bind variables whose value count exceeds the threshold. Results are sorted
+// by name for deterministic batching order. It skips bind vars used for vindex
+// routing (__vals, __vals0, etc.).
+func findOversizedTuples(bvs map[string]*querypb.BindVariable, threshold int) []oversizedTuple {
+	var result []oversizedTuple
+	for name, bv := range bvs {
+		if bv.Type != querypb.Type_TUPLE {
+			continue
+		}
+		if strings.HasPrefix(name, ListVarName) {
+			continue
+		}
+		if len(bv.Values) > threshold {
+			result = append(result, oversizedTuple{
+				name:   name,
+				chunks: chunkTupleValues(bv.Values, threshold),
+			})
+		}
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].name < result[j].name
+	})
+	return result
+}
 
 // findLargestTupleBV scans a bind variable map and returns the name of the
 // TUPLE-type bind variable with the most values that exceeds the given
@@ -87,4 +121,66 @@ func cloneBindVarsWithTuple(original map[string]*querypb.BindVariable, tupleName
 		Values: chunk,
 	}
 	return out
+}
+
+// cloneBindVarsWithTuples creates a shallow copy of the bind var map,
+// replacing multiple named tuple bind variables with new ones containing
+// the provided chunk values.
+func cloneBindVarsWithTuples(original map[string]*querypb.BindVariable, replacements []tupleReplacement) map[string]*querypb.BindVariable {
+	out := make(map[string]*querypb.BindVariable, len(original))
+	for k, v := range original {
+		out[k] = v
+	}
+	for _, r := range replacements {
+		out[r.name] = &querypb.BindVariable{
+			Type:   querypb.Type_TUPLE,
+			Values: r.chunk,
+		}
+	}
+	return out
+}
+
+type tupleReplacement struct {
+	name  string
+	chunk []*querypb.Value
+}
+
+// cartesianBatchCombinations generates all combinations of chunk indices across
+// multiple oversized tuples. For example, if tuple A has 2 chunks and tuple B
+// has 3 chunks, this returns 6 combinations: [(0,0), (0,1), (0,2), (1,0), (1,1), (1,2)].
+// Each combination is a slice of tupleReplacement ready for cloneBindVarsWithTuples.
+func cartesianBatchCombinations(tuples []oversizedTuple) [][]tupleReplacement {
+	if len(tuples) == 0 {
+		return nil
+	}
+
+	totalCombinations := 1
+	for _, t := range tuples {
+		totalCombinations *= len(t.chunks)
+	}
+
+	result := make([][]tupleReplacement, 0, totalCombinations)
+	indices := make([]int, len(tuples))
+
+	for i := 0; i < totalCombinations; i++ {
+		combo := make([]tupleReplacement, len(tuples))
+		for j, t := range tuples {
+			combo[j] = tupleReplacement{
+				name:  t.name,
+				chunk: t.chunks[indices[j]],
+			}
+		}
+		result = append(result, combo)
+
+		// Increment indices (odometer-style, rightmost advances first)
+		for j := len(indices) - 1; j >= 0; j-- {
+			indices[j]++
+			if indices[j] < len(tuples[j].chunks) {
+				break
+			}
+			indices[j] = 0
+		}
+	}
+
+	return result
 }

--- a/go/vt/vtgate/engine/in_clause_batch_test.go
+++ b/go/vt/vtgate/engine/in_clause_batch_test.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	querypb "vitess.io/vitess/go/vt/proto/query"
+)
+
+func makeTestTuple(n int) *querypb.BindVariable {
+	values := make([]*querypb.Value, n)
+	for i := range values {
+		values[i] = &querypb.Value{Type: querypb.Type_INT64, Value: []byte{byte('0' + i%10)}}
+	}
+	return &querypb.BindVariable{Type: querypb.Type_TUPLE, Values: values}
+}
+
+func TestFindLargestTupleBV(t *testing.T) {
+	t.Run("no tuples", func(t *testing.T) {
+		bvs := map[string]*querypb.BindVariable{
+			"v1": {Type: querypb.Type_INT64, Value: []byte("1")},
+		}
+		name, bv := findLargestTupleBV(bvs, 3)
+		assert.Empty(t, name)
+		assert.Nil(t, bv)
+	})
+
+	t.Run("tuple under threshold", func(t *testing.T) {
+		bvs := map[string]*querypb.BindVariable{
+			"v1": makeTestTuple(3),
+		}
+		name, bv := findLargestTupleBV(bvs, 3)
+		assert.Empty(t, name)
+		assert.Nil(t, bv)
+	})
+
+	t.Run("tuple over threshold", func(t *testing.T) {
+		bvs := map[string]*querypb.BindVariable{
+			"v1": makeTestTuple(5),
+		}
+		name, bv := findLargestTupleBV(bvs, 3)
+		assert.Equal(t, "v1", name)
+		require.NotNil(t, bv)
+		assert.Len(t, bv.Values, 5)
+	})
+
+	t.Run("picks the largest tuple", func(t *testing.T) {
+		bvs := map[string]*querypb.BindVariable{
+			"v1": makeTestTuple(5),
+			"v2": makeTestTuple(10),
+			"v3": makeTestTuple(7),
+		}
+		name, bv := findLargestTupleBV(bvs, 3)
+		assert.Equal(t, "v2", name)
+		require.NotNil(t, bv)
+		assert.Len(t, bv.Values, 10)
+	})
+
+	t.Run("skips __vals", func(t *testing.T) {
+		bvs := map[string]*querypb.BindVariable{
+			ListVarName: makeTestTuple(100),
+		}
+		name, bv := findLargestTupleBV(bvs, 3)
+		assert.Empty(t, name)
+		assert.Nil(t, bv)
+	})
+
+	t.Run("skips __vals0 and __vals1", func(t *testing.T) {
+		bvs := map[string]*querypb.BindVariable{
+			ListVarName + "0": makeTestTuple(100),
+			ListVarName + "1": makeTestTuple(100),
+		}
+		name, bv := findLargestTupleBV(bvs, 3)
+		assert.Empty(t, name)
+		assert.Nil(t, bv)
+	})
+
+	t.Run("skips __vals but finds other tuple", func(t *testing.T) {
+		bvs := map[string]*querypb.BindVariable{
+			ListVarName: makeTestTuple(100),
+			"v1":        makeTestTuple(5),
+		}
+		name, bv := findLargestTupleBV(bvs, 3)
+		assert.Equal(t, "v1", name)
+		require.NotNil(t, bv)
+		assert.Len(t, bv.Values, 5)
+	})
+}
+
+func TestChunkTupleValues(t *testing.T) {
+	t.Run("exact division", func(t *testing.T) {
+		values := makeTestTuple(6).Values
+		chunks := chunkTupleValues(values, 3)
+		require.Len(t, chunks, 2)
+		assert.Len(t, chunks[0], 3)
+		assert.Len(t, chunks[1], 3)
+	})
+
+	t.Run("remainder", func(t *testing.T) {
+		values := makeTestTuple(7).Values
+		chunks := chunkTupleValues(values, 3)
+		require.Len(t, chunks, 3)
+		assert.Len(t, chunks[0], 3)
+		assert.Len(t, chunks[1], 3)
+		assert.Len(t, chunks[2], 1)
+	})
+
+	t.Run("single chunk when under batch size", func(t *testing.T) {
+		values := makeTestTuple(2).Values
+		chunks := chunkTupleValues(values, 5)
+		require.Len(t, chunks, 1)
+		assert.Len(t, chunks[0], 2)
+	})
+
+	t.Run("empty values", func(t *testing.T) {
+		chunks := chunkTupleValues(nil, 3)
+		require.Len(t, chunks, 1)
+		assert.Nil(t, chunks[0])
+	})
+
+	t.Run("shares underlying pointers", func(t *testing.T) {
+		values := makeTestTuple(4).Values
+		chunks := chunkTupleValues(values, 2)
+		require.Len(t, chunks, 2)
+		// Verify the chunks reference the same underlying values
+		assert.Same(t, values[0], chunks[0][0])
+		assert.Same(t, values[2], chunks[1][0])
+	})
+}
+
+func TestCloneBindVarsWithTuple(t *testing.T) {
+	original := map[string]*querypb.BindVariable{
+		"v1": {Type: querypb.Type_INT64, Value: []byte("1")},
+		"v2": makeTestTuple(5),
+	}
+	chunk := makeTestTuple(2).Values
+
+	cloned := cloneBindVarsWithTuple(original, "v2", chunk)
+
+	t.Run("original is not modified", func(t *testing.T) {
+		assert.Len(t, original["v2"].Values, 5)
+	})
+
+	t.Run("cloned has the replacement", func(t *testing.T) {
+		assert.Len(t, cloned["v2"].Values, 2)
+		assert.Equal(t, querypb.Type_TUPLE, cloned["v2"].Type)
+	})
+
+	t.Run("other keys are shallow copied", func(t *testing.T) {
+		assert.Same(t, original["v1"], cloned["v1"])
+	})
+
+	t.Run("cloned has same number of keys", func(t *testing.T) {
+		assert.Len(t, cloned, len(original))
+	})
+}

--- a/go/vt/vtgate/engine/in_clause_batch_test.go
+++ b/go/vt/vtgate/engine/in_clause_batch_test.go
@@ -146,6 +146,99 @@ func TestChunkTupleValues(t *testing.T) {
 	})
 }
 
+func TestFindOversizedTuples(t *testing.T) {
+	t.Run("no oversized tuples", func(t *testing.T) {
+		bvs := map[string]*querypb.BindVariable{
+			"v1": makeTestTuple(3),
+			"v2": makeTestTuple(2),
+		}
+		result := findOversizedTuples(bvs, 3)
+		assert.Empty(t, result)
+	})
+
+	t.Run("one oversized tuple", func(t *testing.T) {
+		bvs := map[string]*querypb.BindVariable{
+			"v1": makeTestTuple(5),
+			"v2": makeTestTuple(2),
+		}
+		result := findOversizedTuples(bvs, 3)
+		require.Len(t, result, 1)
+		assert.Equal(t, "v1", result[0].name)
+		assert.Len(t, result[0].chunks, 2) // 5/3 = 2 chunks
+	})
+
+	t.Run("two oversized tuples sorted by name", func(t *testing.T) {
+		bvs := map[string]*querypb.BindVariable{
+			"v2": makeTestTuple(7),
+			"v1": makeTestTuple(5),
+		}
+		result := findOversizedTuples(bvs, 3)
+		require.Len(t, result, 2)
+		assert.Equal(t, "v1", result[0].name) // sorted by name
+		assert.Equal(t, "v2", result[1].name)
+	})
+
+	t.Run("skips __vals", func(t *testing.T) {
+		bvs := map[string]*querypb.BindVariable{
+			ListVarName: makeTestTuple(100),
+			"v1":        makeTestTuple(5),
+		}
+		result := findOversizedTuples(bvs, 3)
+		require.Len(t, result, 1)
+		assert.Equal(t, "v1", result[0].name)
+	})
+}
+
+func TestCartesianBatchCombinations(t *testing.T) {
+	t.Run("single tuple", func(t *testing.T) {
+		tuples := []oversizedTuple{
+			{name: "v1", chunks: [][]*querypb.Value{
+				makeTestTuple(2).Values,
+				makeTestTuple(1).Values,
+			}},
+		}
+		combos := cartesianBatchCombinations(tuples)
+		assert.Len(t, combos, 2)
+		assert.Len(t, combos[0], 1)
+		assert.Equal(t, "v1", combos[0][0].name)
+	})
+
+	t.Run("two tuples produce cartesian product", func(t *testing.T) {
+		tuples := []oversizedTuple{
+			{name: "v1", chunks: [][]*querypb.Value{
+				makeTestTuple(2).Values,
+				makeTestTuple(1).Values,
+			}},
+			{name: "v2", chunks: [][]*querypb.Value{
+				makeTestTuple(3).Values,
+				makeTestTuple(2).Values,
+				makeTestTuple(1).Values,
+			}},
+		}
+		combos := cartesianBatchCombinations(tuples)
+		assert.Len(t, combos, 6) // 2 × 3 = 6
+
+		// Verify all combinations are present: (0,0), (0,1), (0,2), (1,0), (1,1), (1,2)
+		for _, combo := range combos {
+			assert.Len(t, combo, 2)
+			assert.Equal(t, "v1", combo[0].name)
+			assert.Equal(t, "v2", combo[1].name)
+		}
+
+		// First combo should use first chunk of each
+		assert.Len(t, combos[0][0].chunk, 2) // v1 chunk 0 has 2 values
+		assert.Len(t, combos[0][1].chunk, 3) // v2 chunk 0 has 3 values
+		// Last combo should use last chunk of each
+		assert.Len(t, combos[5][0].chunk, 1) // v1 chunk 1 has 1 value
+		assert.Len(t, combos[5][1].chunk, 1) // v2 chunk 2 has 1 value
+	})
+
+	t.Run("empty input", func(t *testing.T) {
+		combos := cartesianBatchCombinations(nil)
+		assert.Nil(t, combos)
+	})
+}
+
 func TestCloneBindVarsWithTuple(t *testing.T) {
 	original := map[string]*querypb.BindVariable{
 		"v1": {Type: querypb.Type_INT64, Value: []byte("1")},

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -126,6 +126,9 @@ type (
 		// GetWarmingReadsPercent gets the percentage of queries to clone to replicas for bufferpool warming
 		GetWarmingReadsPercent() int
 
+		// GetInClauseBatchSize returns the max number of IN clause values per batch. 0 means disabled.
+		GetInClauseBatchSize() int
+
 		// GetWarmingReadsChannel returns the channel for executing warming reads against replicas
 		GetWarmingReadsChannel() chan bool
 

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -123,9 +123,10 @@ func (route *Route) TryExecute(ctx context.Context, vcursor VCursor, bindVars ma
 	return route.executeShards(ctx, vcursor, bindVars, wantfields, rss, bvs)
 }
 
-// tryBatchedExecution checks if any shard's bind vars contain a TUPLE that
-// exceeds batchSize. If so, it splits execution into batches and returns
-// (result, true, err). If no batching is needed, returns (nil, false, nil).
+// tryBatchedExecution checks if any shard's bind vars contain TUPLE(s) that
+// exceed batchSize. If so, it splits execution into batches (with cartesian
+// product for multiple oversized tuples) and returns (result, true, err).
+// If no batching is needed, returns (nil, false, nil).
 func (route *Route) tryBatchedExecution(
 	ctx context.Context,
 	vcursor VCursor,
@@ -135,22 +136,25 @@ func (route *Route) tryBatchedExecution(
 	bvs []map[string]*querypb.BindVariable,
 	batchSize int,
 ) (*sqltypes.Result, bool, error) {
-	// Check the first shard's bind vars for large tuples. For non-vindex IN
-	// clauses all shards receive the same bind vars.
-	tupleName, tupleBV := findLargestTupleBV(bvs[0], batchSize)
-	if tupleName == "" {
+	// Check the first shard's bind vars for oversized tuples. For non-vindex
+	// IN clauses all shards receive the same bind vars.
+	tuples := findOversizedTuples(bvs[0], batchSize)
+	if len(tuples) == 0 {
 		return nil, false, nil
 	}
 
 	inClauseBatchCount.Add(1)
 
-	chunks := chunkTupleValues(tupleBV.Values, batchSize)
+	// Generate all combinations of chunks across all oversized tuples.
+	// For a single tuple this is equivalent to iterating over its chunks.
+	// For multiple tuples this produces a cartesian product.
+	combinations := cartesianBatchCombinations(tuples)
 	var combined *sqltypes.Result
 
-	for i, chunk := range chunks {
+	for i, combo := range combinations {
 		batchBVs := make([]map[string]*querypb.BindVariable, len(rss))
 		for j := range rss {
-			batchBVs[j] = cloneBindVarsWithTuple(bvs[j], tupleName, chunk)
+			batchBVs[j] = cloneBindVarsWithTuples(bvs[j], combo)
 		}
 
 		queries := getQueries(route.Query, batchBVs)
@@ -177,7 +181,7 @@ func (route *Route) tryBatchedExecution(
 	}
 
 	// Re-sort if OrderBy is populated and we produced multiple batches.
-	if len(route.OrderBy) > 0 && len(chunks) > 1 {
+	if len(route.OrderBy) > 0 && len(combinations) > 1 {
 		var err error
 		combined, err = route.sort(combined)
 		if err != nil {
@@ -286,6 +290,17 @@ func (route *Route) TryStreamExecute(
 	rss, bvs, err := route.findRoute(ctx, vcursor, bindVars)
 	if err != nil {
 		return err
+	}
+
+	// When batching is needed, fall back to non-streaming execution since
+	// we need to collect all results to re-sort and de-duplicate across batches.
+	if batchSize := vcursor.GetInClauseBatchSize(); batchSize > 0 && len(rss) > 0 {
+		if result, batched, batchErr := route.tryBatchedExecution(ctx, vcursor, bindVars, wantfields, rss, bvs, batchSize); batched {
+			if batchErr != nil {
+				return batchErr
+			}
+			return callback(result)
+		}
 	}
 
 	return route.streamExecuteShards(ctx, vcursor, bindVars, wantfields, callback, rss, bvs)

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -114,7 +114,78 @@ func (route *Route) TryExecute(ctx context.Context, vcursor VCursor, bindVars ma
 		return nil, err
 	}
 
+	if batchSize := vcursor.GetInClauseBatchSize(); batchSize > 0 && len(rss) > 0 {
+		if result, batched, batchErr := route.tryBatchedExecution(ctx, vcursor, bindVars, wantfields, rss, bvs, batchSize); batched {
+			return result, batchErr
+		}
+	}
+
 	return route.executeShards(ctx, vcursor, bindVars, wantfields, rss, bvs)
+}
+
+// tryBatchedExecution checks if any shard's bind vars contain a TUPLE that
+// exceeds batchSize. If so, it splits execution into batches and returns
+// (result, true, err). If no batching is needed, returns (nil, false, nil).
+func (route *Route) tryBatchedExecution(
+	ctx context.Context,
+	vcursor VCursor,
+	bindVars map[string]*querypb.BindVariable,
+	wantfields bool,
+	rss []*srvtopo.ResolvedShard,
+	bvs []map[string]*querypb.BindVariable,
+	batchSize int,
+) (*sqltypes.Result, bool, error) {
+	// Check the first shard's bind vars for large tuples. For non-vindex IN
+	// clauses all shards receive the same bind vars.
+	tupleName, tupleBV := findLargestTupleBV(bvs[0], batchSize)
+	if tupleName == "" {
+		return nil, false, nil
+	}
+
+	inClauseBatchCount.Add(1)
+
+	chunks := chunkTupleValues(tupleBV.Values, batchSize)
+	var combined *sqltypes.Result
+
+	for i, chunk := range chunks {
+		batchBVs := make([]map[string]*querypb.BindVariable, len(rss))
+		for j := range rss {
+			batchBVs[j] = cloneBindVarsWithTuple(bvs[j], tupleName, chunk)
+		}
+
+		queries := getQueries(route.Query, batchBVs)
+		result, errs := vcursor.ExecuteMultiShard(ctx, route, rss, queries,
+			false /*rollbackOnError*/, false /*canAutocommit*/, route.FetchLastInsertID)
+
+		if errs != nil {
+			errs = filterOutNilErrors(errs)
+			if !route.ScatterErrorsAsWarnings || len(errs) == len(rss) {
+				return nil, true, vterrors.Aggregate(errs)
+			}
+			partialSuccessScatterQueries.Add(1)
+			for _, err := range errs {
+				serr := sqlerror.NewSQLErrorFromError(err).(*sqlerror.SQLError)
+				vcursor.Session().RecordWarning(&querypb.QueryWarning{Code: uint32(serr.Num), Message: err.Error()})
+			}
+		}
+
+		if i == 0 {
+			combined = result
+		} else {
+			combined.AppendResult(result)
+		}
+	}
+
+	// Re-sort if OrderBy is populated and we produced multiple batches.
+	if len(route.OrderBy) > 0 && len(chunks) > 1 {
+		var err error
+		combined, err = route.sort(combined)
+		if err != nil {
+			return nil, true, err
+		}
+	}
+
+	return combined.Truncate(route.TruncateColumnCount), true, nil
 }
 
 type cxtKey int

--- a/go/vt/vtgate/engine/route_test.go
+++ b/go/vt/vtgate/engine/route_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -1834,4 +1835,222 @@ func TestSelectTupleMultiCol(t *testing.T) {
 		`ResolveDestinationsMultiCol user [[INT64(1) VARCHAR("a")] [INT64(4) VARCHAR("b")]] Destinations:DestinationKeyspaceID(166b40b461),DestinationKeyspaceID(d2fd886762)`,
 		fmt.Sprintf(`StreamExecuteMulti select 1 from multicol_tbl where (colb, colx, cola) in ::vals user.-20: {vals: %v} `, &querypb.BindVariable{Type: querypb.Type_TUPLE, Values: []*querypb.Value{{Type: querypb.Type_TUPLE, Value: []byte("\x89\x02\x011\x950\x01a")}, {Type: querypb.Type_TUPLE, Value: []byte("\x89\x02\x014\x950\x01b")}}}),
 	})
+}
+
+func TestInClauseBatching(t *testing.T) {
+	sel := NewRoute(
+		Unsharded,
+		&vindexes.Keyspace{
+			Name:    "ks",
+			Sharded: false,
+		},
+		"select id from t where id in ::v1",
+		"select id from t where 1 != 1",
+	)
+
+	fields := sqltypes.MakeTestFields("id", "int64")
+
+	vc := &loggingVCursor{
+		shards:            []string{"0"},
+		inClauseBatchSize: 3,
+		results: []*sqltypes.Result{
+			sqltypes.MakeTestResult(fields, "1", "2", "3"),
+			sqltypes.MakeTestResult(fields, "4", "5", "6"),
+			sqltypes.MakeTestResult(fields, "7"),
+		},
+	}
+
+	bvs := map[string]*querypb.BindVariable{
+		"v1": {
+			Type:   querypb.Type_TUPLE,
+			Values: make([]*querypb.Value, 7),
+		},
+	}
+	for i := range bvs["v1"].Values {
+		bvs["v1"].Values[i] = &querypb.Value{Type: querypb.Type_INT64, Value: []byte(strconv.Itoa(i + 1))}
+	}
+
+	result, err := sel.TryExecute(context.Background(), vc, bvs, false)
+	require.NoError(t, err)
+
+	// Should have 3 ExecuteMultiShard calls (3+3+1)
+	executeCount := 0
+	for _, l := range vc.log {
+		if strings.HasPrefix(l, "ExecuteMultiShard") {
+			executeCount++
+		}
+	}
+	assert.Equal(t, 3, executeCount, "expected 3 batched ExecuteMultiShard calls")
+
+	// All 7 rows should be present
+	assert.Len(t, result.Rows, 7)
+}
+
+func TestInClauseBatchingWithOrderBy(t *testing.T) {
+	sel := NewRoute(
+		Unsharded,
+		&vindexes.Keyspace{
+			Name:    "ks",
+			Sharded: false,
+		},
+		"select id from t where id in ::v1 order by id",
+		"select id from t where 1 != 1",
+	)
+	sel.OrderBy = []evalengine.OrderByParams{{
+		Col:             0,
+		WeightStringCol: -1,
+	}}
+
+	fields := sqltypes.MakeTestFields("id", "int64")
+
+	// Return results out of global order across batches
+	vc := &loggingVCursor{
+		shards:            []string{"0"},
+		inClauseBatchSize: 3,
+		results: []*sqltypes.Result{
+			sqltypes.MakeTestResult(fields, "2", "5", "8"),
+			sqltypes.MakeTestResult(fields, "1", "4", "7"),
+			sqltypes.MakeTestResult(fields, "3"),
+		},
+	}
+
+	bvs := map[string]*querypb.BindVariable{
+		"v1": {
+			Type:   querypb.Type_TUPLE,
+			Values: make([]*querypb.Value, 7),
+		},
+	}
+	for i := range bvs["v1"].Values {
+		bvs["v1"].Values[i] = &querypb.Value{Type: querypb.Type_INT64, Value: []byte(strconv.Itoa(i + 1))}
+	}
+
+	result, err := sel.TryExecute(context.Background(), vc, bvs, false)
+	require.NoError(t, err)
+
+	// Results should be sorted ascending by id
+	wantResult := sqltypes.MakeTestResult(fields, "1", "2", "3", "4", "5", "7", "8")
+	expectResult(t, result, wantResult)
+}
+
+func TestInClauseBatchingSkipsSmallTuples(t *testing.T) {
+	sel := NewRoute(
+		Unsharded,
+		&vindexes.Keyspace{
+			Name:    "ks",
+			Sharded: false,
+		},
+		"select id from t where id in ::v1",
+		"select id from t where 1 != 1",
+	)
+
+	vc := &loggingVCursor{
+		shards:            []string{"0"},
+		inClauseBatchSize: 10,
+		results:           []*sqltypes.Result{defaultSelectResult},
+	}
+
+	bvs := map[string]*querypb.BindVariable{
+		"v1": {
+			Type:   querypb.Type_TUPLE,
+			Values: make([]*querypb.Value, 5),
+		},
+	}
+	for i := range bvs["v1"].Values {
+		bvs["v1"].Values[i] = &querypb.Value{Type: querypb.Type_INT64, Value: []byte(strconv.Itoa(i + 1))}
+	}
+
+	result, err := sel.TryExecute(context.Background(), vc, bvs, false)
+	require.NoError(t, err)
+
+	// Only 1 ExecuteMultiShard call (no batching)
+	executeCount := 0
+	for _, l := range vc.log {
+		if strings.HasPrefix(l, "ExecuteMultiShard") {
+			executeCount++
+		}
+	}
+	assert.Equal(t, 1, executeCount, "expected 1 ExecuteMultiShard call (no batching)")
+	expectResult(t, result, defaultSelectResult)
+}
+
+func TestInClauseBatchingSkipsVindexVals(t *testing.T) {
+	sel := NewRoute(
+		Unsharded,
+		&vindexes.Keyspace{
+			Name:    "ks",
+			Sharded: false,
+		},
+		"select id from t where id in ::__vals",
+		"select id from t where 1 != 1",
+	)
+
+	vc := &loggingVCursor{
+		shards:            []string{"0"},
+		inClauseBatchSize: 3,
+		results:           []*sqltypes.Result{defaultSelectResult},
+	}
+
+	bvs := map[string]*querypb.BindVariable{
+		ListVarName: {
+			Type:   querypb.Type_TUPLE,
+			Values: make([]*querypb.Value, 100),
+		},
+	}
+	for i := range bvs[ListVarName].Values {
+		bvs[ListVarName].Values[i] = &querypb.Value{Type: querypb.Type_INT64, Value: []byte(strconv.Itoa(i + 1))}
+	}
+
+	result, err := sel.TryExecute(context.Background(), vc, bvs, false)
+	require.NoError(t, err)
+
+	// Only 1 ExecuteMultiShard call (__vals is not batched)
+	executeCount := 0
+	for _, l := range vc.log {
+		if strings.HasPrefix(l, "ExecuteMultiShard") {
+			executeCount++
+		}
+	}
+	assert.Equal(t, 1, executeCount, "expected 1 ExecuteMultiShard call (__vals should not be batched)")
+	expectResult(t, result, defaultSelectResult)
+}
+
+func TestInClauseBatchingDisabled(t *testing.T) {
+	sel := NewRoute(
+		Unsharded,
+		&vindexes.Keyspace{
+			Name:    "ks",
+			Sharded: false,
+		},
+		"select id from t where id in ::v1",
+		"select id from t where 1 != 1",
+	)
+
+	vc := &loggingVCursor{
+		shards:            []string{"0"},
+		inClauseBatchSize: 0, // disabled
+		results:           []*sqltypes.Result{defaultSelectResult},
+	}
+
+	bvs := map[string]*querypb.BindVariable{
+		"v1": {
+			Type:   querypb.Type_TUPLE,
+			Values: make([]*querypb.Value, 10000),
+		},
+	}
+	for i := range bvs["v1"].Values {
+		bvs["v1"].Values[i] = &querypb.Value{Type: querypb.Type_INT64, Value: []byte(strconv.Itoa(i + 1))}
+	}
+
+	result, err := sel.TryExecute(context.Background(), vc, bvs, false)
+	require.NoError(t, err)
+
+	// Only 1 ExecuteMultiShard call (batching disabled)
+	executeCount := 0
+	for _, l := range vc.log {
+		if strings.HasPrefix(l, "ExecuteMultiShard") {
+			executeCount++
+		}
+	}
+	assert.Equal(t, 1, executeCount, "expected 1 ExecuteMultiShard call (batching disabled)")
+	expectResult(t, result, defaultSelectResult)
 }

--- a/go/vt/vtgate/engine/route_test.go
+++ b/go/vt/vtgate/engine/route_test.go
@@ -2054,3 +2054,259 @@ func TestInClauseBatchingDisabled(t *testing.T) {
 	assert.Equal(t, 1, executeCount, "expected 1 ExecuteMultiShard call (batching disabled)")
 	expectResult(t, result, defaultSelectResult)
 }
+
+func TestInClauseBatchingMultiIN(t *testing.T) {
+	sel := NewRoute(
+		Unsharded,
+		&vindexes.Keyspace{
+			Name:    "ks",
+			Sharded: false,
+		},
+		"select id from t where id in ::v1 and name in ::v2",
+		"select id from t where 1 != 1",
+	)
+
+	fields := sqltypes.MakeTestFields("id", "int64")
+
+	// v1 has 5 values (batch size 3 → 2 chunks), v2 has 7 values (batch size 3 → 3 chunks)
+	// Cartesian product: 2 × 3 = 6 batch executions
+	vc := &loggingVCursor{
+		shards:            []string{"0"},
+		inClauseBatchSize: 3,
+		results: []*sqltypes.Result{
+			sqltypes.MakeTestResult(fields, "1"),
+			sqltypes.MakeTestResult(fields, "2"),
+			sqltypes.MakeTestResult(fields, "3"),
+			sqltypes.MakeTestResult(fields, "4"),
+			sqltypes.MakeTestResult(fields, "5"),
+			sqltypes.MakeTestResult(fields, "6"),
+		},
+	}
+
+	bvs := map[string]*querypb.BindVariable{
+		"v1": {Type: querypb.Type_TUPLE, Values: make([]*querypb.Value, 5)},
+		"v2": {Type: querypb.Type_TUPLE, Values: make([]*querypb.Value, 7)},
+	}
+	for i := range bvs["v1"].Values {
+		bvs["v1"].Values[i] = &querypb.Value{Type: querypb.Type_INT64, Value: []byte(strconv.Itoa(i + 1))}
+	}
+	for i := range bvs["v2"].Values {
+		bvs["v2"].Values[i] = &querypb.Value{Type: querypb.Type_INT64, Value: []byte(strconv.Itoa(i + 100))}
+	}
+
+	result, err := sel.TryExecute(context.Background(), vc, bvs, false)
+	require.NoError(t, err)
+
+	executeCount := 0
+	for _, l := range vc.log {
+		if strings.HasPrefix(l, "ExecuteMultiShard") {
+			executeCount++
+		}
+	}
+	assert.Equal(t, 6, executeCount, "expected 2×3=6 batched ExecuteMultiShard calls")
+	assert.Len(t, result.Rows, 6)
+}
+
+func TestInClauseBatchingMultiINWithOrderBy(t *testing.T) {
+	sel := NewRoute(
+		Unsharded,
+		&vindexes.Keyspace{
+			Name:    "ks",
+			Sharded: false,
+		},
+		"select id from t where id in ::v1 and name in ::v2 order by id",
+		"select id from t where 1 != 1",
+	)
+	sel.OrderBy = []evalengine.OrderByParams{{
+		Col:             0,
+		WeightStringCol: -1,
+	}}
+
+	fields := sqltypes.MakeTestFields("id", "int64")
+
+	// v1: 4 values (2 chunks), v2: 4 values (2 chunks) → 4 batches
+	// Each batch returns results sorted, but the global order is mixed
+	vc := &loggingVCursor{
+		shards:            []string{"0"},
+		inClauseBatchSize: 3,
+		results: []*sqltypes.Result{
+			sqltypes.MakeTestResult(fields, "1", "5"),
+			sqltypes.MakeTestResult(fields, "3", "7"),
+			sqltypes.MakeTestResult(fields, "2", "6"),
+			sqltypes.MakeTestResult(fields, "4", "8"),
+		},
+	}
+
+	bvs := map[string]*querypb.BindVariable{
+		"v1": {Type: querypb.Type_TUPLE, Values: make([]*querypb.Value, 4)},
+		"v2": {Type: querypb.Type_TUPLE, Values: make([]*querypb.Value, 4)},
+	}
+	for i := range bvs["v1"].Values {
+		bvs["v1"].Values[i] = &querypb.Value{Type: querypb.Type_INT64, Value: []byte(strconv.Itoa(i + 1))}
+	}
+	for i := range bvs["v2"].Values {
+		bvs["v2"].Values[i] = &querypb.Value{Type: querypb.Type_INT64, Value: []byte(strconv.Itoa(i + 100))}
+	}
+
+	result, err := sel.TryExecute(context.Background(), vc, bvs, false)
+	require.NoError(t, err)
+
+	// 4 batch calls
+	executeCount := 0
+	for _, l := range vc.log {
+		if strings.HasPrefix(l, "ExecuteMultiShard") {
+			executeCount++
+		}
+	}
+	assert.Equal(t, 4, executeCount, "expected 2×2=4 batched calls")
+
+	// Results should be globally sorted
+	wantResult := sqltypes.MakeTestResult(fields, "1", "2", "3", "4", "5", "6", "7", "8")
+	expectResult(t, result, wantResult)
+}
+
+func TestInClauseBatchingMultiINOnlyOneLarge(t *testing.T) {
+	sel := NewRoute(
+		Unsharded,
+		&vindexes.Keyspace{
+			Name:    "ks",
+			Sharded: false,
+		},
+		"select id from t where id in ::v1 and name in ::v2",
+		"select id from t where 1 != 1",
+	)
+
+	fields := sqltypes.MakeTestFields("id", "int64")
+
+	// v1: 7 values (3 chunks at batch size 3), v2: 2 values (under threshold, 1 chunk)
+	// Only v1 is batched → 3 calls
+	vc := &loggingVCursor{
+		shards:            []string{"0"},
+		inClauseBatchSize: 3,
+		results: []*sqltypes.Result{
+			sqltypes.MakeTestResult(fields, "1", "2"),
+			sqltypes.MakeTestResult(fields, "3", "4"),
+			sqltypes.MakeTestResult(fields, "5"),
+		},
+	}
+
+	bvs := map[string]*querypb.BindVariable{
+		"v1": {Type: querypb.Type_TUPLE, Values: make([]*querypb.Value, 7)},
+		"v2": {Type: querypb.Type_TUPLE, Values: make([]*querypb.Value, 2)},
+	}
+	for i := range bvs["v1"].Values {
+		bvs["v1"].Values[i] = &querypb.Value{Type: querypb.Type_INT64, Value: []byte(strconv.Itoa(i + 1))}
+	}
+	for i := range bvs["v2"].Values {
+		bvs["v2"].Values[i] = &querypb.Value{Type: querypb.Type_INT64, Value: []byte(strconv.Itoa(i + 100))}
+	}
+
+	result, err := sel.TryExecute(context.Background(), vc, bvs, false)
+	require.NoError(t, err)
+
+	executeCount := 0
+	for _, l := range vc.log {
+		if strings.HasPrefix(l, "ExecuteMultiShard") {
+			executeCount++
+		}
+	}
+	assert.Equal(t, 3, executeCount, "only v1 should be batched (3 chunks)")
+	assert.Len(t, result.Rows, 5)
+}
+
+func TestInClauseBatchingStreaming(t *testing.T) {
+	sel := NewRoute(
+		Unsharded,
+		&vindexes.Keyspace{
+			Name:    "ks",
+			Sharded: false,
+		},
+		"select id from t where id in ::v1",
+		"select id from t where 1 != 1",
+	)
+
+	fields := sqltypes.MakeTestFields("id", "int64")
+
+	vc := &loggingVCursor{
+		shards:            []string{"0"},
+		inClauseBatchSize: 3,
+		results: []*sqltypes.Result{
+			sqltypes.MakeTestResult(fields, "1", "2", "3"),
+			sqltypes.MakeTestResult(fields, "4", "5", "6"),
+			sqltypes.MakeTestResult(fields, "7"),
+		},
+	}
+
+	bvs := map[string]*querypb.BindVariable{
+		"v1": {Type: querypb.Type_TUPLE, Values: make([]*querypb.Value, 7)},
+	}
+	for i := range bvs["v1"].Values {
+		bvs["v1"].Values[i] = &querypb.Value{Type: querypb.Type_INT64, Value: []byte(strconv.Itoa(i + 1))}
+	}
+
+	var results []*sqltypes.Result
+	err := sel.TryStreamExecute(context.Background(), vc, bvs, false, func(result *sqltypes.Result) error {
+		results = append(results, result)
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Streaming batching falls back to non-streaming, so we get ExecuteMultiShard calls
+	executeCount := 0
+	for _, l := range vc.log {
+		if strings.HasPrefix(l, "ExecuteMultiShard") {
+			executeCount++
+		}
+	}
+	assert.Equal(t, 3, executeCount, "expected 3 batched ExecuteMultiShard calls in streaming mode")
+
+	// Should receive one callback with all rows
+	require.Len(t, results, 1)
+	assert.Len(t, results[0].Rows, 7)
+}
+
+func TestInClauseBatchingStreamingWithOrderBy(t *testing.T) {
+	sel := NewRoute(
+		Unsharded,
+		&vindexes.Keyspace{
+			Name:    "ks",
+			Sharded: false,
+		},
+		"select id from t where id in ::v1 order by id",
+		"select id from t where 1 != 1",
+	)
+	sel.OrderBy = []evalengine.OrderByParams{{
+		Col:             0,
+		WeightStringCol: -1,
+	}}
+
+	fields := sqltypes.MakeTestFields("id", "int64")
+
+	vc := &loggingVCursor{
+		shards:            []string{"0"},
+		inClauseBatchSize: 3,
+		results: []*sqltypes.Result{
+			sqltypes.MakeTestResult(fields, "2", "5", "8"),
+			sqltypes.MakeTestResult(fields, "1", "4", "7"),
+			sqltypes.MakeTestResult(fields, "3"),
+		},
+	}
+
+	bvs := map[string]*querypb.BindVariable{
+		"v1": {Type: querypb.Type_TUPLE, Values: make([]*querypb.Value, 7)},
+	}
+	for i := range bvs["v1"].Values {
+		bvs["v1"].Values[i] = &querypb.Value{Type: querypb.Type_INT64, Value: []byte(strconv.Itoa(i + 1))}
+	}
+
+	var results []*sqltypes.Result
+	err := sel.TryStreamExecute(context.Background(), vc, bvs, false, func(result *sqltypes.Result) error {
+		results = append(results, result)
+		return nil
+	})
+	require.NoError(t, err)
+
+	require.Len(t, results, 1)
+	wantResult := sqltypes.MakeTestResult(fields, "1", "2", "3", "4", "5", "7", "8")
+	expectResult(t, results[0], wantResult)
+}

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -112,9 +112,10 @@ type (
 		Normalize  bool
 		StreamSize int
 		// AllowScatter will fail planning if set to false and a plan contains any scatter queries
-		AllowScatter        bool
-		WarmingReadsPercent int
-		QueryLogToFile      string
+		AllowScatter         bool
+		WarmingReadsPercent  int
+		InClauseBatchSize    int
+		QueryLogToFile       string
 	}
 
 	Executor struct {
@@ -1558,6 +1559,8 @@ func (e *Executor) initVConfig(warnOnShardedOnly bool, pv plancontext.PlannerVer
 		WarmingReadsPercent: e.config.WarmingReadsPercent,
 		WarmingReadsTimeout: warmingReadsQueryTimeout,
 		WarmingReadsChannel: e.warmingReadsChannel,
+
+		InClauseBatchSize: e.config.InClauseBatchSize,
 	}
 }
 

--- a/go/vt/vtgate/executorcontext/vcursor_impl.go
+++ b/go/vt/vtgate/executorcontext/vcursor_impl.go
@@ -91,6 +91,8 @@ type (
 		WarmingReadsPercent int
 		WarmingReadsTimeout time.Duration
 		WarmingReadsChannel chan bool
+
+		InClauseBatchSize int
 	}
 
 	// vcursor_impl needs these facilities to be able to be able to execute queries for vindexes
@@ -1628,6 +1630,10 @@ func (vc *VCursorImpl) GetPrepareData(stmtName string) *vtgatepb.PrepareData {
 
 func (vc *VCursorImpl) GetWarmingReadsPercent() int {
 	return vc.config.WarmingReadsPercent
+}
+
+func (vc *VCursorImpl) GetInClauseBatchSize() int {
+	return vc.config.InClauseBatchSize
 }
 
 func (vc *VCursorImpl) GetWarmingReadsChannel() chan bool {

--- a/go/vt/vtgate/planbuilder/operators/route.go
+++ b/go/vt/vtgate/planbuilder/operators/route.go
@@ -773,13 +773,13 @@ func isSpecialOrderBy(o OrderBy) bool {
 }
 
 func (r *Route) planOffsets(ctx *plancontext.PlanningContext) Operator {
-	// if operator is returning data from a single shard, we don't need to do anything more
 	if r.IsSingleShard() {
+		r.planSingleShardOrderBy(ctx)
 		return nil
 	}
 
-	// if we are getting results from multiple shards, we need to do a merge-sort
-	// between them to get the final output correctly sorted
+	// For multi-shard routes, add columns (and weight strings) as needed
+	// so the engine can merge-sort results from different shards.
 	ordering := r.Source.GetOrdering(ctx)
 	if len(ordering) == 0 {
 		return nil
@@ -805,6 +805,39 @@ func (r *Route) planOffsets(ctx *plancontext.PlanningContext) Operator {
 		r.Ordering = append(r.Ordering, o)
 	}
 	return nil
+}
+
+// planSingleShardOrderBy attempts to record ORDER BY column offsets for
+// single-shard routes. This lets the engine re-sort results when IN-clause
+// batching splits a query into multiple round trips. We only use FindCol
+// (no AddColumn) so the SQL sent to MySQL is unchanged. If columns can't
+// be resolved (e.g., SELECT * without schema tracking), we silently skip —
+// batching will still work, just without global re-sort guarantees.
+func (r *Route) planSingleShardOrderBy(ctx *plancontext.PlanningContext) {
+	// GetOrdering can trigger schema tracking errors for SELECT * queries.
+	// Recover gracefully — ordering info is best-effort for single-shard.
+	defer func() {
+		if rec := recover(); rec != nil {
+			r.Ordering = nil
+		}
+	}()
+
+	ordering := r.Source.GetOrdering(ctx)
+	for _, order := range ordering {
+		if isSpecialOrderBy(order) {
+			continue
+		}
+		offset := r.FindCol(ctx, order.SimplifiedExpr, true)
+		if offset == -1 {
+			continue
+		}
+		r.Ordering = append(r.Ordering, RouteOrdering{
+			AST:       order.Inner.Expr,
+			Offset:    offset,
+			WOffset:   -1,
+			Direction: order.Inner.Direction,
+		})
+	}
 }
 
 func weightStringFor(expr sqlparser.Expr) sqlparser.Expr {

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -1278,6 +1278,7 @@
           "Sharded": true
         },
         "FieldQuery": "select col from ref where 1 != 1",
+        "OrderBy": "0 ASC",
         "Query": "select col from ref order by ref.col asc"
       },
       "TablesUsed": [

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.json
@@ -4865,6 +4865,7 @@
           "Sharded": true
         },
         "FieldQuery": "select user_id, col1, col2 from authoritative where 1 != 1",
+        "OrderBy": "0 ASC",
         "Query": "select user_id, col1, col2 from authoritative where user_id = 5 order by authoritative.user_id asc",
         "Values": [
           "5"
@@ -4891,6 +4892,7 @@
           "Sharded": true
         },
         "FieldQuery": "select user_id, col1, col2 from authoritative where 1 != 1 group by user_id",
+        "OrderBy": "0 ASC",
         "Query": "select user_id, col1, col2 from authoritative where user_id = 5 group by user_id having count(user_id) = 6 order by authoritative.user_id asc",
         "Values": [
           "5"

--- a/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
@@ -3278,6 +3278,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u_tbl1.id from u_tbl1 where 1 != 1",
+            "OrderBy": "0 ASC",
             "Query": "select u_tbl1.id from u_tbl1 order by id asc limit 1 for update"
           },
           {
@@ -3818,6 +3819,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u_tbl2.id from u_tbl2 where 1 != 1",
+            "OrderBy": "0 ASC",
             "Query": "select u_tbl2.id from u_tbl2 order by id asc limit 2 for update"
           },
           {

--- a/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
@@ -305,6 +305,7 @@
               "Sharded": false
             },
             "FieldQuery": "select kcu.`constraint_name` as `constraint_name`, kcu.`column_name` as `column_name`, kcu.referenced_table_name as referenced_table_name, kcu.referenced_column_name as referenced_column_name, kcu.ordinal_position as ordinal_position, kcu.`table_name` as `table_name` from information_schema.key_column_usage as kcu where 1 != 1",
+            "OrderBy": "4 ASC",
             "Query": "select kcu.`constraint_name` as `constraint_name`, kcu.`column_name` as `column_name`, kcu.referenced_table_name as referenced_table_name, kcu.referenced_column_name as referenced_column_name, kcu.ordinal_position as ordinal_position, kcu.`table_name` as `table_name` from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname /* VARCHAR */ and kcu.referenced_column_name is not null order by kcu.ordinal_position asc",
             "SysTableTableSchema": "[:v1]"
           },

--- a/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
@@ -305,6 +305,7 @@
               "Sharded": false
             },
             "FieldQuery": "select kcu.`constraint_name` as `constraint_name`, kcu.`column_name` as `column_name`, kcu.referenced_table_name as referenced_table_name, kcu.referenced_column_name as referenced_column_name, kcu.ordinal_position as ordinal_position, kcu.`table_name` as `table_name` from information_schema.key_column_usage as kcu where 1 != 1",
+            "OrderBy": "4 ASC",
             "Query": "select kcu.`constraint_name` as `constraint_name`, kcu.`column_name` as `column_name`, kcu.referenced_table_name as referenced_table_name, kcu.referenced_column_name as referenced_column_name, kcu.ordinal_position as ordinal_position, kcu.`table_name` as `table_name` from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname /* VARCHAR */ and kcu.referenced_column_name is not null order by kcu.ordinal_position asc",
             "SysTableTableSchema": "[:v1]"
           },

--- a/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
@@ -195,6 +195,7 @@
           "Sharded": true
         },
         "FieldQuery": "select col from `user` where 1 != 1",
+        "OrderBy": "0 ASC",
         "Query": "select col from `user` where id = 1 order by col asc",
         "Values": [
           "1"
@@ -603,6 +604,7 @@
               "Sharded": true
             },
             "FieldQuery": "select `user`.col1 as a, `user`.col2, `user`.id from `user` where 1 != 1",
+            "OrderBy": "0 ASC",
             "Query": "select `user`.col1 as a, `user`.col2, `user`.id from `user` where `user`.id = 1 order by `user`.col1 asc",
             "Values": [
               "1"
@@ -678,6 +680,7 @@
               "Sharded": true
             },
             "FieldQuery": "select `user`.col1 as a, `user`.col2, `user`.id from `user` where 1 != 1",
+            "OrderBy": "0 ASC",
             "Query": "select `user`.col1 as a, `user`.col2, `user`.id from `user` where `user`.id = 1 order by `user`.col1 asc",
             "Values": [
               "1"
@@ -1219,6 +1222,7 @@
           "Sharded": true
         },
         "FieldQuery": "select col from `user` as route1 where 1 != 1",
+        "OrderBy": "0 ASC",
         "Query": "select col from `user` as route1 where id = 1 order by route1.col asc",
         "Values": [
           "1"

--- a/go/vt/vtgate/planbuilder/testdata/reference_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/reference_cases.json
@@ -182,6 +182,7 @@
           "Sharded": true
         },
         "FieldQuery": "select u.id from (select a.id, a.u_id from ref_with_source as a where 1 != 1) as u left join ref_with_source as u0 on u.u_id = u0.u_uid where 1 != 1",
+        "OrderBy": "0 ASC",
         "Query": "select u.id from (select a.id, a.u_id from ref_with_source as a where a.id in (3) order by a.d_at asc limit 1) as u left join ref_with_source as u0 on u.u_id = u0.u_uid order by u.id asc"
       },
       "TablesUsed": [

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -846,6 +846,7 @@
           "Sharded": true
         },
         "FieldQuery": "select col, trim((select user_name from `user` where 1 != 1)) as val from user_extra where 1 != 1 group by col",
+        "OrderBy": "1 ASC",
         "Query": "select col, trim((select user_name from `user` where id = 3)) as val from user_extra where user_id = 3 group by col order by trim((select `user`.user_name from `user` where `user`.id = 3)) asc",
         "Values": [
           "3"
@@ -1458,6 +1459,7 @@
           "Sharded": true
         },
         "FieldQuery": "select user0_.col as col0_ from `user` as user0_ where 1 != 1",
+        "OrderBy": "0 DESC",
         "Query": "select user0_.col as col0_ from `user` as user0_ where id = 1 order by user0_.col desc limit 2",
         "Values": [
           "1"
@@ -1484,6 +1486,7 @@
           "Sharded": true
         },
         "FieldQuery": "select user0_.col as col0_ from `user` as user0_ where 1 != 1",
+        "OrderBy": "0 DESC",
         "Query": "select user0_.col as col0_ from `user` as user0_ where id = 1 order by user0_.col desc limit 3",
         "Values": [
           "1"
@@ -6372,10 +6375,10 @@
         },
         "FieldQuery": "select r from (select rank() over (partition by col) as r from `user` where 1 != 1) as t where 1 != 1",
         "Query": "select r from (select rank() over (partition by col) as r from `user` where id = 1) as t",
-        "Vindex": "user_index",
         "Values": [
           "1"
-        ]
+        ],
+        "Vindex": "user_index"
       },
       "TablesUsed": [
         "user.user"

--- a/go/vt/vtgate/planbuilder/testdata/sysschema_default.json
+++ b/go/vt/vtgate/planbuilder/testdata/sysschema_default.json
@@ -36,6 +36,7 @@
           "Sharded": false
         },
         "FieldQuery": "select t.table_schema, t.`table_name`, c.`column_name`, c.column_type from information_schema.`tables` as t, information_schema.`columns` as c where 1 != 1",
+        "OrderBy": "0 ASC COLLATE utf8mb3_general_ci, 1 ASC COLLATE utf8mb3_general_ci, 2 ASC COLLATE utf8mb3_general_ci",
         "Query": "select t.table_schema, t.`table_name`, c.`column_name`, c.column_type from information_schema.`tables` as t, information_schema.`columns` as c where t.table_schema = :__vtschemaname /* VARCHAR */ and c.table_schema = :__vtschemaname /* VARCHAR */ and c.table_schema = t.table_schema and c.`table_name` = t.`table_name` order by t.table_schema asc, t.`table_name` asc, c.`column_name` asc",
         "SysTableTableSchema": "['user']"
       }

--- a/go/vt/vtgate/planbuilder/testdata/tpcc_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/tpcc_cases.json
@@ -547,6 +547,7 @@
           "Sharded": true
         },
         "FieldQuery": "select c_balance, c_first, c_middle, c_id from customer1 where 1 != 1",
+        "OrderBy": "1 ASC",
         "Query": "select c_balance, c_first, c_middle, c_id from customer1 where c_w_id = 840 and c_d_id = 1 and c_last = 'test' order by customer1.c_first asc",
         "Values": [
           "840"
@@ -599,6 +600,7 @@
           "Sharded": true
         },
         "FieldQuery": "select o_id, o_carrier_id, o_entry_d from orders1 where 1 != 1",
+        "OrderBy": "0 DESC",
         "Query": "select o_id, o_carrier_id, o_entry_d from orders1 where o_w_id = 9894 and o_d_id = 3 and o_c_id = 159 order by orders1.o_id desc",
         "Values": [
           "9894"
@@ -651,6 +653,7 @@
           "Sharded": true
         },
         "FieldQuery": "select no_o_id from new_orders1 where 1 != 1",
+        "OrderBy": "0 ASC",
         "Query": "select no_o_id from new_orders1 where no_d_id = 689 and no_w_id = 15 order by new_orders1.no_o_id asc limit 1 for update",
         "Values": [
           "15"

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -168,6 +168,8 @@ var (
 	warmingReadsPercent      = 0
 	warmingReadsQueryTimeout = 5 * time.Second
 	warmingReadsConcurrency  = 500
+
+	inClauseBatchSize = 0
 )
 
 func registerFlags(fs *pflag.FlagSet) {
@@ -205,6 +207,7 @@ func registerFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&warmingReadsPercent, "warming-reads-percent", 0, "Percentage of reads on the primary to forward to replicas. Useful for keeping buffer pools warm")
 	fs.IntVar(&warmingReadsConcurrency, "warming-reads-concurrency", 500, "Number of concurrent warming reads allowed")
 	fs.DurationVar(&warmingReadsQueryTimeout, "warming-reads-query-timeout", 5*time.Second, "Timeout of warming read queries")
+	utils.SetFlagIntVar(fs, &inClauseBatchSize, "in-clause-batch-size", inClauseBatchSize, "Maximum number of values per IN clause sent to MySQL. When set, VTGate splits large IN clauses into multiple queries and merges results. 0 disables batching.")
 
 	viperutil.BindFlags(fs,
 		enableOnlineDDL,
@@ -380,6 +383,7 @@ func Init(
 		StreamSize:          streamBufferSize,
 		AllowScatter:        !noScatter,
 		WarmingReadsPercent: warmingReadsPercent,
+		InClauseBatchSize:   inClauseBatchSize,
 		QueryLogToFile:      queryLogToFile,
 	}
 


### PR DESCRIPTION
### Background / Why?

Production queries on the `vifl` keyspace have IN clauses with 5,000–20,000+ elements on non-vindex columns (e.g., `SELECT ... FROM channels WHERE team_id = ? AND id IN (...) LIMIT ?`). These are expensive for MySQL. Today we batch these manually per-query in the webapp repo. This prototype moves that logic into VTGate itself so all applications benefit without code changes.

### Summary

- **New flag `--in-clause-batch-size`** (default 0 = disabled). When set, VTGate automatically splits large IN-clause TUPLE bind variables into batches of that size.
- **Batching logic in `Route.TryExecute()`**: after `findRoute()` resolves shards, scans per-shard bind vars for TUPLE types exceeding the threshold. Chunks the tuple, executes one `ExecuteMultiShard` call per chunk, concatenates results, re-sorts if `Route.OrderBy` is populated.
- **Skips vindex routing vars** (`__vals`, `__vals0`, etc.) which are already optimally split across shards.
- **`Limit` primitive above `Route`** handles re-limiting for free — each batch returns up to LIMIT rows from MySQL, the Limit primitive trims the merged result.
- **Stats counter `InClauseBatchCount`** for observability.

**Prototype limitations:**
- ORDER BY not re-applied for single-shard queries (`Route.OrderBy` is only populated for multi-shard scatter). Most target queries don't have ORDER BY.
- GROUP BY with aggregation functions (COUNT, SUM) split across batches will produce incorrect results.
- Only `TryExecute` — streaming (`TryStreamExecute`) is not batched.

### Testing

- Unit tests for all three helper functions (`findLargestTupleBV`, `chunkTupleValues`, `cloneBindVarsWithTuple`)
- Integration tests for Route batching: basic batching, ORDER BY re-sort, small-tuple passthrough, `__vals` skip, disabled mode
- Full engine test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)