### PR TITLE
Gate DML with Snake load shedder

### DIFF
--- a/go/vt/vttablet/tabletserver/tx/api.go
+++ b/go/vt/vttablet/tabletserver/tx/api.go
@@ -57,6 +57,8 @@ type (
 		LogToFile       bool
 
 		Stats *servenv.TimingsWrapper
+
+		SnakeRelease func()
 	}
 
 	// Query contains the query and involved tables executed inside transaction.

--- a/go/vt/vttablet/tabletserver/tx_engine.go
+++ b/go/vt/vttablet/tabletserver/tx_engine.go
@@ -34,6 +34,7 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/connpool"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/loadshed"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tx"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/txlimiter"
@@ -114,6 +115,19 @@ func NewTxEngine(env tabletenv.Env, dxNotifier func()) *TxEngine {
 	}
 	limiter := txlimiter.New(env)
 	te.txPool = NewTxPool(env, limiter)
+	if config.SnakeEnabled {
+		te.txPool.snake = loadshed.NewSnake(loadshed.SnakeConfig{
+			Name: "dml",
+			CoDel: loadshed.CoDelConfig{
+				TargetNs:       func() int64 { return config.SnakeTarget.Nanoseconds() },
+				IntervalNs:     func() int64 { return config.SnakeInterval.Nanoseconds() },
+				Exponent:       func() float64 { return 0.5 },
+				MinDropDelayNs: func() int64 { return int64(time.Millisecond) },
+			},
+			Capacity:            func() int { return config.TxPool.Size },
+			LoadsheddingAllowed: func() bool { return true },
+		})
+	}
 	// We initially allow twoPC (handles vttablet restarts).
 	// We will disallow them for a few reasons -
 	//	1. When a new tablet is promoted if semi-sync is turned off.

