### PR TITLE
Inline vitess-addons and remove private repo access scaffolding

### DIFF
--- a/.github/actions/build-bootstrap/action.yml
+++ b/.github/actions/build-bootstrap/action.yml
@@ -10,10 +10,6 @@ inputs:
     description: "Bootstrap image flavor (e.g. mysql84)"
     required: false
     default: "mysql84"
-  gh-access-token:
-    description: "GitHub access token for private dependencies"
-    required: false
-    default: ""
 
 runs:
   using: "composite"
@@ -32,4 +28,3 @@ runs:
       env:
         BOOTSTRAP_VERSION: ${{ inputs.bootstrap-version }}
         BOOTSTRAP_FLAVOR: ${{ inputs.bootstrap-flavor }}
-        GH_ACCESS_TOKEN: ${{ inputs.gh-access-token }}

--- a/.github/workflows/check_make_vtadmin_authz_testgen.yml
+++ b/.github/workflows/check_make_vtadmin_authz_testgen.yml
@@ -42,11 +42,6 @@ jobs:
             - 'Makefile'
             - 'go/vt/vtadmin/**'
             - '.github/workflows/check_make_vtadmin_authz_testgen.yml'
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.vtadmin_changes == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
-
     - name: Tune the OS
       if: steps.changes.outputs.vtadmin_changes == 'true'
       uses: ./.github/actions/tune-os

--- a/.github/workflows/check_make_vtadmin_web_proto.yml
+++ b/.github/workflows/check_make_vtadmin_web_proto.yml
@@ -53,11 +53,6 @@ jobs:
       if: steps.changes.outputs.proto_changes == 'true'
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.proto_changes == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
-
     - name: Setup Node
       if: steps.changes.outputs.proto_changes == 'true'
       uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3

--- a/.github/workflows/cluster_endtoend_12.yml
+++ b/.github/workflows/cluster_endtoend_12.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_18.yml
+++ b/.github/workflows/cluster_endtoend_18.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_backup_pitr.yml
+++ b/.github/workflows/cluster_endtoend_backup_pitr.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_backup_pitr_mysqlshell.yml
+++ b/.github/workflows/cluster_endtoend_backup_pitr_mysqlshell.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_backup_pitr_xtrabackup.yml
+++ b/.github/workflows/cluster_endtoend_backup_pitr_xtrabackup.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
+++ b/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_mysql80.yml
+++ b/.github/workflows/cluster_endtoend_mysql80.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_mysql_server_vault.yml
+++ b/.github/workflows/cluster_endtoend_mysql_server_vault.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -68,10 +67,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -68,10 +67,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -68,10 +67,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -68,10 +67,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -68,10 +67,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -68,10 +67,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -68,10 +67,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_topo.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_topo.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_topo_connection_cache.yml
+++ b/.github/workflows/cluster_endtoend_topo_connection_cache.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_copy_parallel.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_copy_parallel.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_foreign_key_stress.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_foreign_key_stress.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_mariadb_to_mysql.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_mariadb_to_mysql.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_migrate.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_multi_tenant.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multi_tenant.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_partial_movetables_and_materialize.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_partial_movetables_and_materialize.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_vdiff2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_vdiff2.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_vtctldclient_movetables_tz.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_vtctldclient_movetables_tz.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vstream.yml
+++ b/.github/workflows/cluster_endtoend_vstream.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtbackup.yml
+++ b/.github/workflows/cluster_endtoend_vtbackup.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_foreignkey_stress.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_foreignkey_stress.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_general_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_general_heavy.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_godriver.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_godriver.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_partial_keyspace.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_partial_keyspace.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_plantests.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_plantests.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_queries.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_queries.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_vindex_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex_heavy.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -76,10 +75,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vttablet_prscomplex.yml
+++ b/.github/workflows/cluster_endtoend_vttablet_prscomplex.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_xb_backup.yml
+++ b/.github/workflows/cluster_endtoend_xb_backup.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -67,10 +66,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -36,11 +36,6 @@ jobs:
             - go.mod
             - go.sum
             - Makefile
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.changed_files == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
-
     - name: Set up Go
       if: steps.changes.outputs.changed_files == 'true'
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0

--- a/.github/workflows/docker_ci.yml
+++ b/.github/workflows/docker_ci.yml
@@ -10,8 +10,6 @@ on:
 permissions: read-all
 
 env:
-  GOPRIVATE: github.com/slackhq/vitess-addons
-  GH_ACCESS_TOKEN: "${{ secrets.GH_ACCESS_TOKEN }}"
   BOOTSTRAP_VERSION: "ci"
   BOOTSTRAP_FLAVOR: "mysql84"
 
@@ -68,18 +66,12 @@ jobs:
               - 'docker/**'
               - 'java/**'
               - '.github/workflows/docker_ci.yml'
-
-      - name: Setup GitHub access token
-        if: steps.changes.outputs.end_to_end == 'true'
-        run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
-
       - name: Build bootstrap images
         if: steps.changes.outputs.end_to_end == 'true'
         uses: ./.github/actions/build-bootstrap
         with:
           bootstrap-version: ${{ env.BOOTSTRAP_VERSION }}
           bootstrap-flavor: ${{ env.BOOTSTRAP_FLAVOR }}
-          gh-access-token: ${{ env.GH_ACCESS_TOKEN }}
 
       - name: Set up Go
         if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/e2e_race.yml
+++ b/.github/workflows/e2e_race.yml
@@ -50,11 +50,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
-
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'
       uses: ./.github/actions/tune-os

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -50,11 +50,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
-
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'
       uses: ./.github/actions/tune-os

--- a/.github/workflows/local_example.yml
+++ b/.github/workflows/local_example.yml
@@ -59,7 +59,6 @@ jobs:
     - name: Build bootstrap images
       if: steps.changes.outputs.examples == 'true'
       uses: ./.github/actions/build-bootstrap
-      with:
 
     - name: Set up Go
       if: steps.changes.outputs.examples == 'true'

--- a/.github/workflows/local_example.yml
+++ b/.github/workflows/local_example.yml
@@ -10,8 +10,6 @@ on:
 permissions: read-all
 
 env:
-  GOPRIVATE: github.com/slackhq/vitess-addons
-  GH_ACCESS_TOKEN: "${{ secrets.GH_ACCESS_TOKEN }}"
   BOOTSTRAP_VERSION: "ci"
   BOOTSTRAP_FLAVOR: "mysql84"
 
@@ -62,18 +60,12 @@ jobs:
       if: steps.changes.outputs.examples == 'true'
       uses: ./.github/actions/build-bootstrap
       with:
-        gh-access-token: ${{ env.GH_ACCESS_TOKEN }}
 
     - name: Set up Go
       if: steps.changes.outputs.examples == 'true'
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.examples == 'true'
-      run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
-
     - name: Tune the OS
       if: steps.changes.outputs.examples == 'true'
       uses: ./.github/actions/tune-os

--- a/.github/workflows/region_example.yml
+++ b/.github/workflows/region_example.yml
@@ -19,8 +19,6 @@ jobs:
     name: Region Sharding example using ${{ matrix.topo }} on Ubuntu
     runs-on: vitess-ubuntu24-16cpu-1
     env:
-      GOPRIVATE: github.com/slackhq/vitess-addons
-      GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
     strategy:
       matrix:
         topo: [etcd]
@@ -63,17 +61,12 @@ jobs:
       if: steps.changes.outputs.examples == 'true'
       uses: ./.github/actions/build-bootstrap
       with:
-        gh-access-token: ${{ env.GH_ACCESS_TOKEN }}
 
     - name: Set up Go
       if: steps.changes.outputs.examples == 'true'
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup github.com/slackhq/vitess-addons access token
-      if: steps.changes.outputs.examples == 'true'
-      run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
 
     - name: Tune the OS
       if: steps.changes.outputs.examples == 'true'

--- a/.github/workflows/region_example.yml
+++ b/.github/workflows/region_example.yml
@@ -60,7 +60,6 @@ jobs:
     - name: Build bootstrap images
       if: steps.changes.outputs.examples == 'true'
       uses: ./.github/actions/build-bootstrap
-      with:
 
     - name: Set up Go
       if: steps.changes.outputs.examples == 'true'

--- a/.github/workflows/static_checks_etc.yml
+++ b/.github/workflows/static_checks_etc.yml
@@ -15,7 +15,6 @@ jobs:
   build:
     name: Static Code Checks Etc
     runs-on: vitess-ubuntu24-16cpu-1
