### PR TITLE
Backport vitessio#19872: cache proto3 row encoding to reduce query consolidation memory

### DIFF
--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -44,6 +44,7 @@ Flags:
       --config-path strings                                              Paths to search for config files in. (default [{{ .Workdir }}])
       --config-persistence-min-interval duration                         minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                               Config file type (omit to infer config type from file extension).
+      --consolidator-cache-proto3-rows                                   If true, the consolidation leader pre-caches proto3-encoded rows so that waiters avoid redundant encoding work.
       --consolidator-query-waiter-cap int                                Configure the maximum number of clients allowed to wait on the consolidator.
       --consolidator-query-waiter-cap-method string                      Configure the method when consolidator waiter cap is exceeded. Options: fallthrough, reject. (default "fallthrough")
       --consolidator-stream-query-size int                               Configure the stream consolidator query size in bytes. Setting to 0 disables the stream consolidator. (default 2097152)

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -78,6 +78,7 @@ Flags:
       --config-path strings                                              Paths to search for config files in. (default [{{ .Workdir }}])
       --config-persistence-min-interval duration                         minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                               Config file type (omit to infer config type from file extension).
+      --consolidator-cache-proto3-rows                                   If true, the consolidation leader pre-caches proto3-encoded rows so that waiters avoid redundant encoding work.
       --consolidator-query-waiter-cap int                                Configure the maximum number of clients allowed to wait on the consolidator.
       --consolidator-query-waiter-cap-method string                      Configure the method when consolidator waiter cap is exceeded. Options: fallthrough, reject. (default "fallthrough")
       --consolidator-stream-query-size int                               Configure the stream consolidator query size in bytes. Setting to 0 disables the stream consolidator. (default 2097152)