--- a/go/vt/vttablet/tabletserver/tx_pool.go
+++ b/go/vt/vttablet/tabletserver/tx_pool.go
@@ -31,6 +31,7 @@ import (
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/loadshed"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tx"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/txlimiter"
@@ -68,6 +69,7 @@ type (
 		scp     *StatefulConnectionPool
 		ticks   *timer.Timer
 		limiter txlimiter.TxLimiter
+		snake   *loadshed.Snake
 
 		logMu   sync.Mutex
 		lastLog time.Time
@@ -235,6 +237,7 @@ func (tp *TxPool) Begin(ctx context.Context, options *querypb.ExecuteOptions, re
 
 	var conn *StatefulConnection
 	var err error
+	var snakeRelease func()
 	if reservedID != 0 {
 		conn, err = tp.scp.GetAndLock(reservedID, "start transaction on reserve conn")
 		if err != nil {
@@ -249,12 +252,27 @@ func (tp *TxPool) Begin(ctx context.Context, options *querypb.ExecuteOptions, re
 		if !tp.limiter.Get(immediateCaller, effectiveCaller) {
 			return nil, "", "", vterrors.Errorf(vtrpcpb.Code_RESOURCE_EXHAUSTED, "per-user transaction pool connection limit exceeded")
 		}
+
+		if tp.snake != nil {
+			if contentionID := options.GetUniqueId(); contentionID != "" {
+				unlock, snakeErr := tp.snake.Acquire(ctx, contentionID)
+				if snakeErr != nil {
+					tp.limiter.Release(immediateCaller, effectiveCaller)
+					return nil, "", "", vterrors.Errorf(vtrpcpb.Code_RESOURCE_EXHAUSTED, "dml load shed: %v", snakeErr)
+				}
+				snakeRelease = func() { unlock.Release() }
+			}
+		}
+
 		conn, err = tp.createConn(ctx, options, setting)
 		defer func() {
 			if err != nil {
 				// The transaction limiter frees transactions on rollback or commit. If we fail to create the transaction,
 				// release immediately since there will be no rollback or commit.
 				tp.limiter.Release(immediateCaller, effectiveCaller)
+				if snakeRelease != nil {
+					snakeRelease()
+				}
 			}
 		}()
 	}
@@ -272,6 +290,7 @@ func (tp *TxPool) Begin(ctx context.Context, options *querypb.ExecuteOptions, re
 	if setting != nil {
 		conn.TxProperties().RecordQueryDetail(setting.ApplyQuery(), nil)
 	}
+	conn.TxProperties().SnakeRelease = snakeRelease
 	return conn, sql, sessionStateChanges, nil
 }
 
@@ -444,6 +463,9 @@ func (tp *TxPool) LogActive() {
 
 func (tp *TxPool) txComplete(conn *StatefulConnection, reason tx.ReleaseReason) {
 	conn.LogTransaction(reason)
+	if release := conn.TxProperties().SnakeRelease; release != nil {
+		release()
+	}
 	tp.limiter.Release(conn.TxProperties().ImmediateCaller, conn.TxProperties().EffectiveCaller)
 	conn.CleanTxState()
 }

--- a/go/vt/vttablet/tabletserver/tx_pool_snake_test.go
+++ b/go/vt/vttablet/tabletserver/tx_pool_snake_test.go
@@ -1,0 +1,254 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tabletserver
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql/fakesqldb"
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/dbconfigs"
+	"vitess.io/vitess/go/vt/vtenv"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/loadshed"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/tx"
+
+	querypb "vitess.io/vitess/go/vt/proto/query"
+)
+
+func setupWithSnake(t *testing.T, capacity int) (*fakesqldb.DB, *TxPool, func()) {
+	t.Helper()
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.TxPool.Size = 300
+	cfg.Oltp.TxTimeout = 30 * time.Second
+	cfg.TxPool.Timeout = 40 * time.Second
+	cfg.OltpReadPool.IdleTimeout = 30 * time.Second
+	cfg.OlapReadPool.IdleTimeout = 30 * time.Second
+	cfg.TxPool.IdleTimeout = 30 * time.Second
+	env := tabletenv.NewEnv(vtenv.NewTestEnv(), cfg, "TxPoolSnakeTest")
+
+	limiter := &fakeLimiter{}
+	txPool := NewTxPool(env, limiter)
+	txPool.snake = loadshed.NewSnake(loadshed.SnakeConfig{
+		Name: "dml-test",
+		CoDel: loadshed.CoDelConfig{
+			TargetNs:       func() int64 { return (5 * time.Millisecond).Nanoseconds() },
+			IntervalNs:     func() int64 { return (100 * time.Millisecond).Nanoseconds() },
+			Exponent:       func() float64 { return 0.5 },
+			MinDropDelayNs: func() int64 { return int64(time.Millisecond) },
+		},
+		Capacity:            func() int { return capacity },
+		LoadsheddingAllowed: func() bool { return true },
+	})
+
+	db := fakesqldb.New(t)
+	db.AddQueryPattern(".*", &sqltypes.Result{})
+	params := dbconfigs.New(db.ConnParams())
+	txPool.Open(params, params, params)
+
+	return db, txPool, func() {
+		txPool.Close()
+		db.Close()
+	}
+}
+
+func TestTxPoolSnake_BeginAcquiresSlot(t *testing.T) {
+	_, txPool, closer := setupWithSnake(t, 2)
+	defer closer()
+
+	ctx := context.Background()
+	opts := &querypb.ExecuteOptions{UniqueId: "req-1"}
+
+	conn, _, _, err := txPool.Begin(ctx, opts, false, 0, nil)
+	require.NoError(t, err)
+	assert.NotNil(t, conn.TxProperties().SnakeRelease)
+	conn.Unlock()
+
+	// Commit releases the snake slot via txComplete.
+	conn2, err := txPool.GetAndLock(conn.ReservedID(), "")
+	require.NoError(t, err)
+	_, err = txPool.Commit(ctx, conn2)
+	require.NoError(t, err)
+	conn2.Release(tx.TxCommit)
+}
+
+func TestTxPoolSnake_CommitReleasesSlot(t *testing.T) {
+	_, txPool, closer := setupWithSnake(t, 1)
+	defer closer()
+
+	ctx := context.Background()
+	opts := &querypb.ExecuteOptions{UniqueId: "req-1"}
+
+	// Fill the single slot.
+	conn, _, _, err := txPool.Begin(ctx, opts, false, 0, nil)
+	require.NoError(t, err)
+	conn.Unlock()
+
+	// Second begin with a different ID would block/fail if slot is not released.
+	// Commit the first to free the slot.
+	conn2, err := txPool.GetAndLock(conn.ReservedID(), "")
+	require.NoError(t, err)
+	_, err = txPool.Commit(ctx, conn2)
+	require.NoError(t, err)
+	conn2.Release(tx.TxCommit)
+
+	// Now a new begin should succeed.
+	conn3, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{UniqueId: "req-2"}, false, 0, nil)
+	require.NoError(t, err)
+	conn3.Unlock()
+	conn4, err := txPool.GetAndLock(conn3.ReservedID(), "")
+	require.NoError(t, err)
+	_, _ = txPool.Commit(ctx, conn4)
+	conn4.Release(tx.TxCommit)
+}
+
+func TestTxPoolSnake_RollbackReleasesSlot(t *testing.T) {
+	_, txPool, closer := setupWithSnake(t, 1)
+	defer closer()
+
+	ctx := context.Background()
+	opts := &querypb.ExecuteOptions{UniqueId: "req-1"}
+
+	conn, _, _, err := txPool.Begin(ctx, opts, false, 0, nil)
+	require.NoError(t, err)
+	conn.Unlock()
+
+	// Rollback should release the slot.
+	conn2, err := txPool.GetAndLock(conn.ReservedID(), "")
+	require.NoError(t, err)
+	txPool.RollbackAndRelease(ctx, conn2)
+
+	// Slot is free — new begin should succeed.
+	conn3, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{UniqueId: "req-2"}, false, 0, nil)
+	require.NoError(t, err)
+	conn3.Unlock()
+	conn4, err := txPool.GetAndLock(conn3.ReservedID(), "")
+	require.NoError(t, err)
+	_, _ = txPool.Commit(ctx, conn4)
+	conn4.Release(tx.TxCommit)
+}
+
+func TestTxPoolSnake_EmptyUniqueIdBypassesSnake(t *testing.T) {
+	_, txPool, closer := setupWithSnake(t, 1)
+	defer closer()
+
+	ctx := context.Background()
+
+	// Fill the single slot with a tagged request.
+	conn, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{UniqueId: "req-1"}, false, 0, nil)
+	require.NoError(t, err)
+	conn.Unlock()
+
+	// A request with no UniqueId should bypass the snake entirely.
+	conn2, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
+	require.NoError(t, err)
+	assert.Nil(t, conn2.TxProperties().SnakeRelease)
+	conn2.Unlock()
+
+	// Cleanup.
+	c, _ := txPool.GetAndLock(conn.ReservedID(), "")
+	_, _ = txPool.Commit(ctx, c)
+	c.Release(tx.TxCommit)
+	c2, _ := txPool.GetAndLock(conn2.ReservedID(), "")
+	_, _ = txPool.Commit(ctx, c2)
+	c2.Release(tx.TxCommit)
+}
+
+func TestTxPoolSnake_ReservedConnSkipsSnake(t *testing.T) {
+	_, txPool, closer := setupWithSnake(t, 1)
+	defer closer()
+
+	ctx := context.Background()
+	opts := &querypb.ExecuteOptions{UniqueId: "req-1"}
+
+	// Fill the single slot.
+	conn, _, _, err := txPool.Begin(ctx, opts, false, 0, nil)
+	require.NoError(t, err)
+	reservedID := conn.ReservedID()
+	conn.Unlock()
+
+	// Begin on a reserved conn (reservedID != 0) should skip the snake.
+	conn2, err := txPool.GetAndLock(reservedID, "")
+	require.NoError(t, err)
+	_, _ = txPool.Commit(ctx, conn2)
+	conn2.Release(tx.TxCommit)
+
+	// Begin with reservedID on the same conn: since the first tx committed and released,
+	// we need a new conn to test reservedID path. Create one via Begin first.
+	conn3, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{UniqueId: "req-2"}, false, 0, nil)
+	require.NoError(t, err)
+	rid := conn3.ReservedID()
+	conn3.Unlock()
+
+	// Now do a Begin with the reservedID — this takes the reservedID != 0 path.
+	conn4, _, _, err := txPool.Begin(ctx, opts, false, rid, nil)
+	require.NoError(t, err)
+	// SnakeRelease is nil because the reservedID path doesn't acquire from snake.
+	assert.Nil(t, conn4.TxProperties().SnakeRelease)
+	conn4.Unlock()
+	conn5, _ := txPool.GetAndLock(rid, "")
+	_, _ = txPool.Commit(ctx, conn5)
+	conn5.Release(tx.TxCommit)
+}
+
+func TestTxPoolSnake_CapacityExhaustedShedsLoad(t *testing.T) {
+	_, txPool, closer := setupWithSnake(t, 1)
+	defer closer()
+
+	ctx := context.Background()
+
+	// Fill the single slot.
+	conn, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{UniqueId: "req-1"}, false, 0, nil)
+	require.NoError(t, err)
+	conn.Unlock()
+
+	// Second request with a different contention ID should be shed once CoDel kicks in.
+	// Use a short-lived context to avoid waiting forever.
+	shortCtx, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
+	defer cancel()
+
+	_, _, _, err = txPool.Begin(shortCtx, &querypb.ExecuteOptions{UniqueId: "req-2"}, false, 0, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dml load shed")
+
+	// Cleanup.
+	c, _ := txPool.GetAndLock(conn.ReservedID(), "")
+	_, _ = txPool.Commit(ctx, c)
+	c.Release(tx.TxCommit)
+}
+
+func TestTxPoolSnake_NilSnakePassesThrough(t *testing.T) {
+	// Standard setup without snake — verify no panic.
+	_, txPool, _, closer := setup(t)
+	defer closer()
+
+	ctx := context.Background()
+	opts := &querypb.ExecuteOptions{UniqueId: "req-1"}
+
+	conn, _, _, err := txPool.Begin(ctx, opts, false, 0, nil)
+	require.NoError(t, err)
+	assert.Nil(t, conn.TxProperties().SnakeRelease)
+	conn.Unlock()
+	c, _ := txPool.GetAndLock(conn.ReservedID(), "")
+	_, _ = txPool.Commit(ctx, c)
+	c.Release(tx.TxCommit)
+}


### PR DESCRIPTION
### Background / Why?

The OLTP read pool is already gated by the Snake CoDel-based load shedder (PR #864). DML paths (autocommit and explicit transactions) need the same protection — when MySQL is overloaded, we want to shed excess DML requests at the gate rather than letting them pile up in the transaction pool and contribute to further latency spiral.

The integration point is `TxPool.Begin` / `txComplete`, which is the single convergence point for all DML execution paths. A Snake slot is acquired before getting a pool connection and released when the transaction ends (commit, rollback, or kill). Reserved connections (`reservedID != 0`) skip acquisition since they already hold a connection. Requests without a `unique_id` bypass the gate entirely, matching the OLTP-read behavior.

### Testing

- 7 new tests in `tx_pool_snake_test.go` covering: acquire on begin, release on commit, release on rollback, empty unique_id bypass, reserved conn bypass, capacity exhaustion shedding, nil snake passthrough.
- Existing `TestTxPool*` suite passes without regression.

AI disclosure: Claude Code assisted with development. Every line of code was either written by or carefully reviewed by me :)