### PR TITLE
Backport vitessio/vitess#20113: restore-done hook improvements

### DIFF
--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -26,7 +26,6 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
-	"slices"
 	"strings"
 	"sync"
 	"syscall"

--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -25,6 +25,8 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"syscall"
@@ -403,6 +405,10 @@ func TestBackup(t *testing.T, setupType int, streamMode string, stripes int, cDe
 		{
 			name:   "TestTerminatedRestore",
 			method: terminatedRestore,
+		}, //
+		{
+			name:   "TestRestoreDoneHookOnFailure",
+			method: testRestoreDoneHookOnFailure,
 		}, //
 		{
 			name:   "DoNotDemoteNewlyPromotedPrimaryIfReparentingDuringBackup",
@@ -1635,4 +1641,95 @@ func TestRestoreAllowedBackupEngines(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, backupMsg, result.Named().Row().AsString("msg", ""))
 	})
+}
+
+// testRestoreDoneHookOnFailure verifies that the vttablet_restore_done hook
+// fires synchronously even when the restore fails and the process exits.
+// This is a regression test for a bug where the hook was launched in a
+// goroutine that was killed by os.Exit(1) before it could complete.
+func testRestoreDoneHookOnFailure(t *testing.T) {
+	// Ensure a clean cluster state — preceding tests (e.g., terminatedRestore)
+	// may have torn down all tablets.
+	restartPrimaryAndReplica(t)
+
+	// 1. Install a vttablet_restore_done hook that writes env vars to a file.
+	vtroot := os.Getenv("VTROOT")
+	require.NotEmpty(t, vtroot, "VTROOT must be set")
+
+	hookDir := filepath.Join(vtroot, "vthook")
+	require.NoError(t, os.MkdirAll(hookDir, 0o755))
+
+	hookOutputFile := filepath.Join(localCluster.CurrentVTDATAROOT, "hook_restore_done_output")
+	hookScript := filepath.Join(hookDir, "vttablet_restore_done")
+	hookContent := fmt.Sprintf("#!/bin/bash\nenv > %s\n", hookOutputFile)
+	require.NoError(t, os.WriteFile(hookScript, []byte(hookContent), 0o755))
+	t.Cleanup(func() {
+		os.Remove(hookScript)
+		os.Remove(hookOutputFile)
+	})
+
+	// 2. Take a backup (using replica1 which is already running).
+	err := localCluster.VtctldClientProcess.ExecuteCommand("Backup", replica1.Alias)
+	require.NoError(t, err)
+	backups := localCluster.VerifyBackupCount(t, shardKsName, 1)
+	require.Len(t, backups, 1)
+
+	// 3. Corrupt the backup by overwriting one of its data files with garbage.
+	backupDir := filepath.Join(replica1.VttabletProcess.FileBackupStorageRoot, keyspaceName, shardName, backups[0])
+	entries, err := os.ReadDir(backupDir)
+	require.NoError(t, err)
+
+	corrupted := false
+	for _, entry := range entries {
+		if entry.IsDir() || entry.Name() == "MANIFEST" {
+			continue
+		}
+		// Overwrite with deterministic garbage to cause a checksum/read error.
+		garbage := []byte("CORRUPTED_FOR_TEST_DO_NOT_USE")
+		require.NoError(t, os.WriteFile(filepath.Join(backupDir, entry.Name()), garbage, 0o644))
+		corrupted = true
+		break
+	}
+	require.True(t, corrupted, "expected at least one data file to corrupt in backup")
+
+	// 4. Start replica3 — it will attempt to restore from the corrupted backup.
+	//    The restore will fail and the process will exit with os.Exit(1).
+	//    We set ExplicitServingStatus so Setup() waits only for SERVING (not
+	//    NOT_SERVING). Since the tablet never reaches SERVING (the background
+	//    restore goroutine fails and calls os.Exit), the exit channel fires
+	//    and Setup() returns "exited prematurely".
+	replica3.VttabletProcess.ExtraArgs = commonTabletArg
+	replica3.VttabletProcess.ServingStatus = "SERVING"
+	replica3.VttabletProcess.ExplicitServingStatus = true
+	err = replica3.VttabletProcess.Setup()
+	require.Error(t, err, "expected vttablet to exit due to failed restore")
+	require.Contains(t, err.Error(), "exited prematurely")
+
+	// 5. Verify the hook output file exists and contains the expected env vars.
+	//    Before the fix, this file would not exist because the hook goroutine was
+	//    killed by os.Exit(1) before it could complete.
+	hookOutput, err := os.ReadFile(hookOutputFile)
+	require.NoError(t, err, "hook output file must exist — hook should fire synchronously before os.Exit")
+
+	output := string(hookOutput)
+	assert.Contains(t, output, "TM_RESTORE_DATA_ERROR=")
+	assert.Contains(t, output, "TM_RESTORE_DATA_START_TS=")
+	assert.Contains(t, output, "TM_RESTORE_DATA_STOP_TS=")
+	assert.Contains(t, output, "TM_RESTORE_DATA_DURATION=")
+	assert.Contains(t, output, "TABLET_ALIAS=")
+	assert.Contains(t, output, "KEYSPACE="+keyspaceName)
+	assert.Contains(t, output, "SHARD="+shardName)
+
+	// With the backup engine fix, the engine should be reported even on failure.
+	switch currentSetupType {
+	case BuiltinBackup:
+		assert.Contains(t, output, "TM_RESTORE_DATA_BACKUP_ENGINE=builtin")
+	case XtraBackup:
+		assert.Contains(t, output, "TM_RESTORE_DATA_BACKUP_ENGINE=xtrabackup")
+	case MySQLShell:
+		assert.Contains(t, output, "TM_RESTORE_DATA_BACKUP_ENGINE=mysqlshell")
+	}
+
+	// Clean up: remove all backups so other tests aren't affected.
+	localCluster.RemoveAllBackups(t, shardKsName)
 }

