### PR TITLE
Preserve query tails by truncating from the middle

### DIFF
--- a/go/vt/sqlparser/truncate_query.go
+++ b/go/vt/sqlparser/truncate_query.go
@@ -26,15 +26,44 @@ func (p *Parser) GetTruncateErrLen() int {
 func TruncateQuery(query string, max int) string {
 	sql, comments := SplitMarginComments(query)
 
-	if max == 0 || len(sql) <= max || len(sql) < len(TruncationText) {
+	if max == 0 || len(sql) <= max {
 		return comments.Leading + sql + comments.Trailing
 	}
 
-	if max < len(TruncationText)+1 {
-		max = len(TruncationText) + 1
+	// The marker " [TRUNCATED] " needs at least len(TruncationText)+2 bytes (spaces on both sides).
+	minLen := len(TruncationText) + 2
+	if max < minLen {
+		max = minLen
 	}
 
-	return comments.Leading + sql[:max-(len(TruncationText)+1)] + " " + TruncationText + comments.Trailing
+	// After enforcing the minimum, the SQL may now fit without truncation.
+	if len(sql) <= max {
+		return comments.Leading + sql + comments.Trailing
+	}
+
+	return comments.Leading + truncateMiddle(sql, max) + comments.Trailing
+}
+
+// truncateMiddle removes content from the middle of s to fit within max bytes,
+// preserving both the beginning (query structure, table names) and the end
+// (WHERE clauses, trailing context). The removed section is replaced with
+// " [TRUNCATED] ".
+//
+// The split is 2/3 prefix, 1/3 suffix. This ratio favors the beginning of the
+// query (which contains SELECT/INSERT/UPDATE keywords and table names) while
+// still preserving meaningful trailing context (WHERE conditions, LIMIT, etc.).
+func truncateMiddle(s string, max int) string {
+	marker := " " + TruncationText + " "
+	available := max - len(marker)
+	if available <= 0 {
+		return marker
+	}
+
+	// 2/3 of available space goes to the prefix, 1/3 to the suffix.
+	prefixLen := (available * 2) / 3
+	suffixLen := available - prefixLen
+
+	return s[:prefixLen] + marker + s[len(s)-suffixLen:]
 }
 
 // TruncateForUI is used when displaying queries on various Vitess status pages

--- a/go/vt/sqlparser/truncate_query_test.go
+++ b/go/vt/sqlparser/truncate_query_test.go
@@ -2,6 +2,7 @@ package sqlparser
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,24 +15,33 @@ func TestTruncateQuery(t *testing.T) {
 		want  string
 	}{
 		{
+			// max < marker length, so min is enforced (13 bytes)
 			query: "select 111",
 			max:   2,
-			want:  "select 111",
+			want:  "select 111", // not truncated because len(sql) <= enforced min
 		},
 		{
+			// "select 1111" is 11 bytes; enforced min is 13.
+			// 11 < 13 so len(sql) <= max after enforcement; no truncation.
 			query: "select 1111",
 			max:   2,
-			want:  " [TRUNCATED]",
+			want:  "select 1111",
 		},
 		{
+			// "select 11111" is 12 bytes; enforced min is 13.
+			// 12 < 13 so no truncation.
 			query: "select 11111",
 			max:   2,
-			want:  " [TRUNCATED]",
+			want:  "select 11111",
 		},
 		{
+			// "select * from test where name = 'abc'" is 38 bytes, max=30.
+			// marker " [TRUNCATED] " is 13 bytes, available = 30-13 = 17.
+			// prefixLen = (17*2)/3 = 11, suffixLen = 17-11 = 6.
+			// prefix: "select * fr", suffix: " 'abc'"
 			query: "select * from test where name = 'abc'",
 			max:   30,
-			want:  "select * from test [TRUNCATED]",
+			want:  "select * fr [TRUNCATED]  'abc'",
 		},
 		{
 			query: "select * from test where name = 'abc'",
@@ -41,7 +51,124 @@ func TestTruncateQuery(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%s-%d", tt.query, tt.max), func(t *testing.T) {
-			assert.Equalf(t, tt.want, TruncateQuery(tt.query, tt.max), "TruncateQuery(%v, %v)", tt.query, tt.max)
+			got := TruncateQuery(tt.query, tt.max)
+			assert.Equalf(t, tt.want, got, "TruncateQuery(%v, %v)", tt.query, tt.max)
+		})
+	}
+}
+
+func TestTruncateQuery_PreservesTrailingComment(t *testing.T) {
+	// Simulate a real webapp query with InfoQueryComment trailing comment
+	sql := "select `id`, `name` from `users` where `team_id` = 123 and `id` in (1,2,3,4,5,6,7,8,9,10)"
+	comment := " /* script(req123): trace|TEAM:123|HOST:host|VTQUERYLOG_SAMPLE_PROB:0.0100000000 */"
+	query := sql + comment
+
+	// Truncate to a length shorter than the SQL body but longer than the marker
+	result := TruncateQuery(query, 60)
+
+	// The trailing comment must always be preserved
+	assert.True(t, strings.HasSuffix(result, comment),
+		"trailing comment must be preserved, got: %s", result)
+	assert.Contains(t, result, TruncationText)
+}
+
+func TestTruncateQuery_MiddleTruncation(t *testing.T) {
+	// A query with a large IN-clause in the middle and important WHERE at the end
+	prefix := "select * from users where team_id = 123 and id in ("
+	inClause := strings.Repeat("12345,", 100) // large repetitive middle section
+	suffix := ") and status = 'active' order by created_at limit 10"
+	query := prefix + inClause + suffix
+
+	result := TruncateQuery(query, 120)
+
+	// The result must contain the truncation marker
+	assert.Contains(t, result, TruncationText)
+
+	// The result preserves the beginning of the query
+	assert.True(t, strings.HasPrefix(result, "select * from users"),
+		"beginning of query should be preserved, got: %s", result)
+
+	// The result preserves the end of the query
+	assert.True(t, strings.HasSuffix(result, "limit 10"),
+		"end of query should be preserved, got: %s", result)
+
+	// The result respects the max length
+	assert.LessOrEqual(t, len(result), 120,
+		"result length %d exceeds max 120", len(result))
+}
+
+func TestTruncateQuery_NoTruncationNeeded(t *testing.T) {
+	query := "select 1"
+	assert.Equal(t, "select 1", TruncateQuery(query, 100))
+	assert.Equal(t, "select 1", TruncateQuery(query, 0)) // 0 means no truncation
+}
+
+func TestTruncateQuery_WithLeadingAndTrailingComments(t *testing.T) {
+	query := "/* leading */ select * from a_long_table_name where id = 1 /* trailing */"
+
+	result := TruncateQuery(query, 30)
+
+	// Both margin comments should be preserved
+	assert.True(t, strings.HasPrefix(result, "/* leading */"),
+		"leading comment must be preserved, got: %s", result)
+	assert.True(t, strings.HasSuffix(result, "/* trailing */"),
+		"trailing comment must be preserved, got: %s", result)
+	assert.Contains(t, result, TruncationText)
+}
+
+func TestTruncateMiddle(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		max    int
+		expect string
+	}{
+		{
+			// max=20, marker=13, available=7, prefix=(7*2)/3=4, suffix=3
+			name:   "basic middle truncation",
+			input:  "abcdefghijklmnopqrstuvwxyz",
+			max:    20,
+			expect: "abcd [TRUNCATED] xyz",
+		},
+		{
+			// max < marker length: available<=0, returns just the marker
+			name:   "max smaller than marker returns marker",
+			input:  "abcdefghijklmnopqrstuvwxyz",
+			max:    5,
+			expect: " [TRUNCATED] ",
+		},
+		{
+			// max == marker length: available=0, returns just the marker
+			name:   "exactly marker size",
+			input:  "abcdefghijklmnopqrstuvwxyz",
+			max:    13, // len(" [TRUNCATED] ") == 13
+			expect: " [TRUNCATED] ",
+		},
+		{
+			// max=14, available=1, prefix=(1*2)/3=0, suffix=1-0=1
+			name:   "one byte over marker goes to suffix",
+			input:  "abcdefghijklmnopqrstuvwxyz",
+			max:    14,
+			expect: " [TRUNCATED] z",
+		},
+		{
+			// max=15, available=2, prefix=(2*2)/3=1, suffix=2-1=1
+			name:   "two bytes available split 1-1",
+			input:  "abcdefghijklmnopqrstuvwxyz",
+			max:    15,
+			expect: "a [TRUNCATED] z",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncateMiddle(tt.input, tt.max)
+			assert.Equal(t, tt.expect, got)
+			// When max >= marker length, result should fit within max.
+			// When max < marker length, we always return the marker (which is the minimum output).
+			if tt.max >= len(" [TRUNCATED] ") {
+				assert.LessOrEqual(t, len(got), tt.max,
+					"result length %d exceeds max %d", len(got), tt.max)
+			}
 		})
 	}
 }

