### PR TITLE
vreplication: fix OOM on tables with large JSON columns (#19878)

### DIFF
--- a/go/bytes2/buffer.go
+++ b/go/bytes2/buffer.go
@@ -72,3 +72,10 @@ func (buf *Buffer) Reset() {
 func (buf *Buffer) Len() int {
 	return len(buf.bytes)
 }
+
+// Truncate discards all but the first n bytes from the buffer but
+// continues to use the same allocated storage.
+// It panics if n is negative or greater than the length of the buffer.
+func (buf *Buffer) Truncate(n int) {
+	buf.bytes = buf.bytes[:n]
+}

--- a/go/mysql/json/marshal.go
+++ b/go/mysql/json/marshal.go
@@ -17,14 +17,18 @@ limitations under the License.
 package json
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
+	"unicode/utf16"
+	"unicode/utf8"
 
+	"vitess.io/vitess/go/bytes2"
 	"vitess.io/vitess/go/hack"
 	"vitess.io/vitess/go/mysql/hex"
-	querypb "vitess.io/vitess/go/vt/proto/query"
-
 	"vitess.io/vitess/go/sqltypes"
+
+	querypb "vitess.io/vitess/go/vt/proto/query"
 )
 
 // MarshalSQLTo appends marshaled v to dst and returns the result in
@@ -162,19 +166,376 @@ func (v *Value) marshalSQLInternal(top bool, dst []byte) []byte {
 	}
 }
 
