### PR TITLE
vttablet_startup_duration_seconds_bucket prom metric

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ report
 /errors/
 go/flags/endtoend/count_flags.sh
 /coverage.out
+
+# claude
+.claude/settings.local.json

--- a/go/vt/vttablet/tabletserver/state_manager.go
+++ b/go/vt/vttablet/tabletserver/state_manager.go
@@ -144,6 +144,9 @@ type stateManager struct {
 	unhealthyThreshold    atomic.Int64
 	shutdownGracePeriod   time.Duration
 	transitionGracePeriod time.Duration
+
+	startupTimings     *servenv.TimingsWrapper
+	logStartupDuration sync.Once
 }
 
 type (
@@ -667,6 +670,11 @@ func (sm *stateManager) setState(tabletType topodatapb.TabletType, state serving
 	defer logInitTime.Do(func() {
 		log.Info(fmt.Sprintf("Tablet Init took %d ms", time.Since(servenv.GetInitStartTime()).Milliseconds()))
 	})
+	if state == StateServing && sm.startupTimings != nil {
+		sm.logStartupDuration.Do(func() {
+			sm.startupTimings.Record("Serving", servenv.GetInitStartTime())
+		})
+	}
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 	if tabletType == topodatapb.TabletType_UNKNOWN {

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -251,6 +251,8 @@ func NewTabletServer(ctx context.Context, env *vtenv.Environment, name string, c
 		return time.Duration(tsv.QueryTimeout.Load())
 	})
 
+	tsv.sm.startupTimings = tsv.exporter.NewTimings("StartupDuration", "Time from vttablet start to first entering serving state", "Status")
+
 	tsv.registerHealthzHealthHandler()
 	tsv.registerDebugHealthHandler()
 	tsv.registerQueryzHandler()
@@ -1163,7 +1165,8 @@ func (tsv *TabletServer) beginWaitForSameRangeTransactions(ctx context.Context, 
 			}
 
 			return waitErr
-		})
+		},
+	)
 	return txDone, err
 }
 


### PR DESCRIPTION
## Description
this PR introduces a histogram metric which tracks vttablet startup time,
from invocation as a daemon to queryserver -> SERVING,
so we can track/compare if this is changing over time as our fleet size and/or 
lockserver infrastructure changes, as well as across major version upgrades.
```
  - state_manager.go — startupTimings field and a per-instance sync.Once. 
     When setState is called with StateServing for the first time, 
     it records the elapsed time since servenv.Init() as a histogram observation.
  - tabletserver.go — Registers the "StartupDuration" timing metric on the exporter.

  In Prometheus this will appear as vttablet_startup_duration_seconds_bucket /
  _sum / _count with label Status="Serving". To query p95 startup time over 4 weeks:
  
  histogram_quantile(0.95, sum(increase(vttablet_startup_duration_seconds_bucket[4w])) by (le))
```

### AI Disclosure
This PR was written primarily by Claude Code under my instruction.