--- a/go/sqltypes/cached_size.go
+++ b/go/sqltypes/cached_size.go
@@ -25,7 +25,7 @@ func (cached *Result) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(112)
+		size += int64(144)
 	}
 	// field Fields []*vitess.io/vitess/go/vt/proto/query.Field
 	{
@@ -50,6 +50,13 @@ func (cached *Result) CachedSize(alloc bool) int64 {
 	size += hack.RuntimeAllocSize(int64(len(cached.SessionStateChanges)))
 	// field Info string
 	size += hack.RuntimeAllocSize(int64(len(cached.Info)))
+	// field proto3Rows []*vitess.io/vitess/go/vt/proto/query.Row
+	{
+		size += hack.RuntimeAllocSize(int64(cap(cached.proto3Rows)) * int64(8))
+		for _, elem := range cached.proto3Rows {
+			size += elem.CachedSize(true)
+		}
+	}
 	return size
 }
 func (cached *Value) CachedSize(alloc bool) int64 {

--- a/go/sqltypes/proto3.go
+++ b/go/sqltypes/proto3.go
@@ -94,17 +94,25 @@ func proto3ToRows(fields []*querypb.Field, rows []*querypb.Row) [][]Value {
 	return result
 }
 
-// ResultToProto3 converts Result to proto3.
 func ResultToProto3(qr *Result) *querypb.QueryResult {
 	if qr == nil {
 		return nil
+	}
+	// This read is susceptible to TOCTOU if proto3Rows is populated
+	// concurrently, but the worst case is a redundant RowsToProto3 call.
+	// In the consolidation path this can't happen today (the leader sets
+	// the cached value before releasing the RWMutex), but the fallback is
+	// harmless.
+	rows := qr.proto3Rows
+	if rows == nil {
+		rows = RowsToProto3(qr.Rows)
 	}
 	return &querypb.QueryResult{
 		Fields:              qr.Fields,
 		RowsAffected:        qr.RowsAffected,
 		InsertId:            qr.InsertID,
 		InsertIdChanged:     qr.InsertIDChanged,
-		Rows:                RowsToProto3(qr.Rows),
+		Rows:                rows,
 		Info:                qr.Info,
 		SessionStateChanges: qr.SessionStateChanges,
 	}

--- a/go/sqltypes/proto3_test.go
+++ b/go/sqltypes/proto3_test.go
@@ -17,6 +17,10 @@ limitations under the License.
 package sqltypes
 
 import (
+	"fmt"
+	"runtime"
+	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -328,5 +332,228 @@ func TestProto3ValuesEqual(t *testing.T) {
 		},
 	} {
 		require.Equal(t, tc.expected, Proto3ValuesEqual(tc.v1, tc.v2))
+	}
+}
+
+func TestResultToProto3_CachedRows(t *testing.T) {
+	fields := []*querypb.Field{{
+		Name: "col1",
+		Type: VarChar,
+	}, {
+		Name: "col2",
+		Type: Int64,
+	}}
+	result := &Result{
+		Fields:       fields,
+		RowsAffected: 2,
+		Rows: [][]Value{{
+			TestValue(VarChar, "aa"),
+			TestValue(Int64, "1"),
+		}, {
+			TestValue(VarChar, "bb"),
+			TestValue(Int64, "2"),
+		}},
+	}
+
+	uncached := ResultToProto3(result)
+	require.Len(t, uncached.Rows, 2)
+
+	result.CacheProto3Rows()
+
+	cached := ResultToProto3(result)
+	require.True(t, proto.Equal(uncached, cached), "cached and uncached proto3 results differ")
+
+	require.Same(t, cached.Rows[0], result.proto3Rows[0])
+	require.Same(t, cached.Rows[1], result.proto3Rows[1])
+}
+
+func TestResultToProto3_NilAndEmptyCache(t *testing.T) {
+	require.Nil(t, ResultToProto3(nil))
+	var nilResult *Result
+	nilResult.CacheProto3Rows() // does not panic
+
+	result := &Result{
+		Fields: []*querypb.Field{{Name: "col1", Type: VarChar}},
+	}
+	result.CacheProto3Rows()
+	require.Nil(t, result.proto3Rows)
+
+	p3 := ResultToProto3(result)
+	require.NotNil(t, p3)
+	require.Empty(t, p3.Rows)
+}
+
+func TestCopy_DoesNotPropagateProto3RowCache(t *testing.T) {
+	result := &Result{
+		Fields: []*querypb.Field{{Name: "col1", Type: Int64}},
+		Rows: [][]Value{{
+			TestValue(Int64, "42"),
+		}},
+	}
+	result.CacheProto3Rows()
+	require.NotNil(t, result.proto3Rows)
+
+	require.Nil(t, result.ShallowCopy().proto3Rows)
+	require.Nil(t, result.Copy().proto3Rows)
+}
+
+func TestMutations_InvalidateCachedProto3Rows(t *testing.T) {
+	resultWithProto3FieldPopulated := func(t *testing.T) *Result {
+		t.Helper()
+		result := &Result{
+			Fields: []*querypb.Field{{Name: "col1", Type: VarChar}},
+			Rows: [][]Value{{
+				TestValue(VarChar, "hello"),
+			}},
+		}
+		result.CacheProto3Rows()
+		require.NotNil(t, result.proto3Rows)
+		return result
+	}
+
+	t.Run("AppendResult", func(t *testing.T) {
+		result := resultWithProto3FieldPopulated(t)
+		result.AppendResult(&Result{
+			Rows: [][]Value{{
+				TestValue(VarChar, "world"),
+			}},
+		})
+		require.Nil(t, result.proto3Rows, "AppendResult must invalidate proto3Rows cache")
+
+		p3 := ResultToProto3(result)
+		require.Len(t, p3.Rows, 2)
+	})
+
+	t.Run("Repair", func(t *testing.T) {
+		result := resultWithProto3FieldPopulated(t)
+		result.Repair([]*querypb.Field{{Name: "col1", Type: VarBinary}})
+		require.Nil(t, result.proto3Rows, "Repair must invalidate proto3Rows cache")
+
+		p3 := ResultToProto3(result)
+		require.Len(t, p3.Rows, 1)
+	})
+}
+
+// makeTestResult builds a Result with numRows rows, each containing 5 columns
+// of mixed types. Row values are deterministic so benchmarks are reproducible.
+func makeTestResult(numRows int) *Result {
+	fields := MakeTestFields(
+		"col1|col2|col3|col4|col5",
+		"int64|varchar|varchar|float64|int64",
+	)
+	rows := make([][]Value, numRows)
+	for i := range rows {
+		rows[i] = []Value{
+			TestValue(Int64, strconv.Itoa(i)),
+			TestValue(VarChar, fmt.Sprintf("val-%06d", i)),
+			TestValue(VarChar, fmt.Sprintf("val-%06d-longervalue", i)),
+			TestValue(Float64, fmt.Sprintf("%d.%02d", i/100, i%100)),
+			TestValue(Int64, strconv.Itoa(i%2)),
+		}
+	}
+	return &Result{
+		Fields:       fields,
+		RowsAffected: uint64(numRows),
+		Rows:         rows,
+	}
+}
+
+// BenchmarkResultToProto3 measures per-call allocation cost of ResultToProto3
+// with and without CacheProto3Rows, across different result sizes.
+func BenchmarkResultToProto3(b *testing.B) {
+	for _, numRows := range []int{100, 1000, 10000} {
+		result := makeTestResult(numRows)
+
+		b.Run(fmt.Sprintf("rows=%d/uncached", numRows), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				ResultToProto3(result)
+			}
+		})
+
+		b.Run(fmt.Sprintf("rows=%d/cached", numRows), func(b *testing.B) {
+			result.CacheProto3Rows()
+			b.ReportAllocs()
+			for b.Loop() {
+				ResultToProto3(result)
+			}
+		})
+	}
+}
+
+// BenchmarkConsolidationFanOut simulates the consolidator scenario: one shared
+// Result is read by N concurrent goroutines calling ResultToProto3. Reports
+// total heap bytes allocated across all waiters.
+func BenchmarkConsolidationFanOut(b *testing.B) {
+	const numRows = 10000
+
+	for _, waiters := range []int{1, 10, 50} {
+		result := makeTestResult(numRows)
+
+		b.Run(fmt.Sprintf("waiters=%d/uncached", waiters), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				var wg sync.WaitGroup
+				wg.Add(waiters)
+				for range waiters {
+					go func() {
+						defer wg.Done()
+						ResultToProto3(result)
+					}()
+				}
+				wg.Wait()
+			}
+		})
+
+		b.Run(fmt.Sprintf("waiters=%d/cached", waiters), func(b *testing.B) {
+			result.CacheProto3Rows()
+			b.ReportAllocs()
+			for b.Loop() {
+				var wg sync.WaitGroup
+				wg.Add(waiters)
+				for range waiters {
+					go func() {
+						defer wg.Done()
+						ResultToProto3(result)
+					}()
+				}
+				wg.Wait()
+			}
+		})
+
+		// Report aggregate heap delta for a single iteration so the savings
+		// are visible in absolute terms, not just per-op.
+		b.Run(fmt.Sprintf("waiters=%d/heap-delta", waiters), func(b *testing.B) {
+			for _, cached := range []bool{false, true} {
+				label := "uncached"
+				r := makeTestResult(numRows)
+				if cached {
+					label = "cached"
+					r.CacheProto3Rows()
+				}
+				b.Run(label, func(b *testing.B) {
+					b.ReportAllocs()
+					for b.Loop() {
+						runtime.GC()
+						var before runtime.MemStats
+						runtime.ReadMemStats(&before)
+
+						var wg sync.WaitGroup
+						wg.Add(waiters)
+						for range waiters {
+							go func() {
+								defer wg.Done()
+								ResultToProto3(r)
+							}()
+						}
+						wg.Wait()
+
+						var after runtime.MemStats
+						runtime.ReadMemStats(&after)
+						b.ReportMetric(float64(after.TotalAlloc-before.TotalAlloc), "heap-bytes/op")
+					}
+				})
+			}
+		})
 	}
 }