--- a/go/vt/mysqlctl/backup.go
+++ b/go/vt/mysqlctl/backup.go
@@ -430,7 +430,7 @@ func Restore(ctx context.Context, params RestoreParams) (*BackupManifest, error)
 		return nil, vterrors.Errorf(vtrpc.Code_INTERNAL, "empty restore path")
 	}
 	bh := restorePath.FullBackupHandle()
-	re, err := GetRestoreEngine(ctx, bh)
+	re, backupManifest, err := GetRestoreEngineAndManifest(ctx, bh)
 	if err != nil {
 		return nil, vterrors.Wrap(err, "Failed to find restore engine")
 	}
@@ -444,9 +444,10 @@ func Restore(ctx context.Context, params RestoreParams) (*BackupManifest, error)
 		backupstats.Component(backupstats.BackupEngine),
 		backupstats.Implementation(textutil.Title(backupEngineImplementation)),
 	)
+
 	manifest, err := re.ExecuteRestore(ctx, reParams, bh)
 	if err != nil {
-		return nil, err
+		return backupManifest, err
 	}
 
 	if re.ShouldStartMySQLAfterRestore() { // all engines except mysqlshell since MySQL is always running there
@@ -460,26 +461,26 @@ func Restore(ctx context.Context, params RestoreParams) (*BackupManifest, error)
 		params.Logger.Infof("Restore: starting mysqld for mysql_upgrade")
 		// Note Start will use dba user for waiting, this is fine, it will be allowed.
 		if err := params.Mysqld.Start(context.Background(), params.Cnf, "--skip-grant-tables", "--skip-networking"); err != nil {
-			return nil, err
+			return backupManifest, err
 		}
 	}
 
 	params.Logger.Infof("Restore: running mysql_upgrade")
 	if err := params.Mysqld.RunMysqlUpgrade(ctx); err != nil {
-		return nil, vterrors.Wrap(err, "mysql_upgrade failed")
+		return backupManifest, vterrors.Wrap(err, "mysql_upgrade failed")
 	}
 
 	// The MySQL manual recommends restarting mysqld after running mysql_upgrade,
 	// so that any changes made to system tables take effect.
 	params.Logger.Infof("Restore: restarting mysqld after mysql_upgrade")
 	if err := params.Mysqld.Shutdown(context.Background(), params.Cnf, true, params.MysqlShutdownTimeout); err != nil {
-		return nil, err
+		return backupManifest, err
 	}
 	if err := params.Mysqld.Start(context.Background(), params.Cnf); err != nil {
-		return nil, err
+		return backupManifest, err
 	}
 	if err = ensureRestoredGTIDPurgedMatchesManifest(ctx, manifest, &params); err != nil {
-		return nil, err
+		return backupManifest, err
 	}
 
 	if handles := restorePath.IncrementalBackupHandles(); len(handles) > 0 {
@@ -490,7 +491,7 @@ func Restore(ctx context.Context, params RestoreParams) (*BackupManifest, error)
 		for _, bh := range handles {
 			manifest, err := builtInRE.ExecuteRestore(ctx, params, bh)
 			if err != nil {
-				return nil, err
+				return backupManifest, err
 			}
 			params.Logger.Infof("Restore: applied incremental backup: %v", manifest.Position)
 		}
@@ -499,7 +500,7 @@ func Restore(ctx context.Context, params RestoreParams) (*BackupManifest, error)
 
 	params.Logger.Infof("Restore: removing state file")
 	if err = removeStateFile(params.Cnf); err != nil {
-		return nil, err
+		return backupManifest, err
 	}
 
 	backupstats.DeprecatedRestoreDurationS.Set(int64(time.Since(startTs).Seconds()))

--- a/go/vt/mysqlctl/backupengine.go
+++ b/go/vt/mysqlctl/backupengine.go
@@ -237,20 +237,30 @@ func GetBackupEngine(backupEngine string) (BackupEngine, error) {
 // GetRestoreEngine returns the RestoreEngine implementation to restore a given backup.
 // It reads the MANIFEST file from the backup to check which engine was used to create it.
 func GetRestoreEngine(ctx context.Context, backup backupstorage.BackupHandle) (RestoreEngine, error) {
+	re, _, err := GetRestoreEngineAndManifest(ctx, backup)
+	return re, err
+}
+
+// GetRestoreEngineAndManifest returns the RestoreEngine and the BackupManifest
+// for a given backup in a single MANIFEST read.
+// Note: if BackupMethod is empty (legacy builtin backups), the returned manifest
+// will have BackupMethod set to "builtin" — this may differ from what is on disk.
+func GetRestoreEngineAndManifest(ctx context.Context, backup backupstorage.BackupHandle) (RestoreEngine, *BackupManifest, error) {
 	manifest, err := GetBackupManifest(ctx, backup)
 	if err != nil {
-		return nil, vterrors.Wrap(err, "can't get backup MANIFEST")
+		return nil, nil, vterrors.Wrap(err, "can't get backup MANIFEST")
 	}
 	engine := manifest.BackupMethod
 	if engine == "" {
 		// The builtin engine is the only one that ever left BackupMethod unset.
 		engine = builtinBackupEngineName
+		manifest.BackupMethod = engine
 	}
 	re, ok := BackupRestoreEngineMap[engine]
 	if !ok {
-		return nil, vterrors.Errorf(vtrpc.Code_NOT_FOUND, "can't restore backup created with %q engine; no such BackupEngine implementation is registered", manifest.BackupMethod)
+		return nil, nil, vterrors.Errorf(vtrpc.Code_NOT_FOUND, "can't restore backup created with %q engine; no such BackupEngine implementation is registered", manifest.BackupMethod)
 	}
-	return re, nil
+	return re, manifest, nil
 }
 
 // GetBackupManifest returns the common fields of the MANIFEST file for a given backup.

--- a/go/vt/vttablet/tabletmanager/restore.go
+++ b/go/vt/vttablet/tabletmanager/restore.go
@@ -99,23 +99,28 @@ func (tm *TabletManager) RestoreData(
 	restoreToPos string,
 	allowedBackupEngines []string,
 	mysqlShutdownTimeout time.Duration) error {
-	if err := tm.lock(ctx); err != nil {
-		return err
-	}
-	defer tm.unlock()
-	if tm.Cnf == nil {
-		return fmt.Errorf("cannot perform restore without my.cnf, please restart vttablet with a my.cnf file specified")
-	}
-
 	var (
 		err          error
 		startTime    time.Time
 		backupEngine string
 	)
 
+	// Declare the hook defer before the lock so it runs after unlock (LIFO).
 	defer func() {
+		if startTime.IsZero() {
+			return
+		}
 		tm.invokeRestoreDoneHook(startTime, err, backupEngine)
 	}()
+
+	if lockErr := tm.lock(ctx); lockErr != nil {
+		return lockErr
+	}
+	defer tm.unlock()
+
+	if tm.Cnf == nil {
+		return fmt.Errorf("cannot perform restore without my.cnf, please restart vttablet with a my.cnf file specified")
+	}
 
 	startTime = time.Now()
 
@@ -149,19 +154,25 @@ func (tm *TabletManager) invokeRestoreDoneHook(startTime time.Time, err error, b
 		h.ExtraEnv["TM_RESTORE_DATA_ERROR"] = err.Error()
 	}
 
-	// vttablet_restore_done is best-effort (for now?).
-	go func() {
-		// Package vthook already logs the stdout/stderr of hooks when they
-		// are run, so we don't duplicate that here.
-		hr := h.Execute()
-		switch hr.ExitStatus {
-		case hook.HOOK_SUCCESS:
-		case hook.HOOK_DOES_NOT_EXIST:
-			log.Info("No vttablet_restore_done hook.")
-		default:
-			log.Warning("vttablet_restore_done hook failed")
-		}
-	}()
+	// Run the hook synchronously so it completes before either (a) the process
+	// exits on restore failure — tm_init.go calls os.Exit immediately, which
+	// would kill a background goroutine — or (b) the tablet finishes startup on
+	// the success path, where a background goroutine could race with serving.
+	//
+	// 30s is generous for typical hooks (write a file, emit a metric) while
+	// short enough to avoid meaningfully delaying tablet startup.
+	hookCtx, hookCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer hookCancel()
+	hr := h.ExecuteContext(hookCtx)
+	switch hr.ExitStatus {
+	case hook.HOOK_SUCCESS:
+	case hook.HOOK_DOES_NOT_EXIST:
+		log.Info("No vttablet_restore_done hook.")
+	case hook.HOOK_TIMEOUT_ERROR:
+		log.Warningf("vttablet_restore_done hook timed out (exit status %d), stderr: %s", hr.ExitStatus, hr.Stderr)
+	default:
+		log.Warningf("vttablet_restore_done hook failed with exit status %d, stderr: %s", hr.ExitStatus, hr.Stderr)
+	}
 }
 
 func (tm *TabletManager) restoreDataLocked(ctx context.Context, logger logutil.Logger, waitForBackupInterval time.Duration, deleteBeforeRestore bool, request *tabletmanagerdatapb.RestoreFromBackupRequest, mysqlShutdownTimeout time.Duration) (string, error) {
@@ -248,7 +259,7 @@ func (tm *TabletManager) restoreDataLocked(ctx context.Context, logger logutil.L
 	var backupManifest *mysqlctl.BackupManifest
 	for {
 		backupManifest, err = mysqlctl.Restore(ctx, params)
-		if backupManifest != nil {
+		if backupManifest != nil && err == nil {
 			statsRestoreBackupPosition.Set(replication.EncodePosition(backupManifest.Position))
 			statsRestoreBackupTime.Set(backupManifest.BackupTime)
 		}
@@ -309,7 +320,11 @@ func (tm *TabletManager) restoreDataLocked(ctx context.Context, logger logutil.L
 		if err := tm.tmState.ChangeTabletType(bgCtx, originalType, DBActionNone); err != nil {
 			log.Errorf("Could not change back to original tablet type %v: %v", originalType, err)
 		}
-		return "", vterrors.Wrap(err, "Can't restore backup")
+		var engine string
+		if backupManifest != nil {
+			engine = backupManifest.BackupMethod
+		}
+		return engine, vterrors.Wrap(err, "can't restore backup")
 	}
 
 	// If we had type BACKUP or RESTORE it's better to set our type to the init_tablet_type to make result of the restore

--- a/go/vt/vttablet/tabletmanager/restore_test.go
+++ b/go/vt/vttablet/tabletmanager/restore_test.go
@@ -67,18 +67,11 @@ func setupHookDir(t *testing.T) (outputFile string) {
 	return outputFile
 }
 
-func waitForHookOutput(t *testing.T, outputFile string) string {
+func readHookOutput(t *testing.T, outputFile string) string {
 	t.Helper()
-	var content string
-	assert.Eventually(t, func() bool {
-		data, err := os.ReadFile(outputFile)
-		if err != nil {
-			return false
-		}
-		content = string(data)
-		return len(content) > 0
-	}, 5*time.Second, 50*time.Millisecond)
-	return content
+	data, err := os.ReadFile(outputFile)
+	require.NoError(t, err, "hook output file should exist after synchronous execution")
+	return string(data)
 }
 
 func TestInvokeRestoreDoneHook_BackupEngine(t *testing.T) {
@@ -88,7 +81,7 @@ func TestInvokeRestoreDoneHook_BackupEngine(t *testing.T) {
 	startTime := time.Now().Add(-10 * time.Second)
 	tm.invokeRestoreDoneHook(startTime, nil, "xtrabackup")
 
-	content := waitForHookOutput(t, outputFile)
+	content := readHookOutput(t, outputFile)
 
 	assert.Contains(t, content, "TM_RESTORE_DATA_BACKUP_ENGINE=xtrabackup")
 	assert.Contains(t, content, "TM_RESTORE_DATA_START_TS=")
@@ -106,7 +99,7 @@ func TestInvokeRestoreDoneHook_EmptyBackupEngine(t *testing.T) {
 
 	tm.invokeRestoreDoneHook(time.Now(), nil, "")
 
-	content := waitForHookOutput(t, outputFile)
+	content := readHookOutput(t, outputFile)
 
 	assert.NotContains(t, content, "TM_RESTORE_DATA_BACKUP_ENGINE=")
 }
@@ -118,7 +111,7 @@ func TestInvokeRestoreDoneHook_WithError(t *testing.T) {
 	restoreErr := errors.New("restore failed: connection refused")
 	tm.invokeRestoreDoneHook(time.Now(), restoreErr, "builtin")
 
-	content := waitForHookOutput(t, outputFile)
+	content := readHookOutput(t, outputFile)
 
 	assert.Contains(t, content, "TM_RESTORE_DATA_BACKUP_ENGINE=builtin")
 	assert.Contains(t, content, "TM_RESTORE_DATA_ERROR=restore failed: connection refused")
@@ -131,7 +124,7 @@ func TestInvokeRestoreDoneHook_ErrorWithoutBackupEngine(t *testing.T) {
 	restoreErr := errors.New("no backup found")
 	tm.invokeRestoreDoneHook(time.Now(), restoreErr, "")
 
-	content := waitForHookOutput(t, outputFile)
+	content := readHookOutput(t, outputFile)
 
 	assert.Contains(t, content, "TM_RESTORE_DATA_ERROR=no backup found")
 	assert.NotContains(t, content, "TM_RESTORE_DATA_BACKUP_ENGINE=")
@@ -144,7 +137,7 @@ func TestInvokeRestoreDoneHook_Timestamps(t *testing.T) {
 	startTime := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
 	tm.invokeRestoreDoneHook(startTime, nil, "xtrabackup")
 
-	content := waitForHookOutput(t, outputFile)
+	content := readHookOutput(t, outputFile)
 
 	assert.Contains(t, content, "TM_RESTORE_DATA_START_TS=2024-01-15T10:30:00Z")
 	// Verify the duration is present and contains a non-zero value.

--- a/go/vt/vttablet/tabletmanager/rpc_backup.go
+++ b/go/vt/vttablet/tabletmanager/rpc_backup.go
@@ -182,6 +182,23 @@ func (tm *TabletManager) Backup(ctx context.Context, logger logutil.Logger, req 
 // RestoreFromBackup deletes all local data and then restores the data from the latest backup [at
 // or before the backupTime value if specified]
 func (tm *TabletManager) RestoreFromBackup(ctx context.Context, logger logutil.Logger, request *tabletmanagerdatapb.RestoreFromBackupRequest) error {
+	var (
+		startTime    time.Time
+		backupEngine string
+		restoreErr   error
+	)
+
+	// Declare the hook defer before the lock so it runs after unlock (LIFO).
+	// BroadcastHealth intentionally runs outside the action lock so vtgate
+	// sees the updated serving state without waiting for the hook to finish.
+	defer func() {
+		if startTime.IsZero() {
+			return
+		}
+		tm.QueryServiceControl.BroadcastHealth()
+		tm.invokeRestoreDoneHook(startTime, restoreErr, backupEngine)
+	}()
+
 	if err := tm.lock(ctx); err != nil {
 		return err
 	}
@@ -199,14 +216,10 @@ func (tm *TabletManager) RestoreFromBackup(ctx context.Context, logger logutil.L
 	l := logutil.NewTeeLogger(logutil.NewConsoleLogger(), logger)
 
 	// Now we can run restore.
-	startTime := time.Now()
-	backupEngine, err := tm.restoreDataLocked(ctx, l, 0 /* waitForBackupInterval */, true /* deleteBeforeRestore */, request, mysqlShutdownTimeout)
-	tm.invokeRestoreDoneHook(startTime, err, backupEngine)
+	startTime = time.Now()
+	backupEngine, restoreErr = tm.restoreDataLocked(ctx, l, 0 /* waitForBackupInterval */, true /* deleteBeforeRestore */, request, mysqlShutdownTimeout)
 
-	// Re-run health check to be sure to capture any replication delay.
-	tm.QueryServiceControl.BroadcastHealth()
-
-	return err
+	return restoreErr
 }
 
 func (tm *TabletManager) IsBackupRunning() bool {


### PR DESCRIPTION
## Summary
- Cherry-pick of upstream [vitessio/vitess#20113](https://github.com/vitessio/vitess/pull/20113) with conflict resolution for slack-22.0
- Supersedes the partial backport in #814

Key changes:
- Run `vttablet_restore_done` hook synchronously with 30s timeout (prevents `os.Exit` killing background goroutine before hook completes)
- Release action lock before invoking hook (defer ordering)
- BroadcastHealth before hook in RestoreFromBackup RPC path
- Return backup engine on failure paths so hook reports engine even when restore fails
- Add hook timeout and failure logging with stderr
- Guard stats update with `err==nil` check
- Normalize `BackupMethod` for legacy builtin backups
- Add e2e test for hook-on-failure scenario

## Test plan
- [x] CI passes (e2e backup tests include the new `TestRestoreDoneHookOnFailure`)
- [ ] Verify hook fires with `TM_RESTORE_DATA_BACKUP_ENGINE` set on both success and failure paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)