--- a/go/vt/vtenv/vtenv_test.go
+++ b/go/vt/vtenv/vtenv_test.go
@@ -30,8 +30,8 @@ func TestNewCustom(t *testing.T) {
 	assert.Equal(t, "8.0.34", e.MySQLVersion())
 	assert.Equal(t, collations.MySQL8(), e.CollationEnv())
 	assert.Equal(t, 15, e.Parser().GetTruncateErrLen())
-	assert.Equal(t, "sel [TRUNCATED]", e.TruncateForLog("select 11111111111"))
-	assert.Equal(t, "sele [TRUNCATED]", e.TruncateForUI("select 11111111111"))
+	assert.Equal(t, "s [TRUNCATED] 1", e.TruncateForLog("select 11111111111"))
+	assert.Equal(t, "se [TRUNCATED] 1", e.TruncateForUI("select 11111111111"))
 }
 
 func TestNewError(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -1710,7 +1710,7 @@ func TestHandlePanicAndSendLogStatsMessageTruncation(t *testing.T) {
 		want := "Uncaught panic for Sql: \"select * from test_table_loooooooooooooooooooooooooooooooooooong\", BindVars: {bv1: \"type:INT64 value:\\\"1111111111\\\"\"bv2: \"type:INT64 value:\\\"2222222222\\\"\"bv3: \"type:INT64 value:\\\"3333333333\\\"\"bv4: \"type:INT64 value:\\\"4444444444\\\"\"}"
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), want)
-		want = "Uncaught panic for Sql: \"select * from test_t [TRUNCATED]\", BindVars: {bv1: \"typ [TRUNCATED]"
+		want = "Uncaught panic for Sql: \"select * fro [TRUNCATED] ooooong\", BindVars: {bv1: \"typ [TRUNCATED]"
 		gotWhatWeWant := false
 		for _, log := range tl.getLogs() {
 			if strings.HasPrefix(log, want) {
@@ -1740,7 +1740,7 @@ func TestQueryAsString(t *testing.T) {
 	require.NoError(t, err)
 
 	query := queryAsString(longSql, longBv, true, true, parser)
-	want := "Sql: \"select * from test_t [TRUNCATED]\", BindVars: {[REDACTED]}"
+	want := "Sql: \"select * fro [TRUNCATED] ooooong\", BindVars: {[REDACTED]}"
 	assert.Equal(t, want, query)
 
 	query = queryAsString(longSql, longBv, true, false, parser)
@@ -1748,7 +1748,7 @@ func TestQueryAsString(t *testing.T) {
 	assert.Equal(t, want, query)
 
 	query = queryAsString(longSql, longBv, false, true, parser)
-	want = "Sql: \"select * from test_t [TRUNCATED]\", BindVars: {bv1: \"typ [TRUNCATED]"
+	want = "Sql: \"select * fro [TRUNCATED] ooooong\", BindVars: {bv1: \"typ [TRUNCATED]"
 	assert.Equal(t, want, query)
 
 	query = queryAsString(longSql, longBv, false, false, parser)
@@ -2060,7 +2060,7 @@ func TestTruncateMessages(t *testing.T) {
 	}
 
 	// but log *is* truncated, and sanitized
-	wantLog := "sensitive message (errno 10) (sqlstate HY000): Sql: \"select * from test_table where xyz = :vt [TRUNCATED]\", BindVars: {[REDACTED]}"
+	wantLog := "sensitive message (errno 10) (sqlstate HY000): Sql: \"select * from test_table w [TRUNCATED] r by abc desc\", BindVars: {[REDACTED]}"
 	if wantLog != tl.getLog(0) {
 		t.Errorf("log got '%s', want '%s'", tl.getLog(0), wantLog)
 	}


### PR DESCRIPTION
### Background / Why?

Henry noticed in [webapp#386252 discussion_r1657498](https://slack-github.com/slack/webapp/pull/386252#discussion_r1657498) that the new `VTQUERYLOG_SAMPLE_PROB` field appended to InfoQueryComment could be lost when Vitess truncates long queries. The existing truncation strategy chops from the end, which discards trailing WHERE clauses, LIMIT statements, and — critically — the trailing `/* ... */` margin comment that carries webapp metadata (TEAM, USER, HOST, VTQUERYLOG_SAMPLE_PROB, etc.).

On closer inspection, the trailing margin comment was already safe: `SplitMarginComments` extracts it before truncation and reattaches it afterward. However, the end-truncation strategy still discards valuable trailing SQL context (WHERE conditions, ORDER BY, LIMIT) while preserving repetitive middle content (large IN-clause value lists) that carries no diagnostic value.

This PR switches to middle-truncation: the SQL body is split with a 2/3 prefix + 1/3 suffix ratio around a ` [TRUNCATED] ` marker. This preserves both the query structure at the beginning (SELECT/INSERT/UPDATE, table names) and the filtering/ordering context at the end (WHERE, LIMIT, trailing expressions).

### Summary

- **`TruncateQuery`** now calls `truncateMiddle` instead of slicing from the end
- **`truncateMiddle`** splits available space 2/3 prefix, 1/3 suffix around the marker
- Margin comments (leading and trailing) remain fully intact — they are stripped by `SplitMarginComments` before truncation and reassembled after
- The `TruncationText` constant and public API are unchanged

### Implications and dependencies

**What depends on truncation output format?**

1. **icekone `VitessQueryExtraction.java`** — parses the trailing `/* ... */` comment for TEAM, USER, HOST, TAGS fields. Uses `lastIndexOf(" /* ")` to find the boundary. **Not affected** because trailing comments are preserved verbatim by `SplitMarginComments`.

2. **Vitess queryz/streamqueryz UI pages** — display truncated queries via `TruncateForUI`. Output format changes from end-truncated to middle-truncated. **Cosmetic change only** — no parsing depends on the truncated SQL body.

3. **Vitess error logs** — use `TruncateForLog` for query text in error messages. Same cosmetic format change. **No downstream parsing depends on the truncated SQL body in error messages.**

4. **`vterrors.TruncateError`** — separate function for error message truncation (not SQL queries). **Completely unaffected** — different code path.

**What could break?**

Nothing in the data pipeline. The only observable change is that truncated SQL bodies now show `prefix [TRUNCATED] suffix` instead of `prefix [TRUNCATED]`. Any tooling that pattern-matches on `[TRUNCATED]` still works since the marker text is unchanged.

### Testing

New unit tests covering: middle-truncation math (prefix/suffix split), trailing comment preservation with realistic InfoQueryComment, leading+trailing comment preservation, large IN-clause truncation, and edge cases (max < marker length, max = 0). Updated expectations in `vtenv_test.go` and `tabletserver_test.go` to match the new output format.

AI disclosure: Claude Code assisted with development. Every line of code was either written by or carefully reviewed by me :)