-    env:
 
     steps:
       - name: Skip CI

--- a/.github/workflows/static_checks_etc.yml
+++ b/.github/workflows/static_checks_etc.yml
@@ -16,8 +16,6 @@ jobs:
     name: Static Code Checks Etc
     runs-on: vitess-ubuntu24-16cpu-1
     env:
-      GOPRIVATE: github.com/slackhq/vitess-addons
-      GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
 
     steps:
       - name: Skip CI
@@ -124,11 +122,6 @@ jobs:
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: go.mod
-
-      - name: Setup GitHub access token
-        if: steps.changes.outputs.go_files == 'true'
-        run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
-
       - name: Tune the OS
         if: steps.changes.outputs.go_files == 'true'
         uses: ./.github/actions/tune-os

--- a/.github/workflows/unit_race.yml
+++ b/.github/workflows/unit_race.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   test:
@@ -64,10 +63,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.unit_tests == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.unit_tests == 'true'

--- a/.github/workflows/unit_race_evalengine.yml
+++ b/.github/workflows/unit_race_evalengine.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   test:
@@ -64,10 +63,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.unit_tests == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.unit_tests == 'true'

--- a/.github/workflows/unit_test_evalengine_mysql57.yml
+++ b/.github/workflows/unit_test_evalengine_mysql57.yml
@@ -21,7 +21,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   test:
@@ -66,11 +65,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.unit_tests == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
-
     - name: Set up python
       if: steps.changes.outputs.unit_tests == 'true'
       uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1

--- a/.github/workflows/unit_test_evalengine_mysql80.yml
+++ b/.github/workflows/unit_test_evalengine_mysql80.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   test:
@@ -64,10 +63,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.unit_tests == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.unit_tests == 'true'

--- a/.github/workflows/unit_test_evalengine_mysql84.yml
+++ b/.github/workflows/unit_test_evalengine_mysql84.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   test:
@@ -64,10 +63,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.unit_tests == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.unit_tests == 'true'

--- a/.github/workflows/unit_test_mysql57.yml
+++ b/.github/workflows/unit_test_mysql57.yml
@@ -21,7 +21,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   test:
@@ -66,11 +65,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.unit_tests == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
-
     - name: Set up python
       if: steps.changes.outputs.unit_tests == 'true'
       uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1

--- a/.github/workflows/unit_test_mysql80.yml
+++ b/.github/workflows/unit_test_mysql80.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   test:
@@ -64,10 +63,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.unit_tests == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.unit_tests == 'true'

--- a/.github/workflows/unit_test_mysql84.yml
+++ b/.github/workflows/unit_test_mysql84.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   test:
@@ -64,10 +63,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.unit_tests == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.unit_tests == 'true'

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -19,7 +19,6 @@ jobs:
     timeout-minutes: 60
     name: Run Upgrade Downgrade Test - Backups - E2E
     runs-on: vitess-ubuntu24-16cpu-1
-    env:
 
     steps:
     - name: Skip CI

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -20,8 +20,6 @@ jobs:
     name: Run Upgrade Downgrade Test - Backups - E2E
     runs-on: vitess-ubuntu24-16cpu-1
     env:
-      GOPRIVATE: github.com/slackhq/vitess-addons
-      GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
 
     steps:
     - name: Skip CI
@@ -97,10 +95,6 @@ jobs:
         sudo percona-release enable-only tools
         sudo apt-get update
         sudo apt-get install -y percona-xtrabackup-80
-
-    - name: Setup github.com/slackhq/vitess-addons access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
 
     # Checkout to the last release of Vitess
     - name: Check out other version's code (${{ steps.output-previous-release-ref.outputs.previous_release_ref }})

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -113,6 +113,8 @@ jobs:
     - name: Get dependencies for the last release
       if: steps.changes.outputs.end_to_end == 'true'
       run: |
+        go mod edit -droprequire github.com/slackhq/vitess-addons
+        go mod tidy -e
         go mod download
 
     - name: Building last release's binaries

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
@@ -69,11 +69,6 @@ jobs:
     - name: Tune the OS
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
       uses: ./.github/actions/tune-os
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
-
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -22,8 +22,6 @@ jobs:
     name: Run Upgrade Downgrade Test - Backups - Manual
     runs-on: vitess-ubuntu24-16cpu-1
     env:
-      GOPRIVATE: github.com/slackhq/vitess-addons
-      GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
 
     steps:
     - name: Skip CI
@@ -73,11 +71,6 @@ jobs:
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'
       uses: ./.github/actions/tune-os
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
-
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -116,6 +116,8 @@ jobs:
     - name: Get dependencies for the last release
       if: steps.changes.outputs.end_to_end == 'true'
       run: |
+        go mod edit -droprequire github.com/slackhq/vitess-addons
+        go mod tidy -e
         go mod download
 
     - name: Building last release's binaries

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -21,7 +21,6 @@ jobs:
     timeout-minutes: 40
     name: Run Upgrade Downgrade Test - Backups - Manual
     runs-on: vitess-ubuntu24-16cpu-1
-    env:
 
     steps:
     - name: Skip CI

--- a/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
@@ -23,7 +23,6 @@ jobs:
     timeout-minutes: 40
     name: Run Upgrade Downgrade Test - Backups - Manual - Next Release
     runs-on: vitess-ubuntu24-16cpu-1
-    env:
 
     steps:
     - name: Skip CI

--- a/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
@@ -24,8 +24,6 @@ jobs:
     name: Run Upgrade Downgrade Test - Backups - Manual - Next Release
     runs-on: vitess-ubuntu24-16cpu-1
     env:
-      GOPRIVATE: github.com/slackhq/vitess-addons
-      GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
 
     steps:
     - name: Skip CI
@@ -75,11 +73,6 @@ jobs:
     - name: Tune the OS
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
       uses: ./.github/actions/tune-os
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
-
     - name: Set up python
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1

--- a/.github/workflows/upgrade_downgrade_test_onlineddl_flow.yml
+++ b/.github/workflows/upgrade_downgrade_test_onlineddl_flow.yml
@@ -24,8 +24,6 @@ jobs:
     name: Run Upgrade Downgrade Test - Online DDL flow
     runs-on: vitess-ubuntu24-16cpu-1
     env:
-      GOPRIVATE: github.com/slackhq/vitess-addons
-      GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
 
     steps:
     - name: Skip CI
@@ -81,11 +79,6 @@ jobs:
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'
       uses: ./.github/actions/tune-os
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
-
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1

--- a/.github/workflows/upgrade_downgrade_test_onlineddl_flow.yml
+++ b/.github/workflows/upgrade_downgrade_test_onlineddl_flow.yml
@@ -23,7 +23,6 @@ jobs:
     timeout-minutes: 60
     name: Run Upgrade Downgrade Test - Online DDL flow
     runs-on: vitess-ubuntu24-16cpu-1
-    env:
 
     steps:
     - name: Skip CI

--- a/.github/workflows/upgrade_downgrade_test_onlineddl_flow.yml
+++ b/.github/workflows/upgrade_downgrade_test_onlineddl_flow.yml
@@ -116,6 +116,8 @@ jobs:
     - name: Get dependencies for the last release
       if: steps.changes.outputs.end_to_end == 'true'
       run: |
+        go mod edit -droprequire github.com/slackhq/vitess-addons
+        go mod tidy -e
         go mod download
 
     - name: Building last release's binaries

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
@@ -23,7 +23,6 @@ jobs:
     timeout-minutes: 60
     name: Run Upgrade Downgrade Test - Query Serving (Queries)
     runs-on: vitess-ubuntu24-16cpu-1
-    env:
 
     steps:
     - name: Skip CI

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
@@ -123,6 +123,8 @@ jobs:
     - name: Get dependencies for the last release
       if: steps.changes.outputs.end_to_end == 'true'
       run: |
+        go mod edit -droprequire github.com/slackhq/vitess-addons
+        go mod tidy -e
         go mod download
 
     - name: Building last release's binaries

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
@@ -24,8 +24,6 @@ jobs:
     name: Run Upgrade Downgrade Test - Query Serving (Queries)
     runs-on: vitess-ubuntu24-16cpu-1
     env:
-      GOPRIVATE: github.com/slackhq/vitess-addons
-      GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
 
     steps:
     - name: Skip CI
