### PR TITLE
Expose CoDel internals via `Stats()` method on Snake

### DIFF
--- a/go/vt/vttablet/tabletserver/loadshed/snake.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake.go
@@ -153,6 +153,30 @@ func (s *Snake) IsHealthy() bool {
 	return s.q.lockedIsHealthy()
 }
 
+// SnakeStats is a point-in-time snapshot of Snake's internal state.
+type SnakeStats struct {
+	QueueLen        int
+	DroppableLen    int
+	HolderCount     int
+	Dropping        bool
+	DropCount       int
+	CurrentInterval int64 // ns
+}
+
+// Stats returns a point-in-time snapshot of Snake's internal state.
+func (s *Snake) Stats() SnakeStats {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return SnakeStats{
+		QueueLen:        s.q.codelq.lockedLen(),
+		DroppableLen:    s.q.codelq.droppableLen,
+		HolderCount:     len(s.holders),
+		Dropping:        s.q.codelq.dropping,
+		DropCount:       s.q.codelq.count,
+		CurrentInterval: s.q.codelq.lockedCurrentInterval(),
+	}
+}
+
 // Release releases the slot. exc is an optional error that caused the release
 // (passed to release callbacks). Release is idempotent.
 func (u *SafeUnlock) Release(exc ...error) error {


### PR DESCRIPTION
### Background / Why?

The bench harness needs visibility into CoDel's internal state to produce diagnostic charts — queue depth over time, whether the algorithm is in dropping mode, and how the adaptive interval evolves under load. Without a dedicated accessor, the only way to observe these is to instrument the internals directly, which couples the bench suite to implementation details and makes it fragile across refactors.

`Stats()` returns a point-in-time snapshot struct (`SnakeStats`) under the existing mutex, giving the bench suite a stable API to poll every 10ms for charting queue depth, dropping state, and interval evolution without reaching into unexported fields.

### Testing

This is a read-only accessor that acquires the same mutex as all other Snake operations — no new concurrency paths introduced. Verified compilation and existing tests pass. The bench harness (out-of-tree) exercises this in its 10ms polling loop and produces correct charts.

AI disclosure: Claude Code assisted with development. Every line of code was either written by or carefully reviewed by me :)