-// MarshalSQLValue converts the byte representation of a json value
-// and returns it formatted by MarshalSQLTo
-func MarshalSQLValue(buf []byte) (*sqltypes.Value, error) {
-	var parser Parser
-	if len(buf) == 0 {
-		buf = sqltypes.NullBytes
+// MarshalSQLValue converts text JSON bytes into a SQL expression using
+// JSON_OBJECT/JSON_ARRAY syntax. It scans the raw bytes directly without
+// building an intermediate tree, avoiding the ~60x memory amplification
+// of tree-based encoding.
+func MarshalSQLValue(raw []byte) (*sqltypes.Value, error) {
+	if len(raw) == 0 {
+		raw = sqltypes.NullBytes
 	}
-
-	jsonVal, err := parser.ParseBytes(buf)
-	if err != nil {
+	buf := &bytes2.Buffer{}
+	if err := AppendMarshalSQL(buf, raw); err != nil {
 		return nil, err
 	}
+	v := sqltypes.MakeTrusted(querypb.Type_RAW, buf.Bytes())
+	return &v, nil
+}
 
-	newVal := sqltypes.MakeTrusted(querypb.Type_RAW, jsonVal.MarshalSQLTo(nil))
-	return &newVal, nil
+// AppendMarshalSQL converts text JSON into a SQL expression using
+// JSON_OBJECT/JSON_ARRAY syntax, writing directly to buf. It scans
+// the raw bytes directly without building an intermediate tree.
+//
+// This has O(recursion depth) memory overhead versus O(total nodes * 72
+// bytes) for the tree-based Value.MarshalSQLTo, and avoids the per-token
+// heap allocations of encoding/json.Decoder.Token.
+//
+// The output format matches the tree-based encoder so that MySQL stores
+// identical binary JSON, including preservation of large integer precision
+// via bare numeric literals.
+func AppendMarshalSQL(buf *bytes2.Buffer, raw []byte) error {
+	w := sqlWriter{
+		data: raw,
+		buf:  buf,
+	}
+	if err := w.writeValue(true, 0); err != nil {
+		return err
+	}
+	w.skipWhitespace()
+	if w.pos != len(w.data) {
+		return errors.New("unexpected trailing data after JSON value")
+	}
+	return nil
+}
+
+// sqlWriter converts text JSON into SQL expressions by scanning
+// the raw bytes directly. It uses O(recursion depth) memory overhead
+// plus a reusable scratch buffer for string unescaping.
+type sqlWriter struct {
+	data    []byte
+	pos     int
+	buf     *bytes2.Buffer
+	scratch []byte
+}
+
+func (w *sqlWriter) skipWhitespace() {
+	for w.pos < len(w.data) {
+		switch w.data[w.pos] {
+		case ' ', '\t', '\n', '\r':
+			w.pos++
+		default:
+			return
+		}
+	}
+}
+
+func (w *sqlWriter) writeValue(top bool, depth int) error {
+	if depth >= MaxDepth {
+		return fmt.Errorf("too big depth for the nested JSON; it exceeds %d", MaxDepth)
+	}
+	w.skipWhitespace()
+	if w.pos >= len(w.data) {
+		return errors.New("unexpected end of JSON input")
+	}
+	switch w.data[w.pos] {
+	case '{':
+		w.pos++
+		return w.writeObject(depth)
+	case '[':
+		w.pos++
+		return w.writeArray(depth)
+	case '"':
+		return w.writeString(top)
+	case 't', 'f':
+		return w.writeBool(top)
+	case 'n':
+		return w.writeNull(top)
+	default:
+		if w.data[w.pos] >= '0' && w.data[w.pos] <= '9' || w.data[w.pos] == '-' {
+			return w.writeNumber(top)
+		}
+		return fmt.Errorf("unexpected character %q in JSON", w.data[w.pos])
+	}
+}
+
+func (w *sqlWriter) writeObject(depth int) error {
+	w.buf.WriteString("JSON_OBJECT(")
+	first := true
+	for {
+		w.skipWhitespace()
+		if w.pos >= len(w.data) {
+			return errors.New("unexpected end of JSON input in object")
+		}
+		if w.data[w.pos] == '}' {
+			w.pos++
+			w.buf.WriteByte(')')
+			return nil
+		}
+		if !first {
+			if w.data[w.pos] != ',' {
+				return fmt.Errorf("expected ',' or '}' in object, got %q", w.data[w.pos])
+			}
+			w.pos++
+			w.buf.WriteString(", ")
+			w.skipWhitespace()
+		}
+		first = false
+
+		// Key (always a string).
+		if w.pos >= len(w.data) || w.data[w.pos] != '"' {
+			return errors.New("expected string key in JSON object")
+		}
+		w.buf.WriteString("_utf8mb4")
+		if err := w.writeStringContent(); err != nil {
+			return fmt.Errorf("reading JSON object key: %w", err)
+		}
+		w.buf.WriteString(", ")
+
+		// Colon separator.
+		w.skipWhitespace()
+		if w.pos >= len(w.data) || w.data[w.pos] != ':' {
+			return errors.New("expected ':' after object key")
+		}
+		w.pos++
+
+		// Value.
+		if err := w.writeValue(false, depth+1); err != nil {
+			return err
+		}
+	}
+}
+
+func (w *sqlWriter) writeArray(depth int) error {
+	w.buf.WriteString("JSON_ARRAY(")
+	first := true
+	for {
+		w.skipWhitespace()
+		if w.pos >= len(w.data) {
+			return errors.New("unexpected end of JSON input in array")
+		}
+		if w.data[w.pos] == ']' {
+			w.pos++
+			w.buf.WriteByte(')')
+			return nil
+		}
+		if !first {
+			if w.data[w.pos] != ',' {
+				return fmt.Errorf("expected ',' or ']' in array, got %q", w.data[w.pos])
+			}
+			w.pos++
+			w.buf.WriteString(", ")
+		}
+		first = false
+
+		if err := w.writeValue(false, depth+1); err != nil {
+			return err
+		}
+	}
+}
+
+func (w *sqlWriter) writeString(top bool) error {
+	if top {
+		w.buf.WriteString("CAST(JSON_QUOTE(")
+	}
+	w.buf.WriteString("_utf8mb4")
+	if err := w.writeStringContent(); err != nil {
+		return err
+	}
+	if top {
+		w.buf.WriteString(") as JSON)")
+	}
+	return nil
+}
+
+// writeStringContent reads a JSON string starting at w.pos (which must point
+// at the opening '"'), JSON-unescapes it, SQL-encodes it into w.buf, and
+// advances w.pos past the closing '"'.
+func (w *sqlWriter) writeStringContent() error {
+	if w.pos >= len(w.data) || w.data[w.pos] != '"' {
+		return errors.New("expected '\"' at start of string")
+	}
+	w.pos++ // skip opening '"'
+
+	// Scan to find the closing quote, tracking whether escape sequences exist.
+	start := w.pos
+	hasEscape := false
+	for w.pos < len(w.data) {
+		ch := w.data[w.pos]
+		if ch == '\\' {
+			if w.pos+1 >= len(w.data) {
+				return errors.New("unterminated string in JSON")
+			}
+			hasEscape = true
+			w.pos += 2 // skip '\' and the escaped character
+			continue
+		}
+		if ch == '"' {
+			break
+		}
+		w.pos++
+	}
+	if w.pos >= len(w.data) {
+		return errors.New("unterminated string in JSON")
+	}
+
+	content := w.data[start:w.pos]
+	w.pos++ // skip closing '"'
+
+	if !hasEscape {
+		// Fast path: no escape sequences, raw bytes are the decoded string.
+		sqltypes.MakeTrusted(querypb.Type_VARCHAR, content).EncodeSQLBytes2(w.buf)
+	} else {
+		// Slow path: unescape JSON into scratch buffer, then SQL-encode.
+		var err error
+		w.scratch, err = unescapeJSON(w.scratch[:0], content)
+		if err != nil {
+			return err
+		}
+		sqltypes.MakeTrusted(querypb.Type_VARCHAR, w.scratch).EncodeSQLBytes2(w.buf)
+	}
+	return nil
+}
+
+// unescapeJSON appends the unescaped form of a JSON string body
+// (the bytes between the quotes, not including the quotes themselves) to
+// dst and returns the result. It handles all JSON escape sequences
+// including \uXXXX and UTF-16 surrogate pairs.
+func unescapeJSON(dst, src []byte) ([]byte, error) {
+	i := 0
+	for i < len(src) {
+		if src[i] != '\\' {
+			dst = append(dst, src[i])
+			i++
+			continue
+		}
+		if i+1 >= len(src) {
+			return dst, errors.New("truncated escape sequence in JSON string")
+		}
+		i++ // skip '\'
+		switch src[i] {
+		case '"', '\\', '/':
+			dst = append(dst, src[i])
+			i++
+		case 'b':
+			dst = append(dst, '\b')
+			i++
+		case 'f':
+			dst = append(dst, '\f')
+			i++
+		case 'n':
+			dst = append(dst, '\n')
+			i++
+		case 'r':
+			dst = append(dst, '\r')
+			i++
+		case 't':
+			dst = append(dst, '\t')
+			i++
+		case 'u':
+			i++ // skip 'u'
+			if i+4 > len(src) {
+				return dst, errors.New("truncated \\u escape in JSON string")
+			}
+			r := parseHex4(src[i : i+4])
+			if r < 0 {
+				return dst, fmt.Errorf("invalid hex digit in \\u escape: %q", src[i:i+4])
+			}
+			i += 4
+
+			// Handle UTF-16 surrogate pairs.
+			if utf16.IsSurrogate(r) {
+				if i+6 <= len(src) && src[i] == '\\' && src[i+1] == 'u' {
+					r2 := parseHex4(src[i+2 : i+6])
+					if r2 >= 0 {
+						combined := utf16.DecodeRune(r, r2)
+						if combined != utf8.RuneError {
+							dst = utf8.AppendRune(dst, combined)
+							i += 6
+							continue
+						}
+					}
+				}
+				// Lone surrogate: encode as replacement character.
+				dst = utf8.AppendRune(dst, utf8.RuneError)
+				continue
+			}
+
+			dst = utf8.AppendRune(dst, r)
+		default:
+			return dst, fmt.Errorf("invalid escape character %q in JSON string", src[i])
+		}
+	}
+	return dst, nil
+}
+
+// parseHex4 parses exactly 4 hex digits into a rune. Returns -1 on error.
+func parseHex4(s []byte) rune {
+	var r rune
+	for _, ch := range s {
+		r <<= 4
+		switch {
+		case ch >= '0' && ch <= '9':
+			r |= rune(ch - '0')
+		case ch >= 'a' && ch <= 'f':
+			r |= rune(ch - 'a' + 10)
+		case ch >= 'A' && ch <= 'F':
+			r |= rune(ch - 'A' + 10)
+		default:
+			return -1
+		}
+	}
+	return r
+}
+
+func (w *sqlWriter) writeNumber(top bool) error {
+	// Use the parser's readFloat to validate number grammar, rejecting
+	// malformed inputs like "1+2", "1..2", or "1e+" that a simple
+	// character-class loop would accept.
+	n, ok := readFloat(w.data[w.pos:])
+	if !ok || n == 0 {
+		return fmt.Errorf("invalid number at position %d in JSON", w.pos)
+	}
+	if top {
+		w.buf.WriteString("CAST(")
+	}
+	w.buf.Write(w.data[w.pos : w.pos+n])
+	w.pos += n
+	if top {
+		w.buf.WriteString(" as JSON)")
+	}
+	return nil
+}
+
+func (w *sqlWriter) writeBool(top bool) error {
+	if top {
+		w.buf.WriteString("CAST(_utf8mb4'")
+	}
+	if w.pos+4 <= len(w.data) && string(w.data[w.pos:w.pos+4]) == "true" {
+		w.buf.WriteString("true")
+		w.pos += 4
+	} else if w.pos+5 <= len(w.data) && string(w.data[w.pos:w.pos+5]) == "false" {
+		w.buf.WriteString("false")
+		w.pos += 5
+	} else {
+		return fmt.Errorf("unexpected token at position %d in JSON", w.pos)
+	}
+	if top {
+		w.buf.WriteString("' as JSON)")
+	}
+	return nil
+}
+
+func (w *sqlWriter) writeNull(top bool) error {
+	if w.pos+4 > len(w.data) || string(w.data[w.pos:w.pos+4]) != "null" {
+		return fmt.Errorf("unexpected token at position %d in JSON", w.pos)
+	}
+	if top {
+		w.buf.WriteString("CAST(_utf8mb4'")
+	}
+	w.buf.WriteString("null")
+	w.pos += 4
+	if top {
+		w.buf.WriteString("' as JSON)")
+	}
+	return nil
 }

--- a/go/mysql/json/marshal_test.go
+++ b/go/mysql/json/marshal_test.go
@@ -17,10 +17,13 @@ limitations under the License.
 package json
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"vitess.io/vitess/go/bytes2"
 	"vitess.io/vitess/go/sqltypes"
 )
 
@@ -84,4 +87,76 @@ func TestMarshalSQLValueNormalizesInvalidUTF8(t *testing.T) {
 	normalized := string([]rune(raw))
 	expected := "CAST(JSON_QUOTE(_utf8mb4" + sqltypes.EncodeStringSQL(normalized) + ") as JSON)"
 	require.Equal(t, expected, string(got.Raw()))
+}
+
+// TestAppendMarshalSQLDepthLimit verifies that AppendMarshalSQL enforces
+// the same nesting depth limit as Parser.Parse.
+func TestAppendMarshalSQLDepthLimit(t *testing.T) {
+	for _, tc := range []struct {
+		depth   int
+		wantErr bool
+	}{
+		{depth: 299, wantErr: false},
+		{depth: 300, wantErr: false},
+		{depth: 301, wantErr: true},
+	} {
+		input := strings.Repeat("[", tc.depth) + strings.Repeat("]", tc.depth)
+
+		var p Parser
+		_, parseErr := p.Parse(input)
+
+		buf := &bytes2.Buffer{}
+		appendErr := AppendMarshalSQL(buf, []byte(input))
+
+		if tc.wantErr {
+			assert.Error(t, parseErr, "depth %d: parser should reject", tc.depth)
+			assert.Error(t, appendErr, "depth %d: AppendMarshalSQL should reject", tc.depth)
+		} else {
+			assert.NoError(t, parseErr, "depth %d: parser should accept", tc.depth)
+			assert.NoError(t, appendErr, "depth %d: AppendMarshalSQL should accept", tc.depth)
+		}
+	}
+}
+
+// TestAppendMarshalSQLNumberGrammar verifies that AppendMarshalSQL rejects
+// malformed JSON numbers that a naive character-class scanner would accept.
+func TestAppendMarshalSQLNumberGrammar(t *testing.T) {
+	malformed := []string{
+		`1+2`,
+		`1-2`,
+		`1..2`,
+		`1e+`,
+		`1e`,
+		`--1`,
+	}
+	for _, input := range malformed {
+		buf := &bytes2.Buffer{}
+		err := AppendMarshalSQL(buf, []byte(input))
+		assert.Error(t, err, "malformed number %q should be rejected", input)
+	}
+
+	valid := []string{
+		`0`, `42`, `-1`, `3.14`, `-0.5`,
+		`1e10`, `1E10`, `1e+10`, `1e-10`, `1.5e2`,
+	}
+	for _, input := range valid {
+		buf := &bytes2.Buffer{}
+		err := AppendMarshalSQL(buf, []byte(input))
+		assert.NoError(t, err, "valid number %q should be accepted", input)
+	}
+}
+
+// TestAppendMarshalSQLTrailingBackslash verifies that a backslash as the
+// last byte of a string is rejected rather than causing an out-of-bounds read.
+func TestAppendMarshalSQLTrailingBackslash(t *testing.T) {
+	inputs := []string{
+		`"trailing\`,      // backslash is last byte, no closing quote
+		`{"key": "val\"}`, // backslash before quote looks like escaped quote, string never closes
+	}
+	for _, input := range inputs {
+		buf := &bytes2.Buffer{}
+		err := AppendMarshalSQL(buf, []byte(input))
+		assert.Error(t, err, "input %q should be rejected", input)
+		assert.ErrorContains(t, err, "unterminated string", "input %q", input)
+	}
 }

--- a/go/mysql/json/parser.go
+++ b/go/mysql/json/parser.go
@@ -512,7 +512,7 @@ func parseRawString(s string) (string, string, error) {
 	}
 }
 
-func readFloat(s string) (i int, ok bool) {
+func readFloat[S string | []byte](s S) (i int, ok bool) {
 	// optional sign
 	if i >= len(s) {
 		return

--- a/go/vt/vttablet/tabletmanager/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/framework_test.go
@@ -171,6 +171,10 @@ func (tenv *testEnv) addTablet(t *testing.T, id int, keyspace, shard string) *fa
 
 	vrdbClient := binlogplayer.NewMockDBClient(t)
 	vrdbClient.Tag = fmt.Sprintf("tablet:%d", id)
+	vrdbClient.AddInvariant(vreplication.SqlMaxAllowedPacket, sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields("max_allowed_packet", "int64"),
+		"65536",
+	))
 	tenv.tmc.tablets[id] = &fakeTabletConn{
 		tablet:     tablet,
 		vrdbClient: vrdbClient,

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
@@ -256,23 +256,74 @@ func (tp *TablePlan) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&v)
 }
 
-func (tp *TablePlan) applyBulkInsert(sqlbuffer *bytes2.Buffer, rows []*querypb.Row, executor func(string) (*sqltypes.Result, error)) (*sqltypes.Result, error) {
-	sqlbuffer.Reset()
-	sqlbuffer.WriteString(tp.BulkInsertFront.Query)
-	sqlbuffer.WriteString(" values ")
+func (tp *TablePlan) applyBulkInsert(sqlbuffer *bytes2.Buffer, rows []*querypb.Row, executor func(string) (*sqltypes.Result, error), maxQuerySize int64) (*sqltypes.Result, error) {
+	insertPrefix := tp.BulkInsertFront.Query + " values "
+	insertSuffixLen := 0
+	if tp.BulkInsertOnDup != nil {
+		insertSuffixLen = len(tp.BulkInsertOnDup.Query)
+	}
 
-	for i, row := range rows {
-		if i > 0 {
+	flush := func(final bool) (*sqltypes.Result, error) {
+		if tp.BulkInsertOnDup != nil {
+			sqlbuffer.WriteString(tp.BulkInsertOnDup.Query)
+		}
+		if final {
+			// Last flush: safe to use StringUnsafe since we won't reuse the buffer.
+			return executor(sqlbuffer.StringUnsafe())
+		}
+		// Mid-batch flush: must copy because we'll reuse the buffer for the next batch.
+		return executor(sqlbuffer.String())
+	}
+
+	sqlbuffer.Reset()
+	sqlbuffer.WriteString(insertPrefix)
+
+	var lastResult *sqltypes.Result
+	rowCount := 0
+	for _, row := range rows {
+		beforeLen := sqlbuffer.Len()
+		if rowCount > 0 {
 			sqlbuffer.WriteString(", ")
 		}
 		if err := tp.appendFromRow(sqlbuffer, row); err != nil {
 			return nil, err
 		}
+		rowCount++
+
+		// If the buffer exceeds maxQuerySize and we have more than one
+		// row, flush everything before this row and start a new statement.
+		if maxQuerySize > 0 && int64(sqlbuffer.Len()+insertSuffixLen) > maxQuerySize && rowCount > 1 {
+			// Roll back to before this row was appended.
+			sqlbuffer.Truncate(beforeLen)
+			result, err := flush(false)
+			if err != nil {
+				return nil, err
+			}
+			if lastResult == nil {
+				lastResult = result
+			} else {
+				lastResult.RowsAffected += result.RowsAffected
+			}
+
+			// Start a new INSERT with this row.
+			sqlbuffer.Reset()
+			sqlbuffer.WriteString(insertPrefix)
+			if err := tp.appendFromRow(sqlbuffer, row); err != nil {
+				return nil, err
+			}
+			rowCount = 1
+		}
 	}
-	if tp.BulkInsertOnDup != nil {
-		sqlbuffer.WriteString(tp.BulkInsertOnDup.Query)
+
+	result, err := flush(true)
+	if err != nil {
+		return nil, err
 	}
-	return executor(sqlbuffer.StringUnsafe())
+	if lastResult != nil {
+		lastResult.RowsAffected += result.RowsAffected
+		return lastResult, nil
+	}
+	return result, nil
 }
 
 // During the copy phase we run catchup and fastforward, which stream binlogs. While streaming we should only process
@@ -613,6 +664,9 @@ func (tp *TablePlan) applyBulkInsertChanges(rowInserts []*binlogdatapb.RowChange
 	prefix.WriteString(tp.BulkInsertFront.Query)
 	prefix.WriteString(" values ")
 	insertPrefix := prefix.String()
+	if tp.BulkInsertOnDup != nil {
+		maxQuerySize -= int64(len(tp.BulkInsertOnDup.Query))
+	}
 	maxQuerySize -= int64(len(insertPrefix))
 	values := &strings.Builder{}
 
@@ -656,7 +710,7 @@ func (tp *TablePlan) applyBulkInsertChanges(rowInserts []*binlogdatapb.RowChange
 		if err := tp.BulkInsertValues.Append(rowValues, bindvars, nil); err != nil {
 			return nil, err
 		}
-		if int64(values.Len()+2+rowValues.Len()) > maxQuerySize { // Plus 2 for the comma and space
+		if !newStmt && int64(values.Len()+2+rowValues.Len()) > maxQuerySize { // Plus 2 for the comma and space
 			if _, err := execQuery(values); err != nil {
 				return nil, err
 			}
@@ -757,13 +811,11 @@ func (tp *TablePlan) appendFromRow(buf *bytes2.Buffer, row *querypb.Row) error {
 		case querypb.Type_JSON:
 			if length < 0 { // An SQL NULL and not an actual JSON value
 				buf.WriteString(sqltypes.NullStr)
-			} else { // A JSON value (which may be a JSON null literal value)
-				buf2 := row.Values[offset : offset+length]
-				vv, err := vjson.MarshalSQLValue(buf2)
-				if err != nil {
+			} else {
+				raw := row.Values[offset : offset+length]
+				if err := vjson.AppendMarshalSQL(buf, raw); err != nil {
 					return err
 				}
-				buf.WriteString(vv.RawStr())
 			}
 		default:
 			if length < 0 {

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
@@ -26,6 +26,7 @@ import (
 
 	"vitess.io/vitess/go/bytes2"
 	"vitess.io/vitess/go/mysql/collations"
+	vjson "vitess.io/vitess/go/mysql/json"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -962,5 +963,320 @@ func TestAppendFromRow(t *testing.T) {
 				require.Equal(t, tc.want, bb.String())
 			}
 		})
+	}
+}
+
+func TestApplyBulkInsertMaxQuerySize(t *testing.T) {
+	tp := &TablePlan{
+		BulkInsertFront: sqlparser.BuildParsedQuery("insert into t(c1, c2)"),
+		BulkInsertValues: sqlparser.BuildParsedQuery("(%a, %a)",
+			":c1", ":c2",
+		),
+		Fields: []*querypb.Field{
+			{Name: "c1", Type: querypb.Type_INT32},
+			{Name: "c2", Type: querypb.Type_VARCHAR},
+		},
+		FieldsToSkip: map[string]bool{},
+	}
+
+	makeRow := func(id int, val string) *querypb.Row {
+		return sqltypes.RowToProto3([]sqltypes.Value{
+			sqltypes.NewInt64(int64(id)),
+			sqltypes.NewVarChar(val),
+		})
+	}
+
+	t.Run("no limit", func(t *testing.T) {
+		rows := []*querypb.Row{makeRow(1, "a"), makeRow(2, "b"), makeRow(3, "c")}
+		var executed []string
+		buf := &bytes2.Buffer{}
+		_, err := tp.applyBulkInsert(buf, rows, func(sql string) (*sqltypes.Result, error) {
+			executed = append(executed, sql)
+			return &sqltypes.Result{RowsAffected: 1}, nil
+		}, 0)
+		require.NoError(t, err)
+		require.Len(t, executed, 1)
+		assert.Equal(t, "insert into t(c1, c2) values (1, 'a'), (2, 'b'), (3, 'c')", executed[0])
+	})
+
+	t.Run("split after second row", func(t *testing.T) {
+		rows := []*querypb.Row{makeRow(1, "a"), makeRow(2, "b"), makeRow(3, "c")}
+		var executed []string
+		buf := &bytes2.Buffer{}
+		// Set limit small enough that 3 rows exceed it but 2 rows don't.
+		// "insert into t(c1, c2) values (1, 'a'), (2, 'b')" = 51 chars
+		_, err := tp.applyBulkInsert(buf, rows, func(sql string) (*sqltypes.Result, error) {
+			executed = append(executed, sql)
+			return &sqltypes.Result{RowsAffected: 1}, nil
+		}, 55)
+		require.NoError(t, err)
+		require.Len(t, executed, 2)
+		assert.Equal(t, "insert into t(c1, c2) values (1, 'a'), (2, 'b')", executed[0])
+		assert.Equal(t, "insert into t(c1, c2) values (3, 'c')", executed[1])
+	})
+
+	t.Run("split accounts for on duplicate key suffix", func(t *testing.T) {
+		tpWithOnDup := *tp
+		tpWithOnDup.BulkInsertOnDup = sqlparser.BuildParsedQuery(" on duplicate key update c2=values(c2)")
+
+		rows := []*querypb.Row{makeRow(1, "a"), makeRow(2, "b")}
+		var executed []string
+		buf := &bytes2.Buffer{}
+		// Two rows fit without the suffix, but exceed this limit once the ON DUPLICATE
+		// KEY UPDATE clause is appended. One row plus the suffix still fits.
+		_, err := tpWithOnDup.applyBulkInsert(buf, rows, func(sql string) (*sqltypes.Result, error) {
+			executed = append(executed, sql)
+			return &sqltypes.Result{RowsAffected: 1}, nil
+		}, 82)
+		require.NoError(t, err)
+		require.Len(t, executed, 2)
+		assert.Equal(t, "insert into t(c1, c2) values (1, 'a') on duplicate key update c2=values(c2)", executed[0])
+		assert.Equal(t, "insert into t(c1, c2) values (2, 'b') on duplicate key update c2=values(c2)", executed[1])
+	})
+
+	t.Run("single row exceeds limit", func(t *testing.T) {
+		longVal := strings.Repeat("x", 100)
+		rows := []*querypb.Row{makeRow(1, longVal)}
+		var executed []string
+		buf := &bytes2.Buffer{}
+		_, err := tp.applyBulkInsert(buf, rows, func(sql string) (*sqltypes.Result, error) {
+			executed = append(executed, sql)
+			return &sqltypes.Result{RowsAffected: 1}, nil
+		}, 10) // Very small limit — single row exceeds it
+		require.NoError(t, err)
+		require.Len(t, executed, 1, "single row must still execute even if it exceeds maxQuerySize")
+	})
+
+	t.Run("rows affected accumulated", func(t *testing.T) {
+		rows := []*querypb.Row{makeRow(1, "a"), makeRow(2, "b"), makeRow(3, "c")}
+		buf := &bytes2.Buffer{}
+		result, err := tp.applyBulkInsert(buf, rows, func(sql string) (*sqltypes.Result, error) {
+			return &sqltypes.Result{RowsAffected: 1}, nil
+		}, 40) // Force each row into its own statement
+		require.NoError(t, err)
+		assert.Equal(t, uint64(3), result.RowsAffected)
+	})
+}
+
+func TestApplyBulkInsertChangesMaxQuerySize(t *testing.T) {
+	tp := &TablePlan{
+		BulkInsertFront: sqlparser.BuildParsedQuery("insert into t(c1, c2)"),
+		BulkInsertValues: sqlparser.BuildParsedQuery("(%a, %a)",
+			":a_c1", ":a_c2",
+		),
+		BulkInsertOnDup: sqlparser.BuildParsedQuery(" on duplicate key update c2=values(c2)"),
+		Fields: []*querypb.Field{
+			{Name: "c1", Type: querypb.Type_INT32},
+			{Name: "c2", Type: querypb.Type_VARCHAR},
+		},
+		FieldsToSkip:     map[string]bool{},
+		TablePlanBuilder: &tablePlanBuilder{stats: binlogplayer.NewStats()},
+	}
+
+	makeRowInsert := func(id int, val string) *binlogdatapb.RowChange {
+		return &binlogdatapb.RowChange{
+			After: sqltypes.RowToProto3([]sqltypes.Value{
+				sqltypes.NewInt64(int64(id)),
+				sqltypes.NewVarChar(val),
+			}),
+		}
+	}
+
+	t.Run("split accounts for on duplicate key suffix", func(t *testing.T) {
+		rowInserts := []*binlogdatapb.RowChange{
+			makeRowInsert(1, "a"),
+			makeRowInsert(2, "b"),
+		}
+		expectedFirst := "insert into t(c1, c2) values (1, 'a') on duplicate key update c2=values(c2)"
+		expectedSecond := "insert into t(c1, c2) values (2, 'b') on duplicate key update c2=values(c2)"
+		var executed []string
+		_, err := tp.applyBulkInsertChanges(rowInserts, func(sql string) (*sqltypes.Result, error) {
+			executed = append(executed, sql)
+			return &sqltypes.Result{RowsAffected: 1}, nil
+		}, int64(len(expectedFirst)))
+		require.NoError(t, err)
+		require.Len(t, executed, 2)
+		assert.Equal(t, expectedFirst, executed[0])
+		assert.Equal(t, expectedSecond, executed[1])
+	})
+
+	t.Run("single row exceeds limit", func(t *testing.T) {
+		longVal := strings.Repeat("x", 100)
+		rowInserts := []*binlogdatapb.RowChange{makeRowInsert(1, longVal)}
+		expected := "insert into t(c1, c2) values (1, '" + longVal + "') on duplicate key update c2=values(c2)"
+		var executed []string
+		_, err := tp.applyBulkInsertChanges(rowInserts, func(sql string) (*sqltypes.Result, error) {
+			executed = append(executed, sql)
+			return &sqltypes.Result{RowsAffected: 1}, nil
+		}, 10)
+		require.NoError(t, err)
+		require.Len(t, executed, 1, "single row must still execute even if it exceeds maxQuerySize")
+		assert.Equal(t, expected, executed[0])
+	})
+}
+
+func TestMarshalJSONForSQL(t *testing.T) {
+	testCases := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "small object",
+			input: `{"key": "value"}`,
+		},
+		{
+			name:  "small array",
+			input: `[1, 2, 3]`,
+		},
+		{
+			name:  "large value uses streaming path",
+			input: `[` + strings.Repeat(`"test",`, 200000) + `"end"]`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := vjson.MarshalSQLValue([]byte(tc.input))
+			require.NoError(t, err)
+
+			sql := result.RawStr()
+			// Both tree and streaming paths produce JSON_ARRAY/JSON_OBJECT format.
+			assert.True(t, strings.HasPrefix(sql, "JSON_ARRAY(") || strings.HasPrefix(sql, "JSON_OBJECT("),
+				"expected JSON_ARRAY or JSON_OBJECT prefix, got: %.80s...", sql)
+		})
+	}
+}
+
+func TestMarshalJSONForSQLCorrectness(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		contains string
+	}{
+		{name: "object", input: `{"key": "value", "num": 42}`, contains: "JSON_OBJECT("},
+		{name: "array of ints", input: `[1, 2, 3, 930701976723823]`, contains: "JSON_ARRAY("},
+		{name: "nested", input: `{"a": [1, {"b": true}], "c": null}`, contains: "JSON_OBJECT("},
+		{name: "special chars", input: `{"bs": "back\\slash", "q": "it's a \"test\""}`, contains: "JSON_OBJECT("},
+		{name: "unicode", input: `{"emoji": "hello \u0041"}`, contains: "JSON_OBJECT("},
+		{name: "empty object", input: `{}`, contains: "JSON_OBJECT()"},
+		{name: "empty array", input: `[]`, contains: "JSON_ARRAY()"},
+		{name: "boolean", input: `true`, contains: "true"},
+		{name: "null", input: `null`, contains: "null"},
+		{name: "number", input: `42`, contains: "42"},
+		{name: "string", input: `"hello world"`, contains: "hello world"},
+		{name: "large integer (original bug #8686)", input: `{"keywordSourceId": 930701976723823}`, contains: "930701976723823"},
+		{name: "control escapes", input: `{"cr": "a\rb", "newline": "a\nb", "tab": "a\tb"}`, contains: "JSON_OBJECT("},
+		{name: "solidus escape", input: `{"path": "a\/b"}`, contains: "JSON_OBJECT("},
+		{name: "surrogate pair", input: `{"emoji": "\uD83D\uDE00"}`, contains: "JSON_OBJECT("},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := vjson.MarshalSQLValue([]byte(tc.input))
+			require.NoError(t, err)
+			assert.Contains(t, result.RawStr(), tc.contains)
+		})
+	}
+
+	// Verify the specific bug from issue #8686: large integers must not
+	// be converted to scientific notation.
+	t.Run("large integer preserved", func(t *testing.T) {
+		raw := []byte(`{"keywordSourceId": 930701976723823}`)
+		result, err := vjson.MarshalSQLValue(raw)
+		require.NoError(t, err)
+		assert.Contains(t, result.RawStr(), "930701976723823")
+		assert.NotContains(t, result.RawStr(), "e+")
+	})
+}
+
+func TestAppendFromRowLargeJSON(t *testing.T) {
+	largeJSON := `[` + strings.Repeat(`12345678,`, 150000) + `0]`
+
+	tp := &TablePlan{
+		BulkInsertValues: sqlparser.BuildParsedQuery("(%a)",
+			":c1",
+		),
+		Fields: []*querypb.Field{
+			{Name: "c1", Type: querypb.Type_JSON},
+		},
+		FieldsToSkip: map[string]bool{},
+	}
+
+	row := sqltypes.RowToProto3([]sqltypes.Value{
+		sqltypes.MakeTrusted(querypb.Type_JSON, []byte(largeJSON)),
+	})
+
+	buf := &bytes2.Buffer{}
+	err := tp.appendFromRow(buf, row)
+	require.NoError(t, err)
+	result := buf.String()
+	// The streaming path produces JSON_ARRAY format, same as the tree encoding.
+	assert.Contains(t, result, "JSON_ARRAY(")
+}
+
+func TestAppendFromRowSmallJSON(t *testing.T) {
+	// Verify that small JSON values use the tree encoding (JSON_OBJECT/JSON_ARRAY).
+	tp := &TablePlan{
+		BulkInsertValues: sqlparser.BuildParsedQuery("(%a)",
+			":c1",
+		),
+		Fields: []*querypb.Field{
+			{Name: "c1", Type: querypb.Type_JSON},
+		},
+		FieldsToSkip: map[string]bool{},
+	}
+
+	row := sqltypes.RowToProto3([]sqltypes.Value{
+		sqltypes.MakeTrusted(querypb.Type_JSON, []byte(`{"key": "value"}`)),
+	})
+
+	buf := &bytes2.Buffer{}
+	err := tp.appendFromRow(buf, row)
+	require.NoError(t, err)
+	result := buf.String()
+	assert.Contains(t, result, "JSON_OBJECT(")
+}
+
+func BenchmarkMarshalJSONForSQL(b *testing.B) {
+	raw := []byte(`[` + strings.Repeat(`12345678,`, 150000) + `0]`)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(raw)))
+	for i := 0; i < b.N; i++ {
+		result, err := vjson.MarshalSQLValue(raw)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(result.Raw()) == 0 {
+			b.Fatal("marshalJSONForSQL returned empty SQL")
+		}
+	}
+}
+
+func BenchmarkAppendFromRowLargeJSON(b *testing.B) {
+	raw := []byte(`[` + strings.Repeat(`12345678,`, 150000) + `0]`)
+	tp := &TablePlan{
+		BulkInsertValues: sqlparser.BuildParsedQuery("(%a)",
+			":c1",
+		),
+		Fields: []*querypb.Field{
+			{Name: "c1", Type: querypb.Type_JSON},
+		},
+		FieldsToSkip: map[string]bool{},
+	}
+	row := sqltypes.RowToProto3([]sqltypes.Value{
+		sqltypes.MakeTrusted(querypb.Type_JSON, raw),
+	})
+
+	buf := &bytes2.Buffer{}
+	b.ReportAllocs()
+	b.SetBytes(int64(len(raw)))
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		if err := tp.appendFromRow(buf, row); err != nil {
+			b.Fatal(err)
+		}
+		if buf.Len() == 0 {
+			b.Fatal("appendFromRow returned empty SQL")
+		}
 	}
 }

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
@@ -136,6 +136,7 @@ type vcopierCopyWorker struct {
 	closeDbClient   bool
 	copyStateInsert *sqlparser.ParsedQuery
 	isOpen          bool
+	maxQuerySize    int64
 	pkfields        []*querypb.Field
 	sqlbuffer       bytes2.Buffer
 	tablePlan       *TablePlan
@@ -206,9 +207,11 @@ func newVCopierCopyWorkQueue(
 func newVCopierCopyWorker(
 	closeDbClient bool,
 	vdbClient *vdbClient,
+	maxQuerySize int64,
 ) *vcopierCopyWorker {
 	return &vcopierCopyWorker{
 		closeDbClient: closeDbClient,
+		maxQuerySize:  maxQuerySize,
 		vdbClient:     vdbClient,
 	}
 }
@@ -405,7 +408,8 @@ func (vc *vcopier) copyTable(ctx context.Context, tableName string, copyState ma
 	defer copyStateGCTicker.Stop()
 
 	parallelism := int(math.Max(1, float64(vc.vr.workflowConfig.ParallelInsertWorkers)))
-	copyWorkerFactory := vc.newCopyWorkerFactory(parallelism)
+	maxQuerySize := vc.vr.maxQuerySize(vc.vr.dbClient)
+	copyWorkerFactory := vc.newCopyWorkerFactory(parallelism, maxQuerySize)
 	copyWorkQueue := vc.newCopyWorkQueue(parallelism, copyWorkerFactory)
 	defer copyWorkQueue.close()
 
@@ -716,16 +720,21 @@ func (vc *vcopier) newCopyWorkQueue(
 	return newVCopierCopyWorkQueue(concurrent, parallelism, workerFactory)
 }
 
-func (vc *vcopier) newCopyWorkerFactory(parallelism int) func(context.Context) (*vcopierCopyWorker, error) {
+func (vc *vcopier) newCopyWorkerFactory(parallelism int, maxQuerySize int64) func(context.Context) (*vcopierCopyWorker, error) {
 	if parallelism > 1 {
 		return func(ctx context.Context) (*vcopierCopyWorker, error) {
 			dbClient, err := vc.vr.newClientConnection(ctx)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create new db client: %s", err.Error())
 			}
+			// Query maxQuerySize from the worker's own connection since it may
+			// differ from the controller's session if @@global.max_allowed_packet
+			// was changed after the controller connection was opened.
+			workerMaxQuerySize := vc.vr.maxQuerySize(dbClient)
 			return newVCopierCopyWorker(
 				true, /* close db client */
 				dbClient,
+				workerMaxQuerySize,
 			), nil
 		}
 	}
@@ -733,6 +742,7 @@ func (vc *vcopier) newCopyWorkerFactory(parallelism int) func(context.Context) (
 		return newVCopierCopyWorker(
 			false, /* close db client */
 			vc.vr.dbClient,
+			maxQuerySize,
 		), nil
 	}
 }
@@ -1154,6 +1164,7 @@ func (vbc *vcopierCopyWorker) insertRows(ctx context.Context, rows []*querypb.Ro
 		func(sql string) (*sqltypes.Result, error) {
 			return vbc.vdbClient.ExecuteWithRetry(ctx, sql)
 		},
+		vbc.maxQuerySize,
 	)
 }
 

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_atomic.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_atomic.go
@@ -84,8 +84,8 @@ func (vc *vcopier) copyAll(ctx context.Context, settings binlogplayer.VRSettings
 	defer rowsCopiedTicker.Stop()
 
 	parallelism := int(math.Max(1, float64(vc.vr.workflowConfig.ParallelInsertWorkers)))
-
-	copyWorkerFactory := vc.newCopyWorkerFactory(parallelism)
+	maxQuerySize := vc.vr.maxQuerySize(vc.vr.dbClient)
+	copyWorkerFactory := vc.newCopyWorkerFactory(parallelism, maxQuerySize)
 	var copyWorkQueue *vcopierCopyWorkQueue
 
 	// Allocate a result channel to collect results from tasks. To not block fast workers, we allocate a buffer of

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
@@ -30,6 +30,7 @@ import (
 
 	"vitess.io/vitess/go/vt/log"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -38,6 +39,180 @@ import (
 	qh "vitess.io/vitess/go/vt/vttablet/tabletmanager/vreplication/queryhistory"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer"
 )
+
+func TestNewCopyWorkerFactoryUsesMaxQuerySize(t *testing.T) {
+	stats := binlogplayer.NewStats()
+	dbClient := binlogplayer.NewMockDBClient(t)
+	vr := &vreplicator{
+		dbClient: newVDBClient(dbClient, stats, vttablet.DefaultVReplicationConfig.RelayLogMaxItems),
+		stats:    stats,
+	}
+
+	workerFactory := newVCopier(vr).newCopyWorkerFactory(1, 123)
+	worker, err := workerFactory(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, worker)
+	assert.Equal(t, int64(123), worker.maxQuerySize)
+	assert.Same(t, vr.dbClient, worker.vdbClient)
+}
+
+func TestPlayerCopyRespectsMaxQuerySize(t *testing.T) {
+	testVcopierTestCases(t, testPlayerCopyRespectsMaxQuerySize, commonVcopierTestCases())
+}
+
+func testPlayerCopyRespectsMaxQuerySize(t *testing.T) {
+	defer deleteTablet(addTablet(100))
+
+	reset := vstreamer.AdjustPacketSize(1 << 20)
+	defer reset()
+
+	ctx := t.Context()
+	qr, err := env.Mysqld.FetchSuperQuery(ctx, "select @@global.max_allowed_packet")
+	require.NoError(t, err)
+	originalMaxAllowedPacket, err := qr.Rows[0][0].ToInt64()
+	require.NoError(t, err)
+
+	val1 := strings.Repeat("a", 350)
+	val2 := strings.Repeat("b", 350)
+	val3 := strings.Repeat("c", 350)
+
+	execStatements(t, []string{
+		"create table src(id int, val varchar(512), primary key(id))",
+		fmt.Sprintf("create table %s.dst(id int, val varchar(512), primary key(id))", vrepldb),
+		fmt.Sprintf("insert into src values(1, '%s')", val1),
+		fmt.Sprintf("insert into src values(2, '%s')", val2),
+		fmt.Sprintf("insert into src values(3, '%s')", val3),
+		"set @@global.max_allowed_packet=1024",
+	})
+	defer execStatements(t, []string{
+		fmt.Sprintf("set @@global.max_allowed_packet=%d", originalMaxAllowedPacket),
+		"drop table src",
+		fmt.Sprintf("drop table %s.dst", vrepldb),
+	})
+
+	filter := &binlogdatapb.Filter{
+		Rules: []*binlogdatapb.Rule{{
+			Match:  "dst",
+			Filter: "select * from src",
+		}},
+	}
+	bls := &binlogdatapb.BinlogSource{
+		Keyspace: env.KeyspaceName,
+		Shard:    env.ShardName,
+		Filter:   filter,
+		OnDdl:    binlogdatapb.OnDDLAction_IGNORE,
+	}
+
+	query := binlogplayer.CreateVReplicationState("test", bls, "", binlogdatapb.VReplicationWorkflowState_Init, playerEngine.dbName, 0, 0)
+	vrqr, err := playerEngine.Exec(query)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		query := fmt.Sprintf("delete from _vt.vreplication where id = %d", vrqr.InsertID)
+		if _, err := playerEngine.Exec(query); err != nil {
+			t.Fatal(err)
+		}
+		expectDeleteQueries(t)
+		playerEngine.Close()
+		playerEngine.Open(context.WithoutCancel(t.Context()))
+	})
+
+	expectNontxQueries(t, qh.Expect(
+		"/insert into _vt.vreplication",
+		"/update _vt.vreplication set message='Picked source tablet.*",
+		"/insert into _vt.copy_state",
+		"/update _vt.vreplication set state='Copying'",
+		fmt.Sprintf("insert into dst(id,val) values (1,'%s'), (2,'%s')", val1, val2),
+		fmt.Sprintf("insert into dst(id,val) values (3,'%s')", val3),
+		"/insert into _vt.copy_state",
+		"/delete cs, pca from _vt.copy_state as cs left join _vt.post_copy_action as pca on cs.vrepl_id=pca.vrepl_id and cs.table_name=pca.table_name.*dst",
+		"/update _vt.vreplication set state='Running",
+	), recvTimeout)
+
+	expectData(t, "dst", [][]string{
+		{"1", val1},
+		{"2", val2},
+		{"3", val3},
+	})
+}
+
+// TestPlayerCopyTablesJSONStreamSQL verifies that JSON values round-trip correctly through MySQL
+// when using the streaming JSON_OBJECT/JSON_ARRAY SQL encoding path.
+func TestPlayerCopyTablesJSONStreamSQL(t *testing.T) {
+	testVcopierTestCases(t, testPlayerCopyTablesJSONStreamSQL, commonVcopierTestCases())
+}
+
+func testPlayerCopyTablesJSONStreamSQL(t *testing.T) {
+	defer deleteTablet(addTablet(100))
+
+	execStatements(t, []string{
+		"create table src(id int, j json, primary key(id))",
+		fmt.Sprintf("create table %s.dst(id int, j json, primary key(id))", vrepldb),
+		`insert into src values(1, '{"foo": "bar"}')`,
+		`insert into src values(2, JSON_ARRAY(123456789012345678901234567890, "abcd"))`,
+		`insert into src values(3, '{"flag": true, "items": [1, false, null]}')`,
+		`insert into src values(4, '{"val": 1.5}')`,
+		`insert into src values(5, 'null')`,
+		`insert into src values(6, null)`,
+		`insert into src values(7, '{}')`,
+		`insert into src values(8, '[]')`,
+		`insert into src values(9, '{"keywordSourceId": 930701976723823}')`,
+	})
+	defer execStatements(t, []string{
+		"drop table src",
+		fmt.Sprintf("drop table %s.dst", vrepldb),
+	})
+
+	filter := &binlogdatapb.Filter{
+		Rules: []*binlogdatapb.Rule{{
+			Match:  "dst",
+			Filter: "select * from src",
+		}},
+	}
+	bls := &binlogdatapb.BinlogSource{
+		Keyspace: env.KeyspaceName,
+		Shard:    env.ShardName,
+		Filter:   filter,
+		OnDdl:    binlogdatapb.OnDDLAction_IGNORE,
+	}
+
+	query := binlogplayer.CreateVReplicationState("test", bls, "", binlogdatapb.VReplicationWorkflowState_Init, playerEngine.dbName, 0, 0)
+	qr, err := playerEngine.Exec(query)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		query := fmt.Sprintf("delete from _vt.vreplication where id = %d", qr.InsertID)
+		if _, err := playerEngine.Exec(query); err != nil {
+			t.Fatal(err)
+		}
+		expectDeleteQueries(t)
+		playerEngine.Close()
+		playerEngine.Open(context.WithoutCancel(t.Context()))
+	})
+
+	expectNontxQueries(t, qh.Expect(
+		"/insert into _vt.vreplication",
+		"/update _vt.vreplication set message='Picked source tablet.*",
+		"/insert into _vt.copy_state",
+		"/update _vt.vreplication set state='Copying'",
+		"/insert into dst",
+		"/insert into _vt.copy_state",
+		"/delete cs, pca from _vt.copy_state as cs left join _vt.post_copy_action as pca on cs.vrepl_id=pca.vrepl_id and cs.table_name=pca.table_name.*dst",
+		"/update _vt.vreplication set state='Running",
+	), recvTimeout)
+
+	expectData(t, "dst", [][]string{
+		{"1", `{"foo": "bar"}`},
+		{"2", `[123456789012345678901234567890, "abcd"]`},
+		{"3", `{"flag": true, "items": [1, false, null]}`},
+		{"4", `{"val": 1.5}`},
+		{"5", "null"},
+		{"6", ""},
+		{"7", "{}"},
+		{"8", "[]"},
+		{"9", `{"keywordSourceId": 930701976723823}`},
+	})
+}
 
 type vcopierTestCase struct {
 	vreplicationExperimentalFlags     int64

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -138,23 +138,7 @@ func newVPlayer(vr *vreplicator, settings binlogplayer.VRSettings, copyState map
 	batchMode := len(copyState) == 0 && vr.workflowConfig.ExperimentalFlags&vttablet.VReplicationExperimentalFlagVPlayerBatching != 0
 
 	if batchMode {
-		// relayLogMaxSize is effectively the limit used when not batching.
-		maxAllowedPacket := int64(vr.workflowConfig.RelayLogMaxSize)
-		// We explicitly do NOT want to batch this, we want to send it down the wire
-		// immediately so we use ExecuteFetch directly.
-		res, err := vr.dbClient.ExecuteFetch(SqlMaxAllowedPacket, 1)
-		if err != nil {
-			log.Errorf("Error getting max_allowed_packet, will use the relay_log_max_size value of %d bytes: %v", vr.workflowConfig.RelayLogMaxSize, err)
-		} else {
-			if maxAllowedPacket, err = res.Rows[0][0].ToInt64(); err != nil {
-				log.Errorf("Error getting max_allowed_packet, will use the relay_log_max_size value of %d bytes: %v", vr.workflowConfig.RelayLogMaxSize, err)
-			}
-		}
-		// Leave 64 bytes of room for the commit to be sure that we have a more than
-		// ample buffer left. The default value of max_allowed_packet is 4MiB in 5.7
-		// and 64MiB in 8.0 -- and the default for max_relay_log_size is 250000
-		// bytes -- so we have plenty of room.
-		maxAllowedPacket -= 64
+		maxAllowedPacket := vr.maxQuerySize(vr.dbClient)
 		queryFunc = func(ctx context.Context, sql string) (*sqltypes.Result, error) {
 			if !vr.dbClient.InTransaction { // Should be sent down the wire immediately
 				return vr.dbClient.Execute(sql)

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -3092,6 +3092,84 @@ func TestPlayerJSONTwoColumns(t *testing.T) {
 
 }
 
+// TestPlayerJSONDocsStreamSQL verifies that JSON values round-trip correctly through MySQL when
+// using the streaming JSON_OBJECT/JSON_ARRAY SQL encoding path.
+func TestPlayerJSONDocsStreamSQL(t *testing.T) {
+	defer deleteTablet(addTablet(100))
+
+	execStatements(t, []string{
+		"create table vitess_json(id int auto_increment, val json, primary key(id))",
+		fmt.Sprintf("create table %s.vitess_json(id int, val json, primary key(id))", vrepldb),
+	})
+	defer execStatements(t, []string{
+		"drop table vitess_json",
+		fmt.Sprintf("drop table %s.vitess_json", vrepldb),
+	})
+
+	filter := &binlogdatapb.Filter{
+		Rules: []*binlogdatapb.Rule{{
+			Match: "/.*",
+		}},
+	}
+	bls := &binlogdatapb.BinlogSource{
+		Keyspace: env.KeyspaceName,
+		Shard:    env.ShardName,
+		Filter:   filter,
+		OnDdl:    binlogdatapb.OnDDLAction_IGNORE,
+	}
+	cancel, _ := startVReplication(t, bls, "")
+	defer cancel()
+
+	type testcase struct {
+		name  string
+		input string
+		data  [][]string
+	}
+	var testcases []testcase
+	id := 0
+	addTestCase := func(name, val string) {
+		id++
+		testcases = append(testcases, testcase{
+			name:  name,
+			input: fmt.Sprintf("insert into vitess_json(val) values (%s)", encodeString(val)),
+			data: [][]string{
+				{strconv.Itoa(id), val},
+			},
+		})
+	}
+	addTestCase("singleDoc", jsonSingleDoc)
+	addTestCase("multipleDocs", jsonMultipleDocs)
+	longString := strings.Repeat("aa", math.MaxInt16)
+	largeObject := fmt.Sprintf(singleLargeObjectTemplate, longString)
+	addTestCase("singleLargeObject", largeObject)
+	largeArray := fmt.Sprintf(`[1, 1234567890, "a", true, %s]`, largeObject)
+	addTestCase("singleLargeArray", largeArray)
+	addTestCase("largeArrayDoc", repeatJSON(jsonSingleDoc, 140, largeJSONArrayCollection))
+	addTestCase("largeObjectDoc", repeatJSON(jsonSingleDoc, 140, largeJSONObjectCollection))
+	// Edge cases identified in code review for type-fidelity between CAST and JSON_OBJECT paths.
+	addTestCase("booleans", `{"flag": true, "off": false}`)
+	addTestCase("largeInteger", `{"keywordSourceId": 930701976723823}`)
+	addTestCase("decimal", `{"val": 1.5}`)
+	addTestCase("emptyObject", `{}`)
+	addTestCase("emptyArray", `[]`)
+	addTestCase("jsonNull", `null`)
+	id = 0
+	for _, tcase := range testcases {
+		t.Run(tcase.name, func(t *testing.T) {
+			id++
+			execStatements(t, []string{tcase.input})
+			want := qh.Expect(
+				"begin",
+				"/insert into vitess_json",
+				"/update _vt.vreplication set pos=",
+				"commit",
+			)
+			expectDBClientQueries(t, want)
+			expectJSON(t, "vitess_json", tcase.data, id, env.Mysqld.FetchSuperQuery)
+		})
+	}
+}
+
 func TestVReplicationLogs(t *testing.T) {
 	defer deleteTablet(addTablet(100))
 	dbClient := playerEngine.dbClientFactoryDba()

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -89,7 +89,8 @@ const (
 	json_unquote(json_extract(action, '$.type'))=%a and vrepl_id=%a and table_name=%a`
 	sqlDeletePostCopyAction = `delete from _vt.post_copy_action where vrepl_id=%a and
 	table_name=%a and id=%a`
-	SqlMaxAllowedPacket = "select @@session.max_allowed_packet as max_allowed_packet"
+	SqlMaxAllowedPacket  = "select @@session.max_allowed_packet as max_allowed_packet"
+	maxQuerySizeHeadroom = int64(64)
 )
 
 // vreplicator provides the core logic to start vreplication streams
@@ -494,6 +495,23 @@ func (vr *vreplicator) setMessage(message string) (err error) {
 	}
 	insertLog(vr.dbClient, LogMessage, vr.id, vr.state.String(), message)
 	return nil
+}
+
+func (vr *vreplicator) maxQuerySize(dbc *vdbClient) int64 {
+	maxQuerySize := int64(vr.workflowConfig.RelayLogMaxSize)
+	res, err := dbc.DBClient.ExecuteFetch(SqlMaxAllowedPacket, 1)
+	if err != nil {
+		log.Error(fmt.Sprintf("Error getting max_allowed_packet, will use the relay-log-max-size value of %d bytes: %v", vr.workflowConfig.RelayLogMaxSize, err))
+	} else {
+		if maxQuerySize, err = res.Rows[0][0].ToInt64(); err != nil {
+			log.Error(fmt.Sprintf("Error getting max_allowed_packet, will use the relay-log-max-size value of %d bytes: %v", vr.workflowConfig.RelayLogMaxSize, err))
+			maxQuerySize = int64(vr.workflowConfig.RelayLogMaxSize)
+		}
+	}
+	if maxQuerySize > maxQuerySizeHeadroom {
+		maxQuerySize -= maxQuerySizeHeadroom
+	}
+	return maxQuerySize
 }
 
 func (vr *vreplicator) insertLog(typ, message string) {

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql/replication"
+	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/mysqlctl"
@@ -41,6 +42,44 @@ import (
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"
 )
+
+func TestMaxQuerySize(t *testing.T) {
+	makeVR := func(dbClient binlogplayer.DBClient, relayLogMaxSize int) *vreplicator {
+		stats := binlogplayer.NewStats()
+		return &vreplicator{
+			dbClient: newVDBClient(dbClient, stats, vttablet.DefaultVReplicationConfig.RelayLogMaxItems),
+			stats:    stats,
+			workflowConfig: &vttablet.VReplicationConfig{
+				RelayLogMaxSize: relayLogMaxSize,
+			},
+		}
+	}
+
+	t.Run("uses session max allowed packet", func(t *testing.T) {
+		dbClient := binlogplayer.NewMockDBClient(t)
+		dbClient.ExpectRequest(
+			SqlMaxAllowedPacket,
+			sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("max_allowed_packet", "int64"),
+				"1024",
+			),
+			nil,
+		)
+
+		vr := makeVR(dbClient, 4096)
+		assert.Equal(t, int64(960), vr.maxQuerySize(vr.dbClient))
+		assert.Nil(t, vr.dbClient.queries)
+	})
+
+	t.Run("falls back to relay log max size", func(t *testing.T) {
+		dbClient := binlogplayer.NewMockDBClient(t)
+		dbClient.ExpectRequest(SqlMaxAllowedPacket, nil, assert.AnError)
+
+		vr := makeVR(dbClient, 4096)
+		assert.Equal(t, int64(4032), vr.maxQuerySize(vr.dbClient))
+		assert.Nil(t, vr.dbClient.queries)
+	})
+}
 
 func TestRecalculatePKColsInfoByColumnNames(t *testing.T) {
 	tt := []struct {


### PR DESCRIPTION
## Description

Backport of vitessio/vitess#19878 to `slack-22.0`.

Fixes two compounding issues in VReplication when processing tables with large JSON columns:

1. **Unbounded SQL buffer in copy phase**: `applyBulkInsert` built one giant SQL INSERT with ALL rows in a single statement, no size limit. With large JSON columns, this could produce a statement exceeding `max_allowed_packet` or exhausting memory.

2. **56x memory amplification in JSON encoding**: `vjson.MarshalSQLValue()` converted binary JSON into SQL via an intermediate Go object tree. Fix replaces with `vjson.AppendMarshalSQL()` which streams token-by-token (~8x memory instead of 56x).

### What changes in VReplication behavior

**No semantic change** -- same rows get inserted, same data arrives at the target.

- **Copy phase (`vcopier.go`)**: Each copy worker now queries `max_allowed_packet` and splits bulk INSERTs when the statement buffer exceeds that size. Same batch of rows, multiple smaller INSERT statements instead of one unbounded one.
- **Bulk insert logic (`replicator_plan.go`)**: `applyBulkInsert` tracks buffer size as it appends rows. When buffer exceeds `maxQuerySize`, it flushes and starts a new INSERT. Accumulates `RowsAffected` across flushes.
- **Replay phase fix**: `applyBulkInsertChanges` adds `!newStmt` guard to prevent flushing on the first row of a new statement.
- **JSON encoding (`marshal.go`)**: `vjson.AppendMarshalSQL(buf, raw)` streams JSON directly into the buffer instead of building an intermediate object tree.
- **vplayer.go**: Inline `maxAllowedPacket` logic replaced with shared `vr.maxQuerySize()` (one implementation for both copy and replay paths).

### Why we need this

We need this backport to safely perform reshards on keyspaces with tables containing large JSON columns. Without this fix, VDiff and VReplication can cause OOM or severe memory/CPU pressure on target primaries during the comparison and copy phases.

## Related Issue(s)

- Upstream issue: https://github.com/vitessio/vitess/issues/19875
- Upstream PR: https://github.com/vitessio/vitess/pull/19878

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [ ] Documentation was added or is not required

## Test Plan

1. Deploy this branch to staging vttablets
2. Upgrade vttest3 keyspace tablets to use this branch
3. Create a test table with multiple JSON columns similar to hermes schema:
   ```sql
   CREATE TABLE json_reshard_test (
     id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
     steps JSON NOT NULL,
     execution_data JSON NOT NULL,
     ancestor_ids JSON NOT NULL DEFAULT ('[]'),
     PRIMARY KEY (id)
   );
   ```
4. Populate with large JSON values (similar size to hermes -- `steps` and `execution_data` columns with 1-5 MB JSON documents)
5. Start a reshard on vttest3 and verify:
   - VReplication copy phase completes without OOM
   - vttablet memory usage stays bounded during copy
   - No ERS triggered on target primaries
   - Data arrives correctly on target shards

## Deployment Notes

Deploy with next vttablet build from `slack-22.0`. No migrations required.

### AI Disclosure

Cherry-pick and conflict resolution performed with Claude Code assistance.