@@ -72,11 +70,6 @@ jobs:
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'
       uses: ./.github/actions/tune-os
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
-
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_2.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_2.yml
@@ -22,7 +22,6 @@ jobs:
     timeout-minutes: 60
     name: Run Upgrade Downgrade Test - Query Serving (Queries - 2)
     runs-on: vitess-ubuntu24-16cpu-1
-    env:
 
     steps:
     - name: Skip CI

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_2.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_2.yml
@@ -23,8 +23,6 @@ jobs:
     name: Run Upgrade Downgrade Test - Query Serving (Queries - 2)
     runs-on: vitess-ubuntu24-16cpu-1
     env:
-      GOPRIVATE: github.com/slackhq/vitess-addons
-      GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
 
     steps:
     - name: Skip CI
@@ -72,11 +70,6 @@ jobs:
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'
       uses: ./.github/actions/tune-os
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
-
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_2.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_2.yml
@@ -123,6 +123,8 @@ jobs:
     - name: Get dependencies for the last release
       if: steps.changes.outputs.end_to_end == 'true'
       run: |
+        go mod edit -droprequire github.com/slackhq/vitess-addons
+        go mod tidy -e
         go mod download
 
     - name: Building last release's binaries

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_2_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_2_next_release.yml
@@ -72,11 +72,6 @@ jobs:
     - name: Tune the OS
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
       uses: ./.github/actions/tune-os
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
-
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
@@ -72,11 +72,6 @@ jobs:
     - name: Tune the OS
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
       uses: ./.github/actions/tune-os
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
-
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
@@ -23,7 +23,6 @@ jobs:
     timeout-minutes: 60
     name: Run Upgrade Downgrade Test - Query Serving (Schema)
     runs-on: vitess-ubuntu24-16cpu-1
-    env:
 
     steps:
     - name: Skip CI

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
@@ -107,6 +107,8 @@ jobs:
     - name: Get dependencies for the last release
       if: steps.changes.outputs.end_to_end == 'true'
       run: |
+        go mod edit -droprequire github.com/slackhq/vitess-addons
+        go mod tidy -e
         go mod download
 
     - name: Building last release's binaries

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
@@ -24,8 +24,6 @@ jobs:
     name: Run Upgrade Downgrade Test - Query Serving (Schema)
     runs-on: vitess-ubuntu24-16cpu-1
     env:
-      GOPRIVATE: github.com/slackhq/vitess-addons
-      GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
 
     steps:
     - name: Skip CI
@@ -72,11 +70,6 @@ jobs:
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'
       uses: ./.github/actions/tune-os
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
-
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
@@ -72,11 +72,6 @@ jobs:
     - name: Tune the OS
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
       uses: ./.github/actions/tune-os
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
-
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
@@ -26,8 +26,6 @@ jobs:
     name: Run Upgrade Downgrade Test - Reparent New Vtctl
     runs-on: vitess-ubuntu24-16cpu-1
     env:
-      GOPRIVATE: github.com/slackhq/vitess-addons
-      GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
 
     steps:
     - name: Skip CI
@@ -75,11 +73,6 @@ jobs:
     - name: Tune the OS
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
       uses: ./.github/actions/tune-os
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
-
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
@@ -25,7 +25,6 @@ jobs:
     timeout-minutes: 60
     name: Run Upgrade Downgrade Test - Reparent New Vtctl
     runs-on: vitess-ubuntu24-16cpu-1
-    env:
 
     steps:
     - name: Skip CI

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
@@ -26,8 +26,6 @@ jobs:
     name: Run Upgrade Downgrade Test - Reparent New VTTablet
     runs-on: vitess-ubuntu24-16cpu-1
     env:
-      GOPRIVATE: github.com/slackhq/vitess-addons
-      GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
 
     steps:
     - name: Skip CI
@@ -75,11 +73,6 @@ jobs:
     - name: Tune the OS
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
       uses: ./.github/actions/tune-os
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
-
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
@@ -25,7 +25,6 @@ jobs:
     timeout-minutes: 60
     name: Run Upgrade Downgrade Test - Reparent New VTTablet
     runs-on: vitess-ubuntu24-16cpu-1
-    env:
 
     steps:
     - name: Skip CI

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -24,8 +24,6 @@ jobs:
     name: Run Upgrade Downgrade Test - Reparent Old Vtctl
     runs-on: vitess-ubuntu24-16cpu-1
     env:
-      GOPRIVATE: github.com/slackhq/vitess-addons
-      GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
 
     steps:
     - name: Skip CI
@@ -72,11 +70,6 @@ jobs:
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'
       uses: ./.github/actions/tune-os
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
-
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -107,6 +107,8 @@ jobs:
     - name: Get dependencies for the last release
       if: steps.changes.outputs.end_to_end == 'true'
       run: |
+        go mod edit -droprequire github.com/slackhq/vitess-addons
+        go mod tidy -e
         go mod download
 
     - name: Building last release's binaries

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -23,7 +23,6 @@ jobs:
     timeout-minutes: 60
     name: Run Upgrade Downgrade Test - Reparent Old Vtctl
     runs-on: vitess-ubuntu24-16cpu-1
-    env:
 
     steps:
     - name: Skip CI

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -23,7 +23,6 @@ jobs:
     timeout-minutes: 60
     name: Run Upgrade Downgrade Test - Reparent Old VTTablet
     runs-on: vitess-ubuntu24-16cpu-1
-    env:
 
     steps:
     - name: Skip CI

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -24,8 +24,6 @@ jobs:
     name: Run Upgrade Downgrade Test - Reparent Old VTTablet
     runs-on: vitess-ubuntu24-16cpu-1
     env:
-      GOPRIVATE: github.com/slackhq/vitess-addons
-      GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
 
     steps:
     - name: Skip CI
@@ -72,11 +70,6 @@ jobs:
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'
       uses: ./.github/actions/tune-os
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
-
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -107,6 +107,8 @@ jobs:
     - name: Get dependencies for the last release
       if: steps.changes.outputs.end_to_end == 'true'
       run: |
+        go mod edit -droprequire github.com/slackhq/vitess-addons
+        go mod tidy -e
         go mod download
 
     - name: Building last release's binaries

--- a/.github/workflows/upgrade_downgrade_test_semi_sync.yml
+++ b/.github/workflows/upgrade_downgrade_test_semi_sync.yml
@@ -19,7 +19,6 @@ jobs:
     timeout-minutes: 60
     name: Run Semi Sync Upgrade Downgrade Test
     runs-on: vitess-ubuntu24-16cpu-1
-    env:
 
     steps:
       - name: Skip CI

--- a/.github/workflows/upgrade_downgrade_test_semi_sync.yml
+++ b/.github/workflows/upgrade_downgrade_test_semi_sync.yml
@@ -20,8 +20,6 @@ jobs:
     name: Run Semi Sync Upgrade Downgrade Test
     runs-on: vitess-ubuntu24-16cpu-1
     env:
-      GOPRIVATE: github.com/slackhq/vitess-addons
-      GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
 
     steps:
       - name: Skip CI
@@ -69,11 +67,6 @@ jobs:
       - name: Tune the OS
         if: steps.changes.outputs.end_to_end == 'true'
         uses: ./.github/actions/tune-os
-
-      - name: Setup GitHub access token
-        if: steps.changes.outputs.end_to_end == 'true'
-        run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
-
       - name: Set up python
         if: steps.changes.outputs.end_to_end == 'true'
         uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1

--- a/.github/workflows/upgrade_downgrade_test_semi_sync.yml
+++ b/.github/workflows/upgrade_downgrade_test_semi_sync.yml
@@ -112,6 +112,8 @@ jobs:
       - name: Get dependencies for the last release
         if: steps.changes.outputs.end_to_end == 'true'
         run: |
+          go mod edit -droprequire github.com/slackhq/vitess-addons
+          go mod tidy -e
           go mod download
 
       - name: Building last release's binaries

--- a/.github/workflows/vitess_tester_vtgate.yml
+++ b/.github/workflows/vitess_tester_vtgate.yml
@@ -19,7 +19,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-  GOPRIVATE: "github.com/slackhq/vitess-addons"
 
 jobs:
   build:
@@ -66,10 +65,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/vtop_example.yml
+++ b/.github/workflows/vtop_example.yml
@@ -12,8 +12,6 @@ concurrency:
   cancel-in-progress: true
 permissions: read-all
 env:
-  GOPRIVATE: github.com/slackhq/vitess-addons
-  GH_ACCESS_TOKEN: "${{ secrets.GH_ACCESS_TOKEN }}"
 
 jobs:
   build:
@@ -59,11 +57,6 @@ jobs:
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: go.mod
-
-      - name: Setup GitHub access token
-        if: steps.changes.outputs.end_to_end == 'true'
-        run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
-
       - name: Tune the OS
         if: steps.changes.outputs.end_to_end == 'true'
         uses: ./.github/actions/tune-os

--- a/build.env
+++ b/build.env
@@ -33,12 +33,6 @@ export ETCD_VER=v3.5.25
 export CONSUL_VER=1.11.4
 export TOXIPROXY_VER=v2.7.0
 
-# support private github.com/slackhq/vitess-addons repo
-export GOPRIVATE=github.com/slackhq/vitess-addons
-if [[ -n "${GH_ACCESS_TOKEN}" ]]; then
-  git config --global url.https://${GH_ACCESS_TOKEN}@github.com/.insteadOf https://github.com/
-fi
-
 mkdir -p "$VTDATAROOT"
 
 # Set up required soft links.

--- a/docker/bootstrap/Dockerfile.common
+++ b/docker/bootstrap/Dockerfile.common
@@ -37,13 +37,6 @@ RUN groupadd -r vitess && useradd -r -g vitess vitess && \
     mkdir -p /vt/vtdataroot /home/vitess && \
     chown -R vitess:vitess /vt /home/vitess
 
-# Setup private repo access
-ARG GH_ACCESS_TOKEN
-ENV GH_ACCESS_TOKEN=${GH_ACCESS_TOKEN}
-ENV GOPRIVATE=github.com/slackhq/vitess-addons
-RUN git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/ && \
-    su vitess -c "git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/"
-
 # Download vendored Go dependencies
 RUN cd /vt/src/vitess.io/vitess && \
  su vitess -c "/usr/local/go/bin/go mod download"

--- a/docker/bootstrap/build.sh
+++ b/docker/bootstrap/build.sh
@@ -63,7 +63,6 @@ if [ -f "docker/bootstrap/Dockerfile.$flavor" ]; then
     docker build \
       -f docker/bootstrap/Dockerfile.$flavor \
       -t $image \
-      --build-arg GH_ACCESS_TOKEN="$GH_ACCESS_TOKEN" \
       --build-arg bootstrap_version=$version \
       --build-arg image=$base_image \
       .

--- a/docker/bootstrap/docker-bake.hcl
+++ b/docker/bootstrap/docker-bake.hcl
@@ -18,10 +18,6 @@ variable "BOOTSTRAP_FLAVOR" {
   default = "mysql84"
 }
 
-variable "GH_ACCESS_TOKEN" {
-  default = ""
-}
-
 group "default" {
   targets = ["common", "flavor"]
 }
@@ -30,9 +26,7 @@ target "common" {
   context    = "."
   dockerfile = "docker/bootstrap/Dockerfile.common"
   tags       = ["vitess/bootstrap:${BOOTSTRAP_VERSION}-common"]
-  args = {
-    GH_ACCESS_TOKEN = GH_ACCESS_TOKEN
-  }
+  args = {}
 }
 
 target "flavor" {

--- a/docker/lite/Dockerfile
+++ b/docker/lite/Dockerfile
@@ -33,11 +33,6 @@ RUN groupadd -r vitess && useradd -r -g vitess vitess
 RUN mkdir -p /vt/vtdataroot /home/vitess
 RUN chown -R vitess:vitess /vt /home/vitess
 
-# Setup private repo
-ARG GH_ACCESS_TOKEN
-ENV GH_ACCESS_TOKEN=${GH_ACCESS_TOKEN}
-RUN git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
-
 USER vitess
 
 # Re-copy sources from working tree.
@@ -65,7 +60,6 @@ RUN mkdir -p /vt/vtdataroot /home/vitess && chown -R vitess:vitess /vt /home/vit
 ENV VTROOT /vt
 ENV VTDATAROOT /vt/vtdataroot
 ENV PATH $VTROOT/bin:$PATH
-ENV GOPRIVATE=github.com/slackhq/vitess-addons
 
 # Copy artifacts from builder layer.
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt

--- a/docker/lite/Dockerfile.mysql84
+++ b/docker/lite/Dockerfile.mysql84
@@ -33,11 +33,6 @@ RUN groupadd -r vitess && useradd -r -g vitess vitess
 RUN mkdir -p /vt/vtdataroot /home/vitess
 RUN chown -R vitess:vitess /vt /home/vitess
 
-# Setup private repo
-ARG GH_ACCESS_TOKEN
-ENV GH_ACCESS_TOKEN=${GH_ACCESS_TOKEN}
-RUN git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
-
 USER vitess
 
 # Re-copy sources from working tree.
@@ -65,7 +60,6 @@ RUN mkdir -p /vt/vtdataroot /home/vitess && chown -R vitess:vitess /vt /home/vit
 ENV VTROOT /vt
 ENV VTDATAROOT /vt/vtdataroot
 ENV PATH $VTROOT/bin:$PATH
-ENV GOPRIVATE=github.com/slackhq/vitess-addons
 
 # Copy artifacts from builder layer.
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt

--- a/docker/lite/Dockerfile.percona80
+++ b/docker/lite/Dockerfile.percona80
@@ -33,11 +33,6 @@ RUN groupadd -r vitess && useradd -r -g vitess vitess
 RUN mkdir -p /vt/vtdataroot /home/vitess
 RUN chown -R vitess:vitess /vt /home/vitess
 
-# Setup private repo
-ARG GH_ACCESS_TOKEN
-ENV GH_ACCESS_TOKEN=${GH_ACCESS_TOKEN}
-RUN git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
-
 USER vitess
 
 # Re-copy sources from working tree.
@@ -60,7 +55,6 @@ RUN mkdir -p /vt/vtdataroot && chown -R vitess:vitess /vt
 ENV VTROOT /vt
 ENV VTDATAROOT /vt/vtdataroot
 ENV PATH $VTROOT/bin:$PATH
-ENV GOPRIVATE=github.com/slackhq/vitess-addons
 
 # Copy artifacts from builder layer.
 COPY --from=builder --chown=vitess:vitess /vt/install /vt

--- a/docker/mini/Dockerfile
+++ b/docker/mini/Dockerfile
@@ -16,11 +16,6 @@ FROM vitess/lite
 
 USER root
 
-# Setup private repo
-ARG GH_ACCESS_TOKEN
-ENV GH_ACCESS_TOKEN=${GH_ACCESS_TOKEN}
-RUN git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
-
 # Install dependencies
 COPY docker/utils/install_dependencies.sh /vt/dist/install_dependencies.sh
 RUN /vt/dist/install_dependencies.sh mysql80
@@ -49,7 +44,6 @@ ENV PATH $VTROOT/bin:$PATH
 ENV PATH="/vt/bin:${PATH}"
 ENV PATH="/var/opt/etcd:${PATH}"
 ENV TOPO="etcd"
-ENV GOPRIVATE=github.com/slackhq/vitess-addons
 
 # Create mount point for actual data (e.g. MySQL data dir)
 VOLUME /vt/vtdataroot

--- a/docker/test/run.sh
+++ b/docker/test/run.sh
@@ -182,11 +182,6 @@ fi
 bashcmd=$(append_cmd "$bashcmd" "export VTROOT=/vt/src/vitess.io/vitess")
 bashcmd=$(append_cmd "$bashcmd" "export VTDATAROOT=/vt/vtdataroot")
 bashcmd=$(append_cmd "$bashcmd" "export EXTRA_BIN=/tmp/bin")
-bashcmd=$(append_cmd "$bashcmd" "export GOPRIVATE=$GOPRIVATE")
-
-# Setup private repo
-bashcmd=$(append_cmd "$bashcmd" "git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/")
-
 bashcmd=$(append_cmd "$bashcmd" "mkdir -p dist; mkdir -p bin; mkdir -p lib; mkdir -p vthook")
 bashcmd=$(append_cmd "$bashcmd" "rm -rf /vt/dist; ln -s /vt/src/vitess.io/vitess/dist /vt/dist")
 bashcmd=$(append_cmd "$bashcmd" "rm -rf /vt/bin; ln -s /vt/src/vitess.io/vitess/bin /vt/bin")

--- a/docker/vttestserver/Dockerfile.mysql80
+++ b/docker/vttestserver/Dockerfile.mysql80
@@ -24,11 +24,6 @@ RUN groupadd -r vitess && useradd -r -g vitess vitess
 RUN mkdir -p /vt/vtdataroot /home/vitess
 RUN chown -R vitess:vitess /vt /home/vitess
 
-# Setup private repo
-ARG GH_ACCESS_TOKEN
-ENV GH_ACCESS_TOKEN=${GH_ACCESS_TOKEN}
-RUN git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
-
 USER vitess
 
 # Re-copy sources from working tree.
@@ -51,7 +46,6 @@ RUN mkdir -p /vt/vtdataroot && chown -R vitess:vitess /vt
 ENV VTROOT /vt
 ENV VTDATAROOT /vt/vtdataroot
 ENV PATH $VTROOT/bin:$PATH
-ENV GOPRIVATE=github.com/slackhq/vitess-addons
 
 # Copy artifacts from builder layer.
 COPY --from=builder --chown=vitess:vitess /vt/install /vt

--- a/docker/vttestserver/Dockerfile.mysql84
+++ b/docker/vttestserver/Dockerfile.mysql84
@@ -24,11 +24,6 @@ RUN groupadd -r vitess && useradd -r -g vitess vitess
 RUN mkdir -p /vt/vtdataroot /home/vitess
 RUN chown -R vitess:vitess /vt /home/vitess
 
-# Setup private repo
-ARG GH_ACCESS_TOKEN
-ENV GH_ACCESS_TOKEN=${GH_ACCESS_TOKEN}
-RUN git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
-
 USER vitess
 
 # Re-copy sources from working tree.
@@ -51,7 +46,6 @@ RUN mkdir -p /vt/vtdataroot && chown -R vitess:vitess /vt
 ENV VTROOT /vt
 ENV VTDATAROOT /vt/vtdataroot
 ENV PATH $VTROOT/bin:$PATH
-ENV GOPRIVATE=github.com/slackhq/vitess-addons
 
 # Copy artifacts from builder layer.
 COPY --from=builder --chown=vitess:vitess /vt/install /vt

--- a/go.mod
+++ b/go.mod
@@ -109,7 +109,6 @@ require (
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c
 	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
 	github.com/shirou/gopsutil/v4 v4.26.1
-	github.com/slackhq/vitess-addons v0.22.3
 	github.com/slok/noglog v0.2.0
 	github.com/spf13/afero v1.12.0
 	github.com/spf13/jwalterweatherman v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -546,8 +546,6 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/sjmudd/stopwatch v0.1.1 h1:x45OvxFB5OtCkjvYtzRF5fWB857Jzjjk84Oyd5C5ebw=
 github.com/sjmudd/stopwatch v0.1.1/go.mod h1:BLw0oIQJ1YLXBO/q9ufK/SgnKBVIkC2qrm6uy78Zw6U=
-github.com/slackhq/vitess-addons v0.22.3 h1:RklIo4FBdcCzEVGPpd8BIBzLbtHdExZFf/k0iA+vie8=
-github.com/slackhq/vitess-addons v0.22.3/go.mod h1:7q5pue6aAKpyiOG2ZpfNK27sWV+LKHcy30Pp8QYD38s=
 github.com/slok/noglog v0.2.0 h1:1czu4l2EoJ8L92UwdSXXa1Y+c5TIjFAFm2P+mjej95E=
 github.com/slok/noglog v0.2.0/go.mod h1:TfKxwpEZPT+UA83bQ6RME146k0MM4e8mwHLf6bhcGDI=
 github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=

--- a/go/durability/slack_cross_cell.go
+++ b/go/durability/slack_cross_cell.go
@@ -1,0 +1,85 @@
+package durability
+
+import (
+	"strconv"
+
+	"vitess.io/vitess/go/vt/log"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/vtctl/reparentutil/promotionrule"
+)
+
+const (
+	defaultSemiSyncAckers = 1
+
+	// TabletTagPromotionRule is a tablet-tag used to override the default promotion rule of a REPLICA tablet.
+	// This can be used to make a tablet ineligible for promotion during a reparent.
+	TabletTagPromotionRule = "promotion_rule"
+	// TabletTagSemiSyncAckers is a tablet-tag used to override the default semi-sync ackers required by a PRIMARY tablet.
+	// This can be used to increase the number of semi-sync ackers.
+	TabletTagSemiSyncAckers = "semi_sync_ackers"
+	// TabletTagSemiSyncNeverAck is a tablet-tag used to ensure a PRIMARY or REPLICA tablet will never become a semi-sync acker.
+	// This tag can introduce availability risks. Consider using a different tablet type instead.
+	TabletTagSemiSyncNeverAck = "semi_sync_never_ack"
+)
+
+// SlackCrossCell is a copy of the builtin "cross_cell" Durability Policy with the addition of
+// tablet-tag-based overrides. The policy only allows Primary and Replica type servers from a
+// different cell to acknowledge semi sync. This means that a transaction must be in two cells
+// for it to be acknowledged. By default it returns NeutralPromoteRule for Primary and Replica
+// tablet types, MustNotPromoteRule for everything else.
+type SlackCrossCell struct{}
+
+// PromotionRule implements the Durabler interfacer. The logic duplicates the built-in "cross_cell"
+// policy unless a valid override is set using the tablet-tag: "promotion_rule".
+func (d *SlackCrossCell) PromotionRule(tablet *topodatapb.Tablet) promotionrule.CandidatePromotionRule {
+	switch tablet.Type {
+	case topodatapb.TabletType_PRIMARY:
+		return promotionrule.Neutral
+	case topodatapb.TabletType_REPLICA:
+		if tagValue := tablet.Tags[TabletTagPromotionRule]; tagValue != "" {
+			if promotionRule, err := promotionrule.Parse(tagValue); err == nil {
+				return promotionRule
+			} else {
+				log.Errorf("failed to parse promotion rule tablet tag: %v", err)
+			}
+		}
+		return promotionrule.Neutral
+	}
+	return promotionrule.MustNot
+}
+
+// SemiSyncAckers implements the Durabler interface. The logic duplicates
+// the built-in "cross_cell" policy unless a valid override is set using
+// the tablet-tag: "semi_sync_ackers".
+func (d *SlackCrossCell) SemiSyncAckers(tablet *topodatapb.Tablet) int {
+	if tagValue := tablet.Tags[TabletTagSemiSyncAckers]; tagValue != "" {
+		if ackers, err := strconv.Atoi(tagValue); err == nil {
+			if ackers > 0 {
+				return ackers
+			}
+		} else {
+			log.Errorf("failed to parse semi-sync ackers tablet tag: %v", err)
+		}
+	}
+	return defaultSemiSyncAckers
+}
+
+// IsReplicaSemiSync implements the Durabler interface. The logic duplicates the built-in
+// "cross_cell" policy unless overridden by the tablet-tag "semi_sync_never_ack" being
+// set to "true".
+func (d *SlackCrossCell) IsReplicaSemiSync(primary, replica *topodatapb.Tablet) bool {
+	switch replica.Type {
+	case topodatapb.TabletType_PRIMARY, topodatapb.TabletType_REPLICA:
+		// WARNING: this tablet tag could lead to availability risks. Deploy this tag with caution!
+		if tagValue := replica.Tags[TabletTagSemiSyncNeverAck]; tagValue == "true" {
+			return false
+		}
+		return primary.Alias.Cell != replica.Alias.Cell
+	}
+	return false
+}
+
+// HasSemiSync returns whether the durability policy uses semi-sync.
+func (d *SlackCrossCell) HasSemiSync() bool {
+	return true
+}

--- a/go/durability/slack_cross_cell_test.go
+++ b/go/durability/slack_cross_cell_test.go
@@ -1,0 +1,186 @@
+package durability
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/vtctl/reparentutil/promotionrule"
+)
+
+func TestSlackCrossCellPromotionRule(t *testing.T) {
+	t.Parallel()
+	scc := &SlackCrossCell{}
+
+	t.Run("PRIMARY", func(t *testing.T) {
+		assert.Equal(t, promotionrule.Neutral, scc.PromotionRule(&topodatapb.Tablet{
+			Hostname: t.Name(),
+			Type:     topodatapb.TabletType_PRIMARY,
+			Tags: map[string]string{
+				TabletTagPromotionRule: string(promotionrule.MustNot), // tag should be ignored on PRIMARY
+			},
+		}))
+	})
+
+	t.Run("REPLICA", func(t *testing.T) {
+		assert.Equal(t, promotionrule.Neutral, scc.PromotionRule(&topodatapb.Tablet{
+			Hostname: t.Name(),
+			Type:     topodatapb.TabletType_REPLICA,
+		}))
+	})
+
+	t.Run("REPLICA_invalid_override_tag", func(t *testing.T) {
+		assert.Equal(t, promotionrule.Neutral, scc.PromotionRule(&topodatapb.Tablet{
+			Hostname: t.Name(),
+			Type:     topodatapb.TabletType_REPLICA,
+			Tags: map[string]string{
+				TabletTagPromotionRule: "invalid-rule", // should be ignored
+			},
+		}))
+	})
+
+	t.Run("REPLICA_valid_override_tag", func(t *testing.T) {
+		assert.Equal(t, promotionrule.PreferNot, scc.PromotionRule(&topodatapb.Tablet{
+			Hostname: t.Name(),
+			Type:     topodatapb.TabletType_REPLICA,
+			Tags: map[string]string{
+				TabletTagPromotionRule: string(promotionrule.PreferNot),
+			},
+		}))
+	})
+
+	t.Run("DRAINED_valid_override_tag_ignored", func(t *testing.T) {
+		assert.Equal(t, promotionrule.MustNot, scc.PromotionRule(&topodatapb.Tablet{
+			Hostname: t.Name(),
+			Type:     topodatapb.TabletType_DRAINED,
+			Tags: map[string]string{
+				TabletTagPromotionRule: string(promotionrule.PreferNot),
+			},
+		}))
+	})
+
+	// test 'must_not' tablet types
+	for _, tabletType := range []topodatapb.TabletType{
+		topodatapb.TabletType_RDONLY,
+		topodatapb.TabletType_DRAINED,
+		topodatapb.TabletType_BACKUP,
+		topodatapb.TabletType_RESTORE,
+	} {
+		t.Run(tabletType.String(), func(t *testing.T) {
+			assert.Equal(t, promotionrule.MustNot, scc.PromotionRule(&topodatapb.Tablet{
+				Hostname: t.Name(),
+				Type:     tabletType,
+			}))
+		})
+	}
+}
+
+func TestSlackCrossCellSemiSyncAckers(t *testing.T) {
+	t.Parallel()
+	scc := &SlackCrossCell{}
+
+	t.Run("default", func(t *testing.T) {
+		assert.Equal(t, defaultSemiSyncAckers, scc.SemiSyncAckers(&topodatapb.Tablet{
+			Hostname: t.Name(),
+		}))
+	})
+
+	t.Run("invalid_override_tag1", func(t *testing.T) {
+		assert.Equal(t, defaultSemiSyncAckers, scc.SemiSyncAckers(&topodatapb.Tablet{
+			Hostname: t.Name(),
+			Tags: map[string]string{
+				TabletTagSemiSyncAckers: "0",
+			},
+		}))
+	})
+
+	t.Run("invalid_override_tag2", func(t *testing.T) {
+		assert.Equal(t, defaultSemiSyncAckers, scc.SemiSyncAckers(&topodatapb.Tablet{
+			Hostname: t.Name(),
+			Tags: map[string]string{
+				TabletTagSemiSyncAckers: "not-a-number",
+			},
+		}))
+	})
+
+	t.Run("valid_override_tag", func(t *testing.T) {
+		assert.Equal(t, 3, scc.SemiSyncAckers(&topodatapb.Tablet{
+			Hostname: t.Name(),
+			Tags: map[string]string{
+				TabletTagSemiSyncAckers: "3",
+			},
+		}))
+	})
+}
+
+func TestSlackCrossCellIsReplicaSemiSync(t *testing.T) {
+	t.Parallel()
+	scc := &SlackCrossCell{}
+
+	primary := &topodatapb.Tablet{
+		Hostname: "primary",
+		Alias: &topodatapb.TabletAlias{
+			Cell: "cell1",
+			Uid:  123,
+		},
+		Type: topodatapb.TabletType_PRIMARY,
+	}
+
+	t.Run("cross_cell", func(t *testing.T) {
+		assert.True(t, scc.IsReplicaSemiSync(primary, &topodatapb.Tablet{
+			Hostname: t.Name(),
+			Alias: &topodatapb.TabletAlias{
+				Cell: "cell2",
+				Uid:  1234,
+			},
+			Type: topodatapb.TabletType_REPLICA,
+		}))
+	})
+
+	t.Run("cross_cell_override_tag", func(t *testing.T) {
+		assert.False(t, scc.IsReplicaSemiSync(primary, &topodatapb.Tablet{
+			Hostname: t.Name(),
+			Alias: &topodatapb.TabletAlias{
+				Cell: "cell2",
+				Uid:  1234,
+			},
+			Type: topodatapb.TabletType_REPLICA,
+			Tags: map[string]string{
+				TabletTagSemiSyncNeverAck: "true",
+			},
+		}))
+	})
+
+	t.Run("cross_cell_override_tag_false", func(t *testing.T) {
+		assert.True(t, scc.IsReplicaSemiSync(primary, &topodatapb.Tablet{
+			Hostname: t.Name(),
+			Alias: &topodatapb.TabletAlias{
+				Cell: "cell2",
+				Uid:  1234,
+			},
+			Type: topodatapb.TabletType_REPLICA,
+			Tags: map[string]string{
+				TabletTagSemiSyncNeverAck: "false",
+			},
+		}))
+	})
+
+	t.Run("same_cell", func(t *testing.T) {
+		assert.False(t, scc.IsReplicaSemiSync(primary, &topodatapb.Tablet{
+			Hostname: t.Name(),
+			Alias: &topodatapb.TabletAlias{
+				Cell: primary.Alias.Cell,
+				Uid:  12345,
+			},
+			Type: topodatapb.TabletType_REPLICA,
+		}))
+	})
+}
+
+func TestSlackCrossCellHasSemiSync(t *testing.T) {
+	t.Parallel()
+	scc := &SlackCrossCell{}
+
+	assert.True(t, scc.HasSemiSync())
+}

--- a/go/external/vtops.go
+++ b/go/external/vtops.go
@@ -1,0 +1,157 @@
+package external
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/pflag"
+	"golang.org/x/sync/semaphore"
+
+	"vitess.io/vitess/go/stats"
+	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/servenv"
+)
+
+const vtopsSendSlackMessageCommand = "send-slack-message"
+
+var (
+	vtopsBinaryPath     string        = os.Getenv("VTOPS_PATH")
+	vtopsExecTimeout    time.Duration = time.Second * 10
+	vtopsMaxConcurrency int64         = 12
+
+	statsVtopsInflightExecutions   *stats.GaugesWithSingleLabel
+	statsVtopsMaxConcurrency       *stats.Gauge
+	statsVtopsFailedExecutions     *stats.CountersWithMultiLabels
+	statsVtopsSuccessfulExecutions *stats.CountersWithSingleLabel
+)
+
+func init() {
+	// flags
+	servenv.OnParse(func(fs *pflag.FlagSet) {
+		fs.StringVar(&vtopsBinaryPath, "vtops-binary-path", vtopsBinaryPath,
+			"path to the slack vtops binary")
+		fs.DurationVar(&vtopsExecTimeout, "vtops-exec-timeout", vtopsExecTimeout,
+			"execution timeout for the slack vtops binary")
+		fs.Int64Var(&vtopsMaxConcurrency, "vtops-max-concurrency", vtopsMaxConcurrency,
+			"max concurrency for executing the slack vtops binary")
+	})
+
+	// stats
+	statsVtopsInflightExecutions = stats.NewGaugesWithSingleLabel("VtopsInflightExecutions",
+		"number of vtops executions currently running", "type")
+	statsVtopsMaxConcurrency = stats.NewGauge("VtopsMaxConcurrency",
+		"maximum number of concurrent vtops executions")
+	statsVtopsFailedExecutions = stats.NewCountersWithMultiLabels("VtopsFailedExecutions",
+		"number of failures executing the slack vtops binary", []string{"type", "exit_code"})
+	statsVtopsSuccessfulExecutions = stats.NewCountersWithSingleLabel("VtopsSuccessfulExecutions",
+		"number of times the slack vtops binary was successfully executed", "type")
+}
+
+type outputHandler func(stderr, stdout *bytes.Buffer)
+
+func logOutputHandler(stderr, stdout *bytes.Buffer) {
+	if stdout.Len() > 0 {
+		log.Infof("vtops stdout: %s", stdout.String())
+	}
+	if stderr.Len() > 0 {
+		log.Errorf("vtops stderr: %s", stderr.String())
+	}
+}
+
+func vtorcServiceName() string {
+	return fmt.Sprintf("vtorc-%s-%s", os.Getenv("POOL"), os.Getenv("VITESS_ENVIRONMENT"))
+}
+
+type ExecVTOps struct {
+	BinaryPath string
+	Service    string
+	Hostname   string
+
+	// output handler
+	outputHandler outputHandler
+
+	// prevent too many concurrent execs
+	sem *semaphore.Weighted
+}
+
+func NewExecVTOps() *ExecVTOps {
+	hostname, err := os.Hostname()
+	if err != nil {
+		panic(err)
+	}
+	statsVtopsMaxConcurrency.Set(vtopsMaxConcurrency)
+	return &ExecVTOps{
+		BinaryPath:    vtopsBinaryPath,
+		Service:       vtorcServiceName(),
+		Hostname:      hostname,
+		outputHandler: logOutputHandler,
+		sem:           semaphore.NewWeighted(vtopsMaxConcurrency),
+	}
+}
+
+func (e *ExecVTOps) execCommand(name string, vtopsArgs ...string) error {
+	if e.BinaryPath == "" {
+		return nil
+	}
+	command := filepath.Base(e.BinaryPath)
+
+	statsVtopsInflightExecutions.Add(name, 1)
+	defer statsVtopsInflightExecutions.Add(name, -1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), vtopsExecTimeout)
+	defer cancel()
+
+	// wait here if too many concurrent execs
+	if err := e.sem.Acquire(ctx, 1); err != nil {
+		log.Errorf("Failed to acquire semaphore for %s command: %+v", command, err)
+		statsVtopsFailedExecutions.Add([]string{name, ""}, 1)
+		return err
+	}
+	defer e.sem.Release(1)
+
+	log.Infof("Running %s command: %s %s", command, e.BinaryPath, strings.Join(vtopsArgs, " "))
+
+	cmd := exec.CommandContext(ctx, e.BinaryPath, vtopsArgs...)
+	if e.outputHandler != nil {
+		var stderr, stdout bytes.Buffer
+		cmd.Stderr = &stderr
+		cmd.Stdout = &stdout
+		defer e.outputHandler(&stderr, &stdout)
+	}
+
+	if err := cmd.Run(); err != nil {
+		log.Errorf("Error executing %q command: %+v", command, err)
+		exitCode := 1
+		var execErr *exec.ExitError
+		if errors.As(err, &execErr) {
+			exitCode = execErr.ExitCode()
+		}
+		statsVtopsFailedExecutions.Add([]string{name, strconv.Itoa(exitCode)}, 1)
+		return err
+	}
+
+	statsVtopsSuccessfulExecutions.Add(name, 1)
+	return nil
+}
+
+func (e *ExecVTOps) SendSlackMessage(message string, channel string) {
+	if e.BinaryPath == "" {
+		log.Warningf("No vtops binary path set, not sending message to slack channel %s", channel)
+		return
+	}
+
+	message = fmt.Sprintf("[%s/%s] %s", e.Service, e.Hostname, message)
+	go e.execCommand("SendSlackMessage", vtopsSendSlackMessageCommand, //nolint:errcheck
+		"--channel", channel,
+		"--message", message,
+		"--sender", e.Service,
+	)
+}

