### PR TITLE
Improve vttablet health check resilience for MySQL connection issues

### DIFF
--- a/go/mysql/sqlerror/constants.go
+++ b/go/mysql/sqlerror/constants.go
@@ -618,10 +618,18 @@ func IsEphemeralError(err error) bool {
 }
 
 // IsTooManyConnectionsErr returns true if the error is due to too many connections.
+// This covers three cases:
+//   - Global max_connections exceeded: MySQL rejects during handshake with CRServerHandshakeErr
+//     and a "Too many connections" message.
+//   - Per-user max_user_connections exceeded (errno 1203 ERTooManyUserConnections).
+//   - Per-user resource limit reached (errno 1226 ERUserLimitReached) for max_user_connections.
 func IsTooManyConnectionsErr(err error) bool {
 	if sqlErr, ok := err.(*SQLError); ok {
-		if sqlErr.Number() == CRServerHandshakeErr && strings.Contains(sqlErr.Message, "Too many connections") {
+		switch sqlErr.Number() {
+		case ERTooManyUserConnections, ERUserLimitReached:
 			return true
+		case CRServerHandshakeErr:
+			return strings.Contains(sqlErr.Message, "Too many connections")
 		}
 	}
 	return false

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -536,16 +536,53 @@ func (qe *QueryEngine) ForEachPlan(each func(plan *TabletPlan) bool) {
 // IsMySQLReachable returns an error if it cannot connect to MySQL.
 // This can be called before opening the QueryEngine.
 func (qe *QueryEngine) IsMySQLReachable() error {
-	conn, err := dbconnpool.NewDBConnection(context.TODO(), qe.env.Config().DB.AppWithDB())
-	if err != nil {
-		if sqlerror.IsTooManyConnectionsErr(err) {
+	return isMySQLReachable(func() error {
+		conn, err := dbconnpool.NewDBConnection(context.TODO(), qe.env.Config().DB.AppWithDB())
+		if err != nil {
+			return err
+		}
+		conn.Close()
+		return nil
+	})
+}
+
+func isMySQLReachable(connect func() error) error {
+	var lastErr error
+	for attempt := range healthCheckMaxRetries {
+		lastErr = connect()
+		if lastErr == nil {
 			return nil
 		}
-		return err
+		if sqlerror.IsTooManyConnectionsErr(lastErr) {
+			return nil
+		}
+		if !isTransientConnErr(lastErr) {
+			return lastErr
+		}
+		if attempt < healthCheckMaxRetries-1 {
+			time.Sleep(healthCheckRetryBaseDelay << attempt)
+		}
 	}
-	conn.Close()
-	return nil
+	return lastErr
 }
+
+func isTransientConnErr(err error) bool {
+	sqlErr, ok := err.(*sqlerror.SQLError)
+	if !ok {
+		return false
+	}
+	switch sqlErr.Number() {
+	case sqlerror.CRConnectionError, sqlerror.CRConnHostError:
+		return true
+	default:
+		return false
+	}
+}
+
+var (
+	healthCheckMaxRetries     = 3
+	healthCheckRetryBaseDelay = 100 * time.Millisecond
+)
 
 func (qe *QueryEngine) schemaChanged(tables map[string]*schema.Table, created, altered, dropped []*schema.Table, _ bool) {
 	qe.schemaMu.Lock()

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -537,7 +537,7 @@ func (qe *QueryEngine) ForEachPlan(each func(plan *TabletPlan) bool) {
 // This can be called before opening the QueryEngine.
 func (qe *QueryEngine) IsMySQLReachable() error {
 	return isMySQLReachable(func() error {
-		conn, err := dbconnpool.NewDBConnection(context.TODO(), qe.env.Config().DB.AppWithDB())
+		conn, err := dbconnpool.NewDBConnection(context.TODO(), qe.env.Config().DB.DbaWithDB())
 		if err != nil {
 			return err
 		}

--- a/go/vt/vttablet/tabletserver/query_engine_test.go
+++ b/go/vt/vttablet/tabletserver/query_engine_test.go
@@ -132,6 +132,26 @@ func TestIsMySQLReachable_TooManyConnectionsTreatedAsReachable(t *testing.T) {
 	assert.Equal(t, 1, calls)
 }
 
+func TestIsMySQLReachable_MaxUserConnectionsTreatedAsReachable(t *testing.T) {
+	calls := 0
+	err := isMySQLReachable(func() error {
+		calls++
+		return sqlerror.NewSQLError(sqlerror.ERUserLimitReached, sqlerror.SSUnknownSQLState, "User 'vt_app' has exceeded the 'max_user_connections' resource (current value: 1000)")
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, calls)
+}
+
+func TestIsMySQLReachable_TooManyUserConnectionsTreatedAsReachable(t *testing.T) {
+	calls := 0
+	err := isMySQLReachable(func() error {
+		calls++
+		return sqlerror.NewSQLError(sqlerror.ERTooManyUserConnections, sqlerror.SSUnknownSQLState, "Too many connections for user")
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, calls)
+}
+
 func TestIsMySQLReachable_ExponentialBackoff(t *testing.T) {
 	defer func(d time.Duration) { healthCheckRetryBaseDelay = d }(healthCheckRetryBaseDelay)
 	healthCheckRetryBaseDelay = 50 * time.Millisecond

--- a/go/vt/vttablet/tabletserver/query_engine_test.go
+++ b/go/vt/vttablet/tabletserver/query_engine_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql/fakesqldb"
+	"vitess.io/vitess/go/mysql/sqlerror"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/streamlog"
 	"vitess.io/vitess/go/vt/dbconfigs"
@@ -54,6 +55,102 @@ import (
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
 )
+
+func TestIsMySQLReachable_SucceedsOnFirstAttempt(t *testing.T) {
+	calls := 0
+	err := isMySQLReachable(func() error {
+		calls++
+		return nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, calls)
+}
+
+func TestIsMySQLReachable_RetriesTransientConnError(t *testing.T) {
+	defer func(d time.Duration) { healthCheckRetryBaseDelay = d }(healthCheckRetryBaseDelay)
+	healthCheckRetryBaseDelay = time.Millisecond
+
+	calls := 0
+	err := isMySQLReachable(func() error {
+		calls++
+		if calls < 3 {
+			return sqlerror.NewSQLError(sqlerror.CRConnectionError, "", "socket backlog full")
+		}
+		return nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 3, calls)
+}
+
+func TestIsMySQLReachable_RetriesTCPConnError(t *testing.T) {
+	defer func(d time.Duration) { healthCheckRetryBaseDelay = d }(healthCheckRetryBaseDelay)
+	healthCheckRetryBaseDelay = time.Millisecond
+
+	calls := 0
+	err := isMySQLReachable(func() error {
+		calls++
+		if calls < 2 {
+			return sqlerror.NewSQLError(sqlerror.CRConnHostError, "", "connection refused")
+		}
+		return nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 2, calls)
+}
+
+func TestIsMySQLReachable_FailsAfterAllRetries(t *testing.T) {
+	defer func(d time.Duration) { healthCheckRetryBaseDelay = d }(healthCheckRetryBaseDelay)
+	healthCheckRetryBaseDelay = time.Millisecond
+
+	calls := 0
+	err := isMySQLReachable(func() error {
+		calls++
+		return sqlerror.NewSQLError(sqlerror.CRConnectionError, "", "socket backlog full")
+	})
+	assert.Error(t, err)
+	assert.Equal(t, healthCheckMaxRetries, calls)
+	assert.Contains(t, err.Error(), "socket backlog full")
+}
+
+func TestIsMySQLReachable_NoRetryOnNonTransientError(t *testing.T) {
+	calls := 0
+	err := isMySQLReachable(func() error {
+		calls++
+		return sqlerror.NewSQLError(sqlerror.ERAccessDeniedError, "", "access denied")
+	})
+	assert.Error(t, err)
+	assert.Equal(t, 1, calls)
+}
+
+func TestIsMySQLReachable_TooManyConnectionsTreatedAsReachable(t *testing.T) {
+	calls := 0
+	err := isMySQLReachable(func() error {
+		calls++
+		return sqlerror.NewSQLError(sqlerror.CRServerHandshakeErr, "", "Too many connections")
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, calls)
+}
+
+func TestIsMySQLReachable_ExponentialBackoff(t *testing.T) {
+	defer func(d time.Duration) { healthCheckRetryBaseDelay = d }(healthCheckRetryBaseDelay)
+	healthCheckRetryBaseDelay = 50 * time.Millisecond
+
+	var timestamps []time.Time
+	err := isMySQLReachable(func() error {
+		timestamps = append(timestamps, time.Now())
+		return sqlerror.NewSQLError(sqlerror.CRConnectionError, "", "socket backlog full")
+	})
+	assert.Error(t, err)
+	assert.Equal(t, healthCheckMaxRetries, len(timestamps))
+
+	// Verify exponential backoff: second gap ~50ms, third gap ~100ms
+	gap1 := timestamps[1].Sub(timestamps[0])
+	gap2 := timestamps[2].Sub(timestamps[1])
+	assert.True(t, gap1 >= 40*time.Millisecond, "first retry delay too short: %v", gap1)
+	assert.True(t, gap2 >= 80*time.Millisecond, "second retry delay too short: %v", gap2)
+	assert.True(t, gap2 > gap1, "backoff should be exponential: gap1=%v gap2=%v", gap1, gap2)
+}
 
 func TestStrictMode(t *testing.T) {
 	db := fakesqldb.New(t)


### PR DESCRIPTION
## Summary

Improve vttablet health check resilience so transient MySQL connection issues don't unnecessarily take the tablet out of service.

Two problems are fixed:

- **IsMySQLReachable used the app user (vt_app) to check MySQL liveness.** When that user hits max_user_connections, the health check fails and the tablet shuts down its query service — even though MySQL is perfectly reachable. Switch to the dba user so the health check doesn't compete with app connection limits.

- **IsTooManyConnectionsErr only recognized the global max_connections error.** Per-user limits (ERTooManyUserConnections errno 1203, ERUserLimitReached errno 1226) were not handled, so they were treated as "MySQL is unreachable" instead of "MySQL is reachable but busy." Extend the check to cover all three cases.

Additionally, the first commit adds retry logic with exponential backoff for transient socket errors (errno 2002/2003) so brief connection blips are absorbed without disruption.

## Background

We observed a production incident where a vttablet with --queryserver-config-pool-size=800 and --queryserver-config-transaction-cap=250 hit MySQL's max_user_connections=1000 limit under load. The resulting CheckMySQL call also failed (same user, same limit), causing the tablet to transition to "Not connected to mysql" for ~60 minutes. The cascading effect of one tablet going down shifted load to other tablets, worsening the problem.

## Changes

| File | Change |
|---|---|
| go/vt/vttablet/tabletserver/query_engine.go | IsMySQLReachable uses DbaWithDB() instead of AppWithDB() |
| go/mysql/sqlerror/constants.go | IsTooManyConnectionsErr handles errno 1203 and 1226 |
| go/vt/vttablet/tabletserver/query_engine_test.go | New tests for per-user connection limit cases |

## Test plan

- [x] Existing TestIsMySQLReachable_* tests pass
- [x] New TestIsMySQLReachable_MaxUserConnectionsTreatedAsReachable passes
- [x] New TestIsMySQLReachable_TooManyUserConnectionsTreatedAsReachable passes

---
_Most of this was written by Claude Code - I just provided direction._