--- a/go/sqltypes/result.go
+++ b/go/sqltypes/result.go
@@ -36,6 +36,12 @@ type Result struct {
 	SessionStateChanges string           `json:"session_state_changes"`
 	StatusFlags         uint16           `json:"status_flags"`
 	Info                string           `json:"info"`
+
+	// proto3Rows caches the proto3-encoded representation of Rows, avoiding
+	// redundant encoding when multiple consumers share the same Result (i.e.
+	// query consolidation). Not populated for the non-consolidation flow;
+	// don't depend on it being present.
+	proto3Rows []*querypb.Row
 }
 
 //goland:noinspection GoUnusedConst
@@ -76,6 +82,7 @@ type MultiResultStream interface {
 // Repair fixes the type info in the rows
 // to conform to the supplied field types.
 func (result *Result) Repair(fields []*querypb.Field) {
+	result.proto3Rows = nil
 	// Usage of j is intentional.
 	for j, f := range fields {
 		for _, r := range result.Rows {
@@ -119,6 +126,7 @@ func (result *Result) Copy() *Result {
 			out.Rows = append(out.Rows, CopyRow(r))
 		}
 	}
+	// proto3Rows is intentionally not propagated: callers may modify Rows
 	return out
 }
 
@@ -132,6 +140,15 @@ func (result *Result) ShallowCopy() *Result {
 		Info:                result.Info,
 		SessionStateChanges: result.SessionStateChanges,
 		Rows:                result.Rows,
+		// proto3Rows is intentionally not propagated: callers may modify Rows
+	}
+}
+
+func (result *Result) CacheProto3Rows() {
+	// result can be nil when the query errors out (e.g. execDBConn returns
+	// a nil Result alongside an error).
+	if result != nil && len(result.Rows) > 0 {
+		result.proto3Rows = RowsToProto3(result.Rows)
 	}
 }
 
@@ -339,6 +356,7 @@ func (result *Result) StripMetadata(incl querypb.ExecuteOptions_IncludedFields) 
 // to another result.Note currently it doesn't handle cases like
 // if two results have different fields.We will enhance this function.
 func (result *Result) AppendResult(src *Result) {
+	result.proto3Rows = nil
 	result.RowsAffected += src.RowsAffected
 	if src.InsertIDUpdated() {
 		result.InsertID = src.InsertID

--- a/go/sync2/consolidator.go
+++ b/go/sync2/consolidator.go
@@ -30,6 +30,7 @@ type Consolidator interface {
 	Create(string) (PendingResult, bool)
 	Items() []ConsolidatorCacheItem
 	Record(query string)
+	TotalWaiterCount() int64
 }
 
 // PendingResult is a wrapper for result of a query.
@@ -40,7 +41,8 @@ type PendingResult interface {
 	SetResult(*sqltypes.Result)
 	Result() *sqltypes.Result
 	Wait()
-	AddWaiterCounter(int64) *int64
+	HasWaiters() bool
+	AddWaiterCounter(int64)
 }
 
 type consolidator struct {
@@ -68,6 +70,7 @@ type pendingResult struct {
 	query        string
 	result       *sqltypes.Result
 	err          error
+	waiterCount  atomic.Int64
 }
 
 // Create adds a query to currently executing queries and acquires a
@@ -117,6 +120,10 @@ func (rs *pendingResult) SetResult(res *sqltypes.Result) {
 	rs.result = res
 }
 
+func (rs *pendingResult) HasWaiters() bool {
+	return rs.waiterCount.Load() > 0
+}
+
 // Wait waits for the original query to complete execution. Wait should
 // be invoked for duplicate queries.
 func (rs *pendingResult) Wait() {
@@ -124,9 +131,11 @@ func (rs *pendingResult) Wait() {
 	rs.executing.RLock()
 }
 
-func (rs *pendingResult) AddWaiterCounter(c int64) *int64 {
+func (rs *pendingResult) AddWaiterCounter(c int64) {
+	// Non-atomic pair is benign: ConsolidatorQueryWaiterCap is a soft limit and
+	// the per-waiter count is only checked before Broadcast().
+	rs.waiterCount.Add(c)
 	atomic.AddInt64(rs.consolidator.totalWaiterCount, c)
-	return rs.consolidator.totalWaiterCount
 }
 
 // ConsolidatorCache is a thread-safe object used for counting how often recent
@@ -136,6 +145,10 @@ func (rs *pendingResult) AddWaiterCounter(c int64) *int64 {
 type ConsolidatorCache struct {
 	*cache.LRUCache[*ccount]
 	totalWaiterCount *int64
+}
+
+func (cc *ConsolidatorCache) TotalWaiterCount() int64 {
+	return atomic.LoadInt64(cc.totalWaiterCount)
 }
 
 // NewConsolidatorCache creates a new cache with the given capacity.

--- a/go/sync2/consolidator_test.go
+++ b/go/sync2/consolidator_test.go
@@ -21,6 +21,8 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"vitess.io/vitess/go/sqltypes"
 )
 
@@ -49,9 +51,23 @@ func TestAddWaiterCount(t *testing.T) {
 	wgAdd.Wait()
 	wgSub.Wait()
 
-	if *pr.AddWaiterCounter(0) != 0 {
-		t.Fatalf("Expect 0 totalWaiterCount but got: %v", *pr.AddWaiterCounter(0))
-	}
+	require.Zero(t, con.TotalWaiterCount(), "expected 0 totalWaiterCount")
+}
+
+func TestHasWaiters(t *testing.T) {
+	con := NewConsolidator()
+	sql := "select * from SomeTable"
+
+	orig, created := con.Create(sql)
+	require.True(t, created, "expected consolidator to register a new entry")
+	require.False(t, orig.HasWaiters(), "expected no waiters for a fresh entry")
+
+	_, created = con.Create(sql)
+	require.False(t, created, "did not expect consolidator to register a new entry")
+	require.True(t, orig.HasWaiters(), "expected waiters after a duplicate Create")
+
+	orig.SetResult(&sqltypes.Result{})
+	orig.Broadcast()
 }
 
 func TestConsolidator(t *testing.T) {

--- a/go/sync2/fake_consolidator.go
+++ b/go/sync2/fake_consolidator.go
@@ -30,7 +30,8 @@ type FakeConsolidator struct {
 	// CreateReturnCreated pre-configures the return value of Create calls.
 	CreateReturn *FakeConsolidatorCreateReturn
 	// RecordCalls can be usd to inspect Record calls.
-	RecordCalls []string
+	RecordCalls      []string
+	totalWaiterCount int64
 }
 
 // FakeConsolidatorCreateReturn wraps the two return values of a call to
@@ -53,10 +54,10 @@ type FakePendingResult struct {
 	WaitCalls int
 	// AddWaiterCounterCalls can be used to inspect AddWaiterCounter calls.
 	AddWaiterCounterCalls []int64
-	// WaiterCount simulates the current waiter count
-	WaiterCount int64
-	err         error
-	result      *sqltypes.Result
+	WaiterCount           int64
+	Consolidator          *FakeConsolidator
+	err                   error
+	result                *sqltypes.Result
 }
 
 var (
@@ -85,6 +86,14 @@ func (fc *FakeConsolidator) Record(sql string) {
 // Items is currently a no-op.
 func (fc *FakeConsolidator) Items() []ConsolidatorCacheItem {
 	return nil
+}
+
+func (fc *FakeConsolidator) TotalWaiterCount() int64 {
+	return fc.totalWaiterCount
+}
+
+func (fc *FakeConsolidator) SetTotalWaiterCount(count int64) {
+	fc.totalWaiterCount = count
 }
 
 // Broadcast records the Broadcast call for later verification.
@@ -117,9 +126,13 @@ func (fr *FakePendingResult) Wait() {
 	fr.WaitCalls++
 }
 
+func (fr *FakePendingResult) HasWaiters() bool {
+	return fr.WaiterCount > 0
+}
+
 // AddWaiterCounter records the call and simulates waiter count changes.
-func (fr *FakePendingResult) AddWaiterCounter(delta int64) *int64 {
+func (fr *FakePendingResult) AddWaiterCounter(delta int64) {
 	fr.AddWaiterCounterCalls = append(fr.AddWaiterCounterCalls, delta)
 	fr.WaiterCount += delta
-	return &fr.WaiterCount
+	fr.Consolidator.totalWaiterCount += delta
 }

--- a/go/vt/proto/query/cached_size.go
+++ b/go/vt/proto/query/cached_size.go
@@ -86,7 +86,6 @@ func (cached *QueryWarning) CachedSize(alloc bool) int64 {
 	}
 	return size
 }
-
 func (cached *Row) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)
@@ -109,7 +108,6 @@ func (cached *Row) CachedSize(alloc bool) int64 {
 	}
 	return size
 }
-
 func (cached *Target) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)

--- a/go/vt/proto/query/cached_size.go
+++ b/go/vt/proto/query/cached_size.go
@@ -86,6 +86,30 @@ func (cached *QueryWarning) CachedSize(alloc bool) int64 {
 	}
 	return size
 }
+
+func (cached *Row) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(96)
+	}
+	// field Lengths []int64
+	{
+		size += hack.RuntimeAllocSize(int64(cap(cached.Lengths)) * int64(8))
+	}
+	// field Values []byte
+	{
+		size += hack.RuntimeAllocSize(int64(cap(cached.Values)))
+	}
+	// field unknownFields google.golang.org/protobuf/runtime/protoimpl.UnknownFields
+	{
+		size += hack.RuntimeAllocSize(int64(cap(cached.unknownFields)))
+	}
+	return size
+}
+
 func (cached *Target) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -721,12 +721,15 @@ func (qre *QueryExecutor) execSelect() (*sqltypes.Result, error) {
 			} else {
 				defer conn.Recycle()
 				res, err := qre.execDBConn(conn.Conn, sql, true)
+				if qre.tsv.config.ConsolidatorCacheProto3Rows && q.HasWaiters() {
+					res.CacheProto3Rows()
+				}
 				q.SetResult(res)
 				q.SetErr(err)
 			}
 		} else {
 			waiterCap := qre.tsv.config.ConsolidatorQueryWaiterCap
-			if waiterCap == 0 || *q.AddWaiterCounter(0) <= waiterCap {
+			if waiterCap == 0 || qre.tsv.qe.consolidator.TotalWaiterCount() <= waiterCap {
 				qre.logStats.QuerySources |= tabletenv.QuerySourceConsolidator
 				startTime := time.Now()
 				q.Wait()

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1423,7 +1423,7 @@ func TestQueryExecutorShouldConsolidate(t *testing.T) {
 
 			// Set up consolidator pre-conditions.
 
-			fakePendingResult := &sync2.FakePendingResult{}
+			fakePendingResult := &sync2.FakePendingResult{Consolidator: fakeConsolidator}
 			fakePendingResult.SetResult(result)
 			fakeConsolidator.CreateReturn = &sync2.FakeConsolidatorCreateReturn{
 				Created:       !tcase.consolidatorHasIdenticalQuery,
@@ -1494,10 +1494,11 @@ func TestQueryExecutorConsolidatorWaiterCapFallback(t *testing.T) {
 	}
 
 	// Set up consolidator to simulate an identical query already running (Created=false)
-	fakePendingResult := &sync2.FakePendingResult{}
+	fakePendingResult := &sync2.FakePendingResult{Consolidator: fakeConsolidator}
 	fakePendingResult.SetResult(result)
 	// Start with waiter count above the cap (2 > 1), so the condition fails
 	fakePendingResult.WaiterCount = 2
+	fakeConsolidator.SetTotalWaiterCount(2)
 
 	fakeConsolidator.CreateReturn = &sync2.FakeConsolidatorCreateReturn{
 		Created:       false, // Simulate identical query already running
@@ -1528,10 +1529,9 @@ func TestQueryExecutorConsolidatorWaiterCapFallback(t *testing.T) {
 	// Verify we did NOT broadcast (because we're not the original)
 	require.Equal(t, 0, fakePendingResult.BroadcastCalls)
 
-	// Verify AddWaiterCounter was called: once with 0 (to check count), once with -1 (cleanup)
-	require.Len(t, fakePendingResult.AddWaiterCounterCalls, 2)
-	require.Equal(t, int64(0), fakePendingResult.AddWaiterCounterCalls[0])  // Check current count
-	require.Equal(t, int64(-1), fakePendingResult.AddWaiterCounterCalls[1]) // Decrement
+	// Verify AddWaiterCounter was called once with -1 (cleanup)
+	require.Len(t, fakePendingResult.AddWaiterCounterCalls, 1)
+	require.Equal(t, int64(-1), fakePendingResult.AddWaiterCounterCalls[0])
 
 	// Verify fallback executed the query independently
 	require.Equal(t, 1, db.GetQueryCalledNum(input))

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1570,6 +1570,7 @@ func TestQueryExecutorConsolidatorWaiterCapReject(t *testing.T) {
 	// Set up consolidator to simulate an identical query already running (Created=false)
 	fakePendingResult := &sync2.FakePendingResult{}
 	fakePendingResult.SetResult(result)
+	fakePendingResult.Consolidator = fakeConsolidator
 
 	// Start with waiter count above the cap (2 > 1), so the condition fails
 	fakePendingResult.WaiterCount = 2

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1574,6 +1574,7 @@ func TestQueryExecutorConsolidatorWaiterCapReject(t *testing.T) {
 
 	// Start with waiter count above the cap (2 > 1), so the condition fails
 	fakePendingResult.WaiterCount = 2
+	fakeConsolidator.SetTotalWaiterCount(2)
 
 	fakeConsolidator.CreateReturn = &sync2.FakeConsolidatorCreateReturn{
 		Created:       false, // Simulate identical query already running
@@ -1602,10 +1603,9 @@ func TestQueryExecutorConsolidatorWaiterCapReject(t *testing.T) {
 	// Verify we did NOT broadcast (because we're not the original)
 	require.Equal(t, 0, fakePendingResult.BroadcastCalls)
 
-	// Verify AddWaiterCounter was called: once with 0 (to check count), once with -1 (cleanup)
-	require.Len(t, fakePendingResult.AddWaiterCounterCalls, 2)
-	require.Equal(t, int64(0), fakePendingResult.AddWaiterCounterCalls[0])  // Check current count
-	require.Equal(t, int64(-1), fakePendingResult.AddWaiterCounterCalls[1]) // Decrement
+	// Verify AddWaiterCounter was called once with -1 (cleanup before reject)
+	require.Len(t, fakePendingResult.AddWaiterCounterCalls, 1)
+	require.Equal(t, int64(-1), fakePendingResult.AddWaiterCounterCalls[0])
 
 	// Verify no database query was executed (rejected before fallback)
 	require.Equal(t, 0, db.GetQueryCalledNum(input))

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -204,6 +204,7 @@ func registerTabletEnvFlags(fs *pflag.FlagSet) {
 
 	fs.Int64Var(&currentConfig.ConsolidatorQueryWaiterCap, "consolidator-query-waiter-cap", 0, "Configure the maximum number of clients allowed to wait on the consolidator.")
 	fs.StringVar(&currentConfig.ConsolidatorQueryWaiterCapMethod, "consolidator-query-waiter-cap-method", "fallthrough", "Configure the method when consolidator waiter cap is exceeded. Options: fallthrough, reject.")
+	fs.BoolVar(&currentConfig.ConsolidatorCacheProto3Rows, "consolidator-cache-proto3-rows", defaultConfig.ConsolidatorCacheProto3Rows, "If true, the consolidation leader pre-caches proto3-encoded rows so that waiters avoid redundant encoding work.")
 	fs.DurationVar(&healthCheckInterval, "health_check_interval", defaultConfig.Healthcheck.Interval, "Interval between health checks")
 	fs.DurationVar(&degradedThreshold, "degraded_threshold", defaultConfig.Healthcheck.DegradedThreshold, "replication lag after which a replica is considered degraded")
 	fs.DurationVar(&unhealthyThreshold, "unhealthy_threshold", defaultConfig.Healthcheck.UnhealthyThreshold, "replication lag after which a replica is considered unhealthy")
@@ -344,6 +345,7 @@ type TabletConfig struct {
 	ConsolidatorStreamQuerySize      int64         `json:"consolidatorStreamQuerySize,omitempty"`
 	ConsolidatorQueryWaiterCap       int64         `json:"consolidatorMaxQueryWait,omitempty"`
 	ConsolidatorQueryWaiterCapMethod string        `json:"consolidatorQueryWaiterCapMethod,omitempty"`
+	ConsolidatorCacheProto3Rows      bool          `json:"consolidatorCacheProto3Rows,omitempty"`
 	QueryCacheMemory                 int64         `json:"queryCacheMemory,omitempty"`
 	QueryCacheDoorkeeper             bool          `json:"queryCacheDoorkeeper,omitempty"`
 	SchemaReloadInterval             time.Duration `json:"schemaReloadIntervalSeconds,omitempty"`
@@ -1093,6 +1095,7 @@ var defaultConfig = TabletConfig{
 	ConsolidatorStreamTotalSize:      128 * 1024 * 1024,
 	ConsolidatorStreamQuerySize:      2 * 1024 * 1024,
 	ConsolidatorQueryWaiterCapMethod: "fallthrough",
+	ConsolidatorCacheProto3Rows:      false,
 	// The value for StreamBufferSize was chosen after trying out a few of
 	// them. Too small buffers force too many packets to be sent. Too big
 	// buffers force the clients to read them in multiple chunks and make


### PR DESCRIPTION
### Background / Why?

This is a cherry-pick of [vitessio/vitess#19872](https://github.com/vitessio/vitess/pull/19872) (`7fce769e77`) to `slack-22.0`.

When multiple clients consolidate on the same `SELECT`, the consolidator shares a single `*sqltypes.Result` pointer across all waiters — zero-copy. But each waiter then independently calls `ResultToProto3`, which calls `RowsToProto3`, copying all row byte data into new `querypb.Row.Values` buffers. For a 100MB result with 50 consolidated waiters, this alone produces ~5GB of transient allocations just from the row encoding step, before the gRPC codec even marshals the proto.

With this change, the proto3 row encoding is computed once by the consolidator leader rather than _N_ times by each waiter.

### Deployment

The behavior is gated behind a new vttablet flag:

```
--consolidator-cache-proto3-rows=true
```

The default is `false`. https://slack-github.com/slack/chef-repo/pull/155196 introduces a feature flag to allow us to enable the behavior.

### Differences from upstream

This was a relatively clean cherry-pick with minor conflict resolution. I've manually reviewed every single line in the diff and can attest there are no meaningful / significant discrepancies. The actual feature logic is identical to upstream; all differences stem from pre-existing divergences between the `slack-22.0` fork and upstream `main` (which is currently at v24). Here's what's different:

1. **Slack's `ConsolidatorQueryWaiterCapMethod` field preserved** — Our fork added a `ConsolidatorQueryWaiterCapMethod` field to `TabletConfig` in a prior PR (the consolidator waiter cap work). Upstream doesn't have this field. During the cherry-pick, the new `ConsolidatorCacheProto3Rows` field landed next to `ConsolidatorQueryWaiterCap` in the struct — I kept our extra field in place and added the new one after it. Same thing in the `defaultConfig` initializer and the flag registration block.

2. **v22 flag registration style retained** — Upstream v24 switched from `fs.DurationVar(...)` with underscore flag names (`health_check_interval`) to a wrapper function `utils.SetFlagDurationVar(...)` with hyphenated names (`health-check-interval`). Our `slack-22.0` branch still uses the old v22 style. The cherry-pick had a conflict in the flag registration block because the new flag was added adjacent to these changed lines.

3. **Sizegen formatting** — The auto-generated `cached_size.go` file in `go/vt/proto/query/` had blank lines between functions in the upstream commit (v24 sizegen style). Our v22 sizegen doesn't emit blank lines between functions, so the CI `check_make_sizegen` step failed. Removed the blank lines to match v22's output.

4. **Test fix: nil `Consolidator` pointer** — The upstream commit restructured `FakePendingResult` to include a `Consolidator` field that `AddWaiterCounter` dereferences. Our fork's `TestQueryExecutorConsolidatorWaiterCapReject` test (added in the waiter cap PR) created a `FakePendingResult` without setting this field, causing a nil pointer panic. Added `fakePendingResult.Consolidator = fakeConsolidator` to fix the crash.

5. **Line number / context shifts** — All remaining diff differences are just different line offsets and git hashes due to `slack-22.0` vs upstream `main` having different file contents. The actual change logic is identical.

### Testing

Upstream CI passed. Fork CI re-running after the sizegen + test fixes.

AI disclosure: Claude Code assisted with development. Every line of code was either written by or carefully reviewed by me :)