--- a/go/external/vtops_test.go
+++ b/go/external/vtops_test.go
@@ -1,0 +1,75 @@
+package external
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExecCommand(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no-binary-path", func(t *testing.T) {
+		e := NewExecVTOps()
+		e.Service = t.Name()
+		assert.NoError(t, e.execCommand("test", ""))
+		assert.Empty(t, statsVtopsFailedExecutions.Counts())
+		assert.Empty(t, statsVtopsSuccessfulExecutions.Counts())
+	})
+
+	t.Run("success", func(t *testing.T) {
+		defer statsVtopsSuccessfulExecutions.ResetAll()
+
+		e := NewExecVTOps()
+		e.Service = t.Name()
+		e.BinaryPath = "/bin/echo"
+		e.outputHandler = func(stderr, stdout *bytes.Buffer) {
+			assert.Zero(t, stderr.Len())
+			assert.Equal(t, "hello world!", strings.TrimSpace(stdout.String()))
+		}
+		assert.NoError(t, e.execCommand("test", "hello world!"))
+		assert.Equal(t, map[string]int64{"test": 1}, statsVtopsSuccessfulExecutions.Counts())
+		assert.Empty(t, statsVtopsFailedExecutions.Counts())
+	})
+
+	t.Run("does-not-exist", func(t *testing.T) {
+		defer statsVtopsFailedExecutions.ResetAll()
+
+		e := NewExecVTOps()
+		e.Service = t.Name()
+		e.BinaryPath = "/bin/does-not-exist"
+		assert.ErrorContains(t, e.execCommand("test", "test"), "fork/exec /bin/does-not-exist: no such file or directory")
+		assert.Equal(t, map[string]int64{"test.1": 1}, statsVtopsFailedExecutions.Counts())
+		assert.Empty(t, statsVtopsSuccessfulExecutions.Counts())
+	})
+
+	t.Run("failed", func(t *testing.T) {
+		defer statsVtopsFailedExecutions.ResetAll()
+
+		e := NewExecVTOps()
+		e.Service = t.Name()
+		e.BinaryPath = "/usr/bin/false"
+		assert.ErrorContains(t, e.execCommand("test", "test"), "exit status 1")
+		assert.Equal(t, map[string]int64{"test.1": 1}, statsVtopsFailedExecutions.Counts())
+		assert.Empty(t, statsVtopsSuccessfulExecutions.Counts())
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		vtopsExecTimeoutOrig := vtopsExecTimeout
+		defer func() {
+			statsVtopsFailedExecutions.ResetAll()
+			vtopsExecTimeout = vtopsExecTimeoutOrig
+		}()
+		vtopsExecTimeout = 500 * time.Millisecond
+
+		e := NewExecVTOps()
+		e.Service = t.Name()
+		e.BinaryPath = "/bin/sleep"
+		assert.ErrorContains(t, e.execCommand("test", "60"), "signal: killed")
+		assert.Equal(t, map[string]int64{"test.-1": 1}, statsVtopsFailedExecutions.Counts())
+		assert.Empty(t, statsVtopsSuccessfulExecutions.Counts())
+	})
+}

--- a/go/vt/vtctl/reparentutil/policy/slack_cross_cell_shim.go
+++ b/go/vt/vtctl/reparentutil/policy/slack_cross_cell_shim.go
@@ -1,6 +1,6 @@
 package policy
 
-import "github.com/slackhq/vitess-addons/go/durability"
+import "vitess.io/vitess/go/durability"
 
 func init() {
 	RegisterDurability("slack_cross_cell", func() Durabler {

--- a/test/ci_workflow_gen.go
+++ b/test/ci_workflow_gen.go
@@ -49,7 +49,6 @@ const (
 	defaultRunnerName = "ubuntu-24.04"
 )
 
-const goPrivate = ""
 
 const (
 	workflowConfigDir = "../.github/workflows"
@@ -171,7 +170,7 @@ var (
 )
 
 type unitTest struct {
-	Name, RunsOn, Platform, FileName, GoPrivate, Evalengine string
+	Name, RunsOn, Platform, FileName, Evalengine string
 	Race                                                    bool
 }
 
@@ -180,7 +179,6 @@ type clusterTest struct {
 	FileName                           string
 	BuildTag                           string
 	RunsOn                             string
-	GoPrivate                          string
 	MemoryCheck                        bool
 	MakeTools, InstallXtraBackup       bool
 	Docker                             bool
@@ -195,7 +193,6 @@ type vitessTesterTest struct {
 	FileName  string
 	Name      string
 	RunsOn    string
-	GoPrivate string
 	Path      string
 }
 
@@ -254,7 +251,6 @@ func generateVitessTesterWorkflows(mp map[string]string, tpl string) {
 		tt := &vitessTesterTest{
 			Name:      fmt.Sprintf("Vitess Tester (%v)", test),
 			RunsOn:    defaultRunnerName,
-			GoPrivate: goPrivate,
 			Path:      testPath,
 		}
 
@@ -277,8 +273,7 @@ func generateClusterWorkflows(list []string, tpl string) {
 				Shard:     cluster,
 				BuildTag:  buildTag[cluster],
 				RunsOn:    defaultRunnerName,
-				GoPrivate: goPrivate,
-			}
+				}
 			cores16Clusters := canonnizeList(clusterRequiring16CoresMachines)
 			for _, cores16Cluster := range cores16Clusters {
 				if cores16Cluster == cluster {
@@ -356,7 +351,6 @@ func generateUnitTestWorkflows() {
 				Name:       fmt.Sprintf("Unit Test (%s%s)", evalengineToString(evalengine), platform),
 				RunsOn:     defaultRunnerName,
 				Platform:   string(platform),
-				GoPrivate:  goPrivate,
 				Evalengine: evalengine,
 			}
 			test.FileName = fmt.Sprintf("unit_test_%s%s.yml", evalengineToString(evalengine), platform)
@@ -374,7 +368,6 @@ func generateUnitTestWorkflows() {
 			Name:       fmt.Sprintf("Unit Test (%sRace)", evalengineToRaceNamePrefix(evalengine)),
 			RunsOn:     cores16RunnerName,
 			Platform:   string(mysql80),
-			GoPrivate:  goPrivate,
 			Evalengine: evalengine,
 			Race:       true,
 		}

--- a/test/ci_workflow_gen.go
+++ b/test/ci_workflow_gen.go
@@ -49,7 +49,6 @@ const (
 	defaultRunnerName = "ubuntu-24.04"
 )
 
-
 const (
 	workflowConfigDir = "../.github/workflows"
 
@@ -171,7 +170,7 @@ var (
 
 type unitTest struct {
 	Name, RunsOn, Platform, FileName, Evalengine string
-	Race                                                    bool
+	Race                                         bool
 }
 
 type clusterTest struct {
@@ -190,10 +189,10 @@ type clusterTest struct {
 }
 
 type vitessTesterTest struct {
-	FileName  string
-	Name      string
-	RunsOn    string
-	Path      string
+	FileName string
+	Name     string
+	RunsOn   string
+	Path     string
 }
 
 // clusterMySQLVersions return list of mysql versions (one or more) that this cluster needs to test against
@@ -249,9 +248,9 @@ func canonnizeList(list []string) []string {
 func generateVitessTesterWorkflows(mp map[string]string, tpl string) {
 	for test, testPath := range mp {
 		tt := &vitessTesterTest{
-			Name:      fmt.Sprintf("Vitess Tester (%v)", test),
-			RunsOn:    defaultRunnerName,
-			Path:      testPath,
+			Name:   fmt.Sprintf("Vitess Tester (%v)", test),
+			RunsOn: defaultRunnerName,
+			Path:   testPath,
 		}
 
 		templateFileName := tpl
@@ -269,11 +268,11 @@ func generateClusterWorkflows(list []string, tpl string) {
 	for _, cluster := range clusters {
 		for _, mysqlVersion := range clusterMySQLVersions() {
 			test := &clusterTest{
-				Name:      fmt.Sprintf("Cluster (%s)", cluster),
-				Shard:     cluster,
-				BuildTag:  buildTag[cluster],
-				RunsOn:    defaultRunnerName,
-				}
+				Name:     fmt.Sprintf("Cluster (%s)", cluster),
+				Shard:    cluster,
+				BuildTag: buildTag[cluster],
+				RunsOn:   defaultRunnerName,
+			}
 			cores16Clusters := canonnizeList(clusterRequiring16CoresMachines)
 			for _, cores16Cluster := range cores16Clusters {
 				if cores16Cluster == cluster {

--- a/test/ci_workflow_gen.go
+++ b/test/ci_workflow_gen.go
@@ -49,11 +49,7 @@ const (
 	defaultRunnerName = "ubuntu-24.04"
 )
 
-// To support a private git repository, set goPrivate to a repo in
-// github.com/org/repo format. This assumes a GitHub PAT token is
-// set as a repo secret named GH_ACCESS_TOKEN. The GitHub PAT must
-// have read access to your vitess fork/repo.
-const goPrivate = "github.com/slackhq/vitess-addons"
+const goPrivate = ""
 
 const (
 	workflowConfigDir = "../.github/workflows"

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -17,7 +17,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{`{{ github.event.pull_request.head.sha }}`}}"
-{{if .GoPrivate}}  GOPRIVATE: "{{.GoPrivate}}"{{end}}
 
 jobs:
   build:
@@ -81,12 +80,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-{{if .GoPrivate}}
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{`{{ secrets.GH_ACCESS_TOKEN }}`}}@github.com/.insteadOf https://github.com/
-{{end}}
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/test/templates/cluster_endtoend_test_docker.tpl
+++ b/test/templates/cluster_endtoend_test_docker.tpl
@@ -10,9 +10,6 @@ on:
 
 permissions: read-all
 
-env:
-{{if .GoPrivate}}  GOPRIVATE: "{{.GoPrivate}}"{{end}}
-
 jobs:
   build:
     name: Run endtoend tests on {{.Name}}
@@ -58,12 +55,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-{{if .GoPrivate}}
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{`{{ secrets.GH_ACCESS_TOKEN }}`}}@github.com/.insteadOf https://github.com/
-{{end}}
 
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'

--- a/test/templates/cluster_endtoend_test_mysql57.tpl
+++ b/test/templates/cluster_endtoend_test_mysql57.tpl
@@ -17,7 +17,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{`{{ github.event.pull_request.head.sha }}`}}"
-{{if .GoPrivate}}  GOPRIVATE: "{{.GoPrivate}}"{{end}}
 {{if .InstallXtraBackup}}
   # This is used if we need to pin the xtrabackup version used in tests.
   # If this is NOT set then the latest version available will be used.
@@ -85,12 +84,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-{{if .GoPrivate}}
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{`{{ secrets.GH_ACCESS_TOKEN }}`}}@github.com/.insteadOf https://github.com/
-{{end}}
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/test/templates/cluster_vitess_tester.tpl
+++ b/test/templates/cluster_vitess_tester.tpl
@@ -17,7 +17,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{`{{ github.event.pull_request.head.sha }}`}}"
-{{if .GoPrivate}}  GOPRIVATE: "{{.GoPrivate}}"{{end}}
 
 jobs:
   build:
@@ -64,12 +63,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-{{if .GoPrivate}}
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.end_to_end == 'true'
-      run: git config --global url.https://${{`{{ secrets.GH_ACCESS_TOKEN }}`}}@github.com/.insteadOf https://github.com/
-{{end}}
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/test/templates/unit_test.tpl
+++ b/test/templates/unit_test.tpl
@@ -17,7 +17,6 @@ env:
   LAUNCHABLE_ORGANIZATION: "vitess"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{`{{ github.event.pull_request.head.sha }}`}}"
-{{if .GoPrivate}}  GOPRIVATE: "{{.GoPrivate}}"{{end}}
 
 jobs:
   test:
@@ -62,12 +61,6 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: go.mod
-
-{{if .GoPrivate}}
-    - name: Setup GitHub access token
-      if: steps.changes.outputs.unit_tests == 'true'
-      run: git config --global url.https://${{`{{ secrets.GH_ACCESS_TOKEN }}`}}@github.com/.insteadOf https://github.com/
-{{end}}
 
     - name: Set up python
       if: steps.changes.outputs.unit_tests == 'true'

--- a/test/vtop_example.sh
+++ b/test/vtop_example.sh
@@ -488,7 +488,7 @@ EOF
 kind delete cluster --name kind || true
 
 # Build the docker image for vitess/lite using the local code
-docker build -f docker/lite/Dockerfile --build-arg GH_ACCESS_TOKEN=$GH_ACCESS_TOKEN -t vitess/lite:pr .
+docker build -f docker/lite/Dockerfile -t vitess/lite:pr .
 # Build the docker image for vitess/vtadmin using the local code
 docker build -f docker/binaries/vtadmin/Dockerfile --build-arg VT_BASE_VER=pr -t vitess/vtadmin:pr ./docker/binaries/vtadmin
 


### PR DESCRIPTION
## What's this?

Brings the vitess-addons code (durability policy + vtops external binary wrapper) directly into this repo and removes all the GH_ACCESS_TOKEN / GOPRIVATE plumbing that was needed to access the private dependency.

## How it works

**Commit 1:** Copies `go/durability/` and `go/external/` from vitess-addons, updates the shim import, removes the module dependency.

**Commit 2:** Strips GH_ACCESS_TOKEN from Dockerfiles, build scripts, CI workflows, and the workflow generator. Regenerates all CI workflow YAMLs.

## Testing

- `go build ./...` passes
- `go test ./go/durability/... ./go/external/... ./go/vt/vtctl/reparentutil/policy/...` all pass
- Zero remaining references to vitess-addons/GH_ACCESS_TOKEN/GOPRIVATE outside of inert template conditionals

---
_Most of this was written by Claude Code - I just provided direction._