### PR TITLE
Add Snake benchmark suite and plotting scripts

### DIFF
--- a/go/vt/vttablet/tabletserver/loadshed/benchmark/README.md
+++ b/go/vt/vttablet/tabletserver/loadshed/benchmark/README.md
@@ -1,0 +1,60 @@
+# Snake Benchmark Suite
+
+Exercises Snake under synthetic load to visualize CoDel behavior (grant rate, shedding,
+queue depth, interval adaptation, latency). Outputs TSV files consumed by the plotting
+scripts.
+
+## Running the bench
+
+```bash
+cd go/vt/vttablet/tabletserver/loadshed/benchmark
+
+# With production defaults (exponent=1.0, target=5ms, interval=100ms):
+go run bench_suite.go
+
+# Override CoDel parameters:
+go run bench_suite.go --exponent 0.5 --target-ms 10 --interval-ms 200
+
+# Custom output directory:
+go run bench_suite.go --out /tmp/my-run
+```
+
+Output lands in `~/snake-load-test-charts/tsv/<date>/<timestamp>/` by default.
+
+## Plotting
+
+Requires Python 3 with matplotlib and pandas:
+
+```bash
+# Plot the most recent run:
+python3 plot_linear_ramp.py
+
+# Plot a specific run:
+python3 plot_linear_ramp.py ~/snake-load-test-charts/tsv/2026-06-17/2026-06-17_14-30-00/
+```
+
+Output PNG goes to `~/snake-load-test-charts/`.
+
+## Easing comparison
+
+To compare multiple exponent values side-by-side:
+
+```bash
+for exp in 0.25 0.5 0.75 1.0 1.5 2.0; do
+  go run bench_suite.go --exponent $exp --out ~/snake-load-test-charts/tsv/easing-comparison/easing_${exp}
+done
+
+python3 plot_easing_comparison.py
+```
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--out` | auto | Output directory for TSVs |
+| `--exponent` | 1.0 | CoDel control law exponent |
+| `--target-ms` | 5 | CoDel target delay (ms) |
+| `--interval-ms` | 100 | CoDel observation interval (ms) |
+
+Defaults match production vttablet values (`--loadshed-exponent`, `--loadshed-target`,
+`--loadshed-interval`). Override to experiment with alternative tuning.

--- a/go/vt/vttablet/tabletserver/loadshed/benchmark/bench_suite.go
+++ b/go/vt/vttablet/tabletserver/loadshed/benchmark/bench_suite.go
@@ -1,0 +1,262 @@
+//go:build ignore
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/loadshed"
+)
+
+type event struct {
+	tsMs      int64
+	eventType string
+	latencyMs float64
+}
+
+type statsSnapshot struct {
+	tsMs            int64
+	queueLen        int
+	droppableLen    int
+	holderCount     int
+	dropping        bool
+	dropCount       int
+	currentInterval int64
+}
+
+type loadProfile func(elapsed, total time.Duration) float64
+
+func linearRamp(elapsed, total time.Duration) float64 {
+	return elapsed.Seconds() / total.Seconds()
+}
+
+func runTest(cfg testConfig) ([]event, []statsSnapshot) {
+	capacity := cfg.capacity
+	workMs := cfg.workMs
+	targetMs := cfg.targetMs
+	intervalMs := cfg.intervalMs
+	exponent := cfg.exponent
+	totalDuration := time.Duration(cfg.durationMs) * time.Millisecond
+	peakArrivalRateMultiplier := cfg.peakArrivalRateMultiplier
+	profile := cfg.profile
+
+	snake := loadshed.NewSnake(loadshed.SnakeConfig{
+		Name: "bench",
+		CoDel: loadshed.CoDelConfig{
+			TargetNs:       func() int64 { return int64(targetMs) * 1_000_000 },
+			IntervalNs:     func() int64 { return int64(intervalMs) * 1_000_000 },
+			MinDropDelayNs: func() int64 { return 1_000_000 },
+			Exponent:       func() float64 { return exponent },
+		},
+		Capacity:            func() int { return capacity },
+		MaxAge:              func() time.Duration { return 30 * time.Second },
+		LoadsheddingAllowed: func() bool { return true },
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var mu sync.Mutex
+	var events []event
+	var stats []statsSnapshot
+	start := time.Now()
+
+	record := func(evtType string, latMs float64) {
+		ts := time.Since(start).Milliseconds()
+		mu.Lock()
+		events = append(events, event{tsMs: ts, eventType: evtType, latencyMs: latMs})
+		mu.Unlock()
+	}
+
+	// Stats polling goroutine
+	statsDone := make(chan struct{})
+	go func() {
+		defer close(statsDone)
+		ticker := time.NewTicker(10 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				s := snake.Stats()
+				ts := time.Since(start).Milliseconds()
+				mu.Lock()
+				stats = append(stats, statsSnapshot{
+					tsMs:            ts,
+					queueLen:        s.QueueLen,
+					droppableLen:    s.DroppableLen,
+					holderCount:     s.HolderCount,
+					dropping:        s.Dropping,
+					dropCount:       s.DropCount,
+					currentInterval: s.CurrentInterval,
+				})
+				mu.Unlock()
+			}
+		}
+	}()
+
+	var wg sync.WaitGroup
+	var issued atomic.Int64
+
+	systemThroughput := float64(capacity) * 1000.0 / float64(workMs)
+	peakArrivalRate := peakArrivalRateMultiplier * systemThroughput
+
+	tickInterval := 1 * time.Millisecond
+	ticker := time.NewTicker(tickInterval)
+	defer ticker.Stop()
+
+	workDur := time.Duration(workMs) * time.Millisecond
+	var accumulator float64
+
+	deadline := time.After(totalDuration)
+	issuing := true
+
+	for issuing {
+		select {
+		case <-deadline:
+			issuing = false
+		case now := <-ticker.C:
+			elapsed := now.Sub(start)
+			loadFraction := profile(elapsed, totalDuration)
+
+			arrivalsPerSec := loadFraction * peakArrivalRate
+			arrivalsThisTick := arrivalsPerSec * tickInterval.Seconds()
+			accumulator += arrivalsThisTick
+
+			toSpawn := int(accumulator)
+			accumulator -= float64(toSpawn)
+
+			for range toSpawn {
+				wg.Add(1)
+				issued.Add(1)
+				go func() {
+					defer wg.Done()
+
+					reqStart := time.Now()
+					record("issued", 0)
+
+					unlock, err := snake.Acquire(ctx, "")
+					if err != nil {
+						record("shed", 0)
+						return
+					}
+					time.Sleep(workDur)
+					unlock.Release()
+					latency := float64(time.Since(reqStart).Microseconds()) / 1000.0
+					record("granted", latency)
+				}()
+			}
+		}
+	}
+
+	cancel()
+	wg.Wait()
+	<-statsDone
+	return events, stats
+}
+
+type testConfig struct {
+	label                     string
+	capacity                  int
+	peakArrivalRateMultiplier float64
+	durationMs                int
+	workMs                    int
+	targetMs                  int
+	intervalMs                int
+	exponent                  float64
+	profile                   loadProfile
+}
+
+func main() {
+	outDir := flag.String("out", "", "Output directory for TSVs (default: ~/snake-load-test-charts/tsv/<date>/<timestamp>/)")
+	flag.Parse()
+
+	if *outDir == "" {
+		now := time.Now()
+		date := now.Format("2006-01-02")
+		ts := now.Format("2006-01-02_15-04-05")
+		home, _ := os.UserHomeDir()
+		*outDir = filepath.Join(home, "snake-load-test-charts", "tsv", date, ts)
+	}
+	os.MkdirAll(*outDir, 0o755)
+
+	tests := []testConfig{
+		{
+			label:                     "linear_ramp__0_to_80x_cap__work_half_target",
+			capacity:                  10,
+			peakArrivalRateMultiplier: 80,
+			durationMs:                20000,
+			workMs:                    2,
+			targetMs:                  5,
+			intervalMs:                100,
+			exponent:                  0.5,
+			profile:                   linearRamp,
+		},
+	}
+
+	for _, tc := range tests {
+		fmt.Printf("Running: %s (capacity=%d, work=%dms, target=%dms, interval=%dms, exponent=%.2f)\n",
+			tc.label, tc.capacity, tc.workMs, tc.targetMs, tc.intervalMs, tc.exponent)
+		events, stats := runTest(tc)
+
+		// Write events TSV
+		tsvPath := filepath.Join(*outDir, tc.label+".tsv")
+		f, err := os.Create(tsvPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR creating %s: %v\n", tsvPath, err)
+			continue
+		}
+		fmt.Fprintf(f, "ts_ms\tevent\tlatency_ms\n")
+		for _, e := range events {
+			latStr := ""
+			if e.eventType == "granted" {
+				latStr = fmt.Sprintf("%.3f", e.latencyMs)
+			}
+			fmt.Fprintf(f, "%d\t%s\t%s\n", e.tsMs, e.eventType, latStr)
+		}
+		f.Close()
+
+		// Write stats TSV
+		statsPath := filepath.Join(*outDir, tc.label+"_stats.tsv")
+		sf, err := os.Create(statsPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR creating %s: %v\n", statsPath, err)
+			continue
+		}
+		fmt.Fprintf(sf, "ts_ms\tqueue_len\tdroppable_len\tholder_count\tdropping\tdrop_count\tcurrent_interval_ns\n")
+		for _, s := range stats {
+			droppingInt := 0
+			if s.dropping {
+				droppingInt = 1
+			}
+			fmt.Fprintf(sf, "%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
+				s.tsMs, s.queueLen, s.droppableLen, s.holderCount, droppingInt, s.dropCount, s.currentInterval)
+		}
+		sf.Close()
+
+		var issuedCount, grantedCount, shedCount int
+		for _, e := range events {
+			switch e.eventType {
+			case "issued":
+				issuedCount++
+			case "granted":
+				grantedCount++
+			case "shed":
+				shedCount++
+			}
+		}
+		shedPct := float64(shedCount) / math.Max(float64(issuedCount), 1) * 100
+		fmt.Printf("  %s: issued=%d granted=%d shed=%d (%.1f%%)\n",
+			tc.label, issuedCount, grantedCount, shedCount, shedPct)
+	}
+
+	fmt.Printf("\nOutput: %s\n", *outDir)
+}

--- a/go/vt/vttablet/tabletserver/loadshed/benchmark/bench_suite.go
+++ b/go/vt/vttablet/tabletserver/loadshed/benchmark/bench_suite.go
@@ -177,6 +177,9 @@ type testConfig struct {
 
 func main() {
 	outDir := flag.String("out", "", "Output directory for TSVs (default: ~/snake-load-test-charts/tsv/<date>/<timestamp>/)")
+	exponent := flag.Float64("exponent", 1.0, "CoDel exponent (production default: 1.0)")
+	targetMs := flag.Int("target-ms", 5, "CoDel target in ms (production default: 5)")
+	intervalMs := flag.Int("interval-ms", 100, "CoDel interval in ms (production default: 100)")
 	flag.Parse()
 
 	if *outDir == "" {
@@ -195,9 +198,9 @@ func main() {
 			peakArrivalRateMultiplier: 80,
 			durationMs:                20000,
 			workMs:                    2,
-			targetMs:                  5,
-			intervalMs:                100,
-			exponent:                  0.5,
+			targetMs:                  *targetMs,
+			intervalMs:                *intervalMs,
+			exponent:                  *exponent,
 			profile:                   linearRamp,
 		},
 	}

--- a/go/vt/vttablet/tabletserver/loadshed/benchmark/plot_easing_comparison.py
+++ b/go/vt/vttablet/tabletserver/loadshed/benchmark/plot_easing_comparison.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Plot 6-column comparison of easing divisor values (work=2ms)."""
+
+import os
+import pandas as pd
+import matplotlib.pyplot as plt
+import matplotlib.ticker as mticker
+import numpy as np
+from pathlib import Path
+from datetime import datetime
+
+BASE = Path.home() / "snake-load-test-charts"
+EASING_BASE = BASE / "tsv" / "easing-comparison"
+
+EASING_RUNS = [
+    (1.0, str(EASING_BASE / "easing_1.0")),
+    (1.2, str(EASING_BASE / "easing_1.2")),
+    (2.0, str(EASING_BASE / "easing_2.0")),
+    (4.0, str(EASING_BASE / "easing_4.0")),
+    (8.0, str(EASING_BASE / "easing_8.0")),
+    (16.0, str(EASING_BASE / "easing_16.0")),
+]
+
+KEY = "linear_ramp__0_to_80x_cap__work_half_target"
+DUR_MS = 20000
+NUM_COLS = len(EASING_RUNS)
+NUM_ROWS = 7  # grant rate, issued/shed Hz, queue depth, codel state, interval, cumulative unfilled, latency
+
+
+def compute_hz_series(df, event_type, bin_ms, max_ts):
+    subset = df[df["event"] == event_type]["ts_ms"].values
+    bins = np.arange(0, max_ts + bin_ms, bin_ms)
+    if len(subset) == 0:
+        centers = (bins[:-1] + bins[1:]) / 2 / 1000
+        return centers, np.zeros(len(centers))
+    counts, edges = np.histogram(subset, bins=bins)
+    centers = (edges[:-1] + edges[1:]) / 2 / 1000
+    hz = counts / (bin_ms / 1000)
+    return centers, hz
+
+
+def compute_latency_percentiles(df, bin_ms, max_ts):
+    granted = df[df["event"] == "granted"].copy()
+    if len(granted) == 0 or "latency_ms" not in granted.columns:
+        return None, None, None, None
+    granted = granted.dropna(subset=["latency_ms"])
+    granted["latency_ms"] = pd.to_numeric(granted["latency_ms"], errors="coerce")
+    granted = granted.dropna(subset=["latency_ms"])
+    if len(granted) == 0:
+        return None, None, None, None
+
+    bins = np.arange(0, max_ts + bin_ms, bin_ms)
+    centers = (bins[:-1] + bins[1:]) / 2 / 1000
+    granted["bin"] = pd.cut(granted["ts_ms"], bins=bins, labels=False)
+
+    p50 = np.full(len(centers), np.nan)
+    p95 = np.full(len(centers), np.nan)
+    p99 = np.full(len(centers), np.nan)
+
+    for i, grp in granted.groupby("bin")["latency_ms"]:
+        if len(grp) >= 3:
+            idx = int(i)
+            if 0 <= idx < len(centers):
+                p50[idx] = grp.quantile(0.5)
+                p95[idx] = grp.quantile(0.95)
+                p99[idx] = grp.quantile(0.99)
+
+    return centers, p50, p95, p99
+
+
+fig, axes = plt.subplots(NUM_ROWS, NUM_COLS, figsize=(30, 22), squeeze=False,
+                         sharey='row')
+fig.suptitle(
+    "CoDel Easing Divisor Comparison — Linear Ramp 0→80× capacity, work=2ms\n"
+    "capacity=10, target=5ms, interval=100ms, exponent=1",
+    fontsize=13, y=0.99,
+)
+
+for col_idx, (divisor, run_dir) in enumerate(EASING_RUNS):
+    tsv_dir = Path(run_dir)
+    events_file = tsv_dir / f"{KEY}.tsv"
+    stats_file = tsv_dir / f"{KEY}_stats.tsv"
+
+    if not events_file.exists():
+        for row in range(NUM_ROWS):
+            axes[row][col_idx].text(0.5, 0.5, "no data", transform=axes[row][col_idx].transAxes, ha="center")
+        continue
+
+    df = pd.read_csv(events_file, sep="\t")
+    max_ts = min(df["ts_ms"].max(), DUR_MS + 500)
+    bin_ms = max(5, int(max_ts / 150))
+
+    t_issued, hz_issued = compute_hz_series(df, "issued", bin_ms, max_ts)
+    t_granted, hz_granted = compute_hz_series(df, "granted", bin_ms, max_ts)
+    t_shed, hz_shed = compute_hz_series(df, "shed", bin_ms, max_ts)
+
+    xlim = DUR_MS / 1000 * 1.02
+
+    total_issued = len(df[df["event"] == "issued"])
+    total_shed = len(df[df["event"] == "shed"])
+    shed_pct = total_shed / total_issued * 100 if total_issued > 0 else 0
+
+    # Row 0: Grant rate
+    ax = axes[0][col_idx]
+    ax.plot(t_granted, hz_granted, color="green", linewidth=1.3)
+    ax.fill_between(t_granted, hz_granted, alpha=0.15, color="green")
+    ax.set_title(f"easing divisor = {divisor}", fontsize=11, fontweight="bold")
+    ax.set_xlim(0, xlim)
+    ax.yaxis.set_major_locator(mticker.MaxNLocator(5))
+    ax.grid(True, alpha=0.3)
+    ax.ticklabel_format(useOffset=False, style='plain', axis='y')
+    if col_idx == 0:
+        ax.set_ylabel("Hz")
+        ax.set_title("Grant Rate\n" + f"easing divisor = {divisor}", fontsize=10, fontweight="bold")
+
+    # Row 1: Hz chart (issued + shed)
+    ax = axes[1][col_idx]
+    ax.fill_between(t_issued, hz_issued, alpha=0.12, color="grey")
+    ax.plot(t_issued, hz_issued, color="grey", linewidth=0.8, label="issued")
+    ax.plot(t_granted, hz_granted, color="green", linewidth=1.3, label="granted")
+    ax.plot(t_shed, hz_shed, color="red", linewidth=1, label="shed")
+    ax.text(0.97, 0.95, f"shed: {shed_pct:.1f}%",
+            transform=ax.transAxes, ha="right", va="top", fontsize=9,
+            bbox=dict(boxstyle="round,pad=0.2", facecolor="white", alpha=0.8))
+    ax.set_xlim(0, xlim)
+    ax.yaxis.set_major_locator(mticker.MaxNLocator(5))
+    ax.grid(True, alpha=0.3)
+    ax.ticklabel_format(useOffset=False, style='plain', axis='y')
+    if col_idx == 0:
+        ax.legend(loc="upper left", fontsize=8)
+        ax.set_ylabel("Hz")
+
+    # Rows 2-5: Stats panels
+    if stats_file.exists():
+        stats_df = pd.read_csv(stats_file, sep="\t")
+        stats_df = stats_df[stats_df["ts_ms"] <= DUR_MS]
+        t = stats_df["ts_ms"].values / 1000
+
+        # Row 2: Queue depth
+        ax = axes[2][col_idx]
+        ax.plot(t, stats_df["queue_len"].values, color="blue", linewidth=1, label="queue total")
+        ax.plot(t, stats_df["droppable_len"].values, color="orange", linewidth=1, label="droppable")
+        ax.plot(t, stats_df["holder_count"].values, color="green", linewidth=1, label="holders")
+        ax.set_xlim(0, xlim)
+        ax.grid(True, alpha=0.3)
+        ax.ticklabel_format(useOffset=False, style='plain', axis='y')
+        if col_idx == 0:
+            ax.set_ylabel("count")
+            ax.legend(fontsize=7, loc="upper left")
+            ax.set_title("Queue Depth", fontsize=9)
+
+        # Row 3: CoDel dropping state + drop count
+        ax = axes[3][col_idx]
+        dropping = stats_df["dropping"].values.astype(float)
+        max_count = stats_df["drop_count"].max() if stats_df["drop_count"].max() > 0 else 1
+        ax.fill_between(t, 0, dropping * max_count, alpha=0.15, color="red", label="dropping state")
+        ax.plot(t, stats_df["drop_count"].values, color="purple", linewidth=1, label="CoDel count")
+        ax.set_xlim(0, xlim)
+        ax.grid(True, alpha=0.3)
+        ax.ticklabel_format(useOffset=False, style='plain', axis='y')
+        if col_idx == 0:
+            ax.set_ylabel("count")
+            ax.legend(fontsize=7, loc="upper left")
+            ax.set_title("CoDel State (shaded = dropping)", fontsize=9)
+
+        # Row 4: Current interval (log scale)
+        ax = axes[4][col_idx]
+        interval_ms = stats_df["current_interval_ns"].values / 1_000_000
+        ax.plot(t, interval_ms, color="darkblue", linewidth=1)
+        ax.set_yscale("log")
+        ax.set_xlim(0, xlim)
+        ax.grid(True, alpha=0.3)
+        ax.axhline(y=100, color="grey", linestyle="--", linewidth=0.7, alpha=0.5)
+        if col_idx == 0:
+            ax.set_ylabel("interval (ms)")
+            ax.set_title("CoDel Current Interval (log)", fontsize=9)
+
+        # Row 5: Cumulative unfilled slots
+        ax = axes[5][col_idx]
+        capacity = 10
+        holders = stats_df["holder_count"].values
+        unfilled = np.maximum(capacity - holders, 0)
+        cumulative_unfilled = np.cumsum(unfilled)
+        ax.plot(t, cumulative_unfilled, color="darkorange", linewidth=1.2)
+        ax.fill_between(t, cumulative_unfilled, alpha=0.15, color="orange")
+        ax.set_xlim(0, xlim)
+        ax.set_ylim(0, 2000)
+        ax.grid(True, alpha=0.3)
+        ax.ticklabel_format(useOffset=False, style='plain', axis='y')
+        if col_idx == 0:
+            ax.set_ylabel("cumulative slots")
+            ax.set_title("Cumulative Unfilled Slots", fontsize=9)
+
+    # Row 6: Request latency (p50, p95, p99)
+    ax = axes[6][col_idx]
+    t_lat, p50, p95, p99 = compute_latency_percentiles(df, bin_ms, max_ts)
+    if t_lat is not None:
+        ax.plot(t_lat, p50, color="green", linewidth=1, label="p50")
+        ax.plot(t_lat, p95, color="orange", linewidth=1, label="p95")
+        ax.plot(t_lat, p99, color="red", linewidth=1, label="p99")
+    ax.set_xlim(0, xlim)
+    ax.set_ylim(bottom=0)
+    ax.grid(True, alpha=0.3)
+    ax.ticklabel_format(useOffset=False, style='plain', axis='y')
+    if col_idx == 0:
+        ax.set_ylabel("ms")
+        ax.legend(fontsize=7, loc="upper left")
+        ax.set_title("Request Latency (granted only)", fontsize=9)
+
+# X labels on bottom row
+for col_idx in range(NUM_COLS):
+    axes[NUM_ROWS - 1][col_idx].set_xlabel("time (s)")
+
+plt.tight_layout(rect=[0, 0, 1, 0.96])
+date_prefix = datetime.now().strftime("%Y-%m-%d")
+out_path = str(BASE / f"{date_prefix}_easing_divisor_comparison.png")
+plt.savefig(out_path, dpi=150, bbox_inches="tight")
+plt.close()
+print(f"Saved: {out_path}")

--- a/go/vt/vttablet/tabletserver/loadshed/benchmark/plot_easing_comparison.py
+++ b/go/vt/vttablet/tabletserver/loadshed/benchmark/plot_easing_comparison.py
@@ -212,8 +212,8 @@ for col_idx in range(NUM_COLS):
     axes[NUM_ROWS - 1][col_idx].set_xlabel("time (s)")
 
 plt.tight_layout(rect=[0, 0, 1, 0.96])
-date_prefix = datetime.now().strftime("%Y-%m-%d")
-out_path = str(BASE / f"{date_prefix}_easing_divisor_comparison.png")
+timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+out_path = str(BASE / f"{timestamp}_easing_divisor_comparison.png")
 plt.savefig(out_path, dpi=150, bbox_inches="tight")
 plt.close()
 print(f"Saved: {out_path}")

--- a/go/vt/vttablet/tabletserver/loadshed/benchmark/plot_linear_ramp.py
+++ b/go/vt/vttablet/tabletserver/loadshed/benchmark/plot_linear_ramp.py
@@ -2,11 +2,14 @@
 """Plot linear ramp test results from snake-22 with Stats() data (7 rows).
 
 Usage:
-    python plot_linear_ramp.py [TSV_DIR]
+    python plot_linear_ramp.py [--capacity N] [--work-ms N] [--target-ms N]
+                               [--interval-ms N] [--exponent F] [--peak-mult N]
+                               [TSV_DIR]
 
 TSV_DIR defaults to the most recent run under ~/snake-load-test-charts/tsv/.
 """
 
+import argparse
 import sys
 import pandas as pd
 import matplotlib.pyplot as plt
@@ -30,8 +33,18 @@ def find_latest_run():
                 return r
     return None
 
-if len(sys.argv) > 1:
-    RUN_DIR = sys.argv[1]
+parser = argparse.ArgumentParser(description="Plot Snake linear ramp benchmark results")
+parser.add_argument("tsv_dir", nargs="?", default=None, help="TSV directory (default: most recent run)")
+parser.add_argument("--capacity", type=int, default=10, help="Semaphore capacity used in the run (default: 10)")
+parser.add_argument("--work-ms", type=int, default=2, help="Work duration per request in ms (default: 2)")
+parser.add_argument("--target-ms", type=int, default=5, help="CoDel target in ms (default: 5)")
+parser.add_argument("--interval-ms", type=int, default=100, help="CoDel interval in ms (default: 100)")
+parser.add_argument("--exponent", type=float, default=1.0, help="CoDel exponent (default: 1.0)")
+parser.add_argument("--peak-mult", type=int, default=80, help="Peak arrival rate multiplier (default: 80)")
+args = parser.parse_args()
+
+if args.tsv_dir:
+    RUN_DIR = args.tsv_dir
 else:
     latest = find_latest_run()
     if latest is None:
@@ -43,13 +56,12 @@ KEY = "linear_ramp__0_to_80x_cap__work_half_target"
 DUR_MS = 20000
 NUM_ROWS = 7
 
-# Config embedded for chart verification
-CAPACITY = 10
-WORK_MS = 2
-TARGET_MS = 5
-INTERVAL_MS = 100
-EXPONENT = 1.0
-PEAK_MULT = 80
+CAPACITY = args.capacity
+WORK_MS = args.work_ms
+TARGET_MS = args.target_ms
+INTERVAL_MS = args.interval_ms
+EXPONENT = args.exponent
+PEAK_MULT = args.peak_mult
 
 
 def compute_hz_series(df, event_type, bin_ms, max_ts):

--- a/go/vt/vttablet/tabletserver/loadshed/benchmark/plot_linear_ramp.py
+++ b/go/vt/vttablet/tabletserver/loadshed/benchmark/plot_linear_ramp.py
@@ -48,7 +48,7 @@ CAPACITY = 10
 WORK_MS = 2
 TARGET_MS = 5
 INTERVAL_MS = 100
-EXPONENT = 0.5
+EXPONENT = 1.0
 PEAK_MULT = 80
 
 
@@ -229,8 +229,8 @@ ax.legend(fontsize=7, loc="upper left")
 
 plt.tight_layout(rect=[0, 0, 1, 0.97])
 
-date_prefix = datetime.now().strftime("%Y-%m-%d")
-out_path = str(BASE / f"{date_prefix}_snake22_linear_ramp.png")
+timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+out_path = str(BASE / f"{timestamp}_snake22_linear_ramp.png")
 plt.savefig(out_path, dpi=150, bbox_inches="tight")
 plt.close()
 print(f"Saved: {out_path}")

--- a/go/vt/vttablet/tabletserver/loadshed/benchmark/plot_linear_ramp.py
+++ b/go/vt/vttablet/tabletserver/loadshed/benchmark/plot_linear_ramp.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Plot linear ramp test results from snake-22 with Stats() data (7 rows).
+
+Usage:
+    python plot_linear_ramp.py [TSV_DIR]
+
+TSV_DIR defaults to the most recent run under ~/snake-load-test-charts/tsv/.
+"""
+
+import sys
+import pandas as pd
+import matplotlib.pyplot as plt
+import matplotlib.ticker as mticker
+import numpy as np
+from pathlib import Path
+from datetime import datetime
+
+BASE = Path.home() / "snake-load-test-charts"
+TSV_BASE = BASE / "tsv"
+
+def find_latest_run():
+    """Find the most recent timestamped run dir under tsv/<date>/."""
+    date_dirs = sorted(TSV_BASE.iterdir(), reverse=True)
+    for d in date_dirs:
+        if not d.is_dir() or d.name == "easing-comparison":
+            continue
+        runs = sorted(d.iterdir(), reverse=True)
+        for r in runs:
+            if r.is_dir():
+                return r
+    return None
+
+if len(sys.argv) > 1:
+    RUN_DIR = sys.argv[1]
+else:
+    latest = find_latest_run()
+    if latest is None:
+        print("ERROR: no run dirs found under", TSV_BASE)
+        sys.exit(1)
+    RUN_DIR = str(latest)
+
+KEY = "linear_ramp__0_to_80x_cap__work_half_target"
+DUR_MS = 20000
+NUM_ROWS = 7
+
+# Config embedded for chart verification
+CAPACITY = 10
+WORK_MS = 2
+TARGET_MS = 5
+INTERVAL_MS = 100
+EXPONENT = 0.5
+PEAK_MULT = 80
+
+
+def compute_hz_series(df, event_type, bin_ms, max_ts):
+    subset = df[df["event"] == event_type]["ts_ms"].values
+    bins = np.arange(0, max_ts + bin_ms, bin_ms)
+    if len(subset) == 0:
+        centers = (bins[:-1] + bins[1:]) / 2 / 1000
+        return centers, np.zeros(len(centers))
+    counts, edges = np.histogram(subset, bins=bins)
+    centers = (edges[:-1] + edges[1:]) / 2 / 1000
+    hz = counts / (bin_ms / 1000)
+    return centers, hz
+
+
+def compute_latency_percentiles(df, bin_ms, max_ts):
+    granted = df[df["event"] == "granted"].copy()
+    if len(granted) == 0 or "latency_ms" not in granted.columns:
+        return None, None, None, None
+    granted = granted.dropna(subset=["latency_ms"])
+    granted["latency_ms"] = pd.to_numeric(granted["latency_ms"], errors="coerce")
+    granted = granted.dropna(subset=["latency_ms"])
+    if len(granted) == 0:
+        return None, None, None, None
+
+    bins = np.arange(0, max_ts + bin_ms, bin_ms)
+    centers = (bins[:-1] + bins[1:]) / 2 / 1000
+    granted["bin"] = pd.cut(granted["ts_ms"], bins=bins, labels=False)
+
+    p50 = np.full(len(centers), np.nan)
+    p95 = np.full(len(centers), np.nan)
+    p99 = np.full(len(centers), np.nan)
+
+    for i, grp in granted.groupby("bin")["latency_ms"]:
+        if len(grp) >= 3:
+            idx = int(i)
+            if 0 <= idx < len(centers):
+                p50[idx] = grp.quantile(0.5)
+                p95[idx] = grp.quantile(0.95)
+                p99[idx] = grp.quantile(0.99)
+
+    return centers, p50, p95, p99
+
+
+tsv_dir = Path(RUN_DIR)
+events_file = tsv_dir / f"{KEY}.tsv"
+stats_file = tsv_dir / f"{KEY}_stats.tsv"
+
+if not events_file.exists():
+    print(f"ERROR: {events_file} not found")
+    sys.exit(1)
+
+df = pd.read_csv(events_file, sep="\t")
+max_ts = min(df["ts_ms"].max(), DUR_MS + 500)
+bin_ms = max(5, int(max_ts / 150))
+
+t_issued, hz_issued = compute_hz_series(df, "issued", bin_ms, max_ts)
+t_granted, hz_granted = compute_hz_series(df, "granted", bin_ms, max_ts)
+t_shed, hz_shed = compute_hz_series(df, "shed", bin_ms, max_ts)
+
+xlim = DUR_MS / 1000 * 1.02
+
+total_issued = len(df[df["event"] == "issued"])
+total_shed = len(df[df["event"] == "shed"])
+shed_pct = total_shed / total_issued * 100 if total_issued > 0 else 0
+
+fig, axes = plt.subplots(NUM_ROWS, 1, figsize=(12, 24), squeeze=True)
+fig.suptitle(
+    f"Snake (bwines/snake-22) — Linear Ramp 0→{PEAK_MULT}× capacity\n"
+    f"capacity={CAPACITY}, work={WORK_MS}ms, target={TARGET_MS}ms, "
+    f"interval={INTERVAL_MS}ms, exponent={EXPONENT} (no easing)",
+    fontsize=12, y=0.995,
+)
+
+# Row 0: Grant rate
+ax = axes[0]
+ax.plot(t_granted, hz_granted, color="green", linewidth=1.3)
+ax.fill_between(t_granted, hz_granted, alpha=0.15, color="green")
+ax.set_xlim(0, xlim)
+ax.set_ylabel("Hz")
+ax.set_title("Grant Rate", fontsize=10, fontweight="bold")
+ax.yaxis.set_major_locator(mticker.MaxNLocator(5))
+ax.grid(True, alpha=0.3)
+ax.ticklabel_format(useOffset=False, style='plain', axis='y')
+
+# Row 1: Issued / Granted / Shed Hz
+ax = axes[1]
+ax.fill_between(t_issued, hz_issued, alpha=0.12, color="grey")
+ax.plot(t_issued, hz_issued, color="grey", linewidth=0.8, label="issued")
+ax.plot(t_granted, hz_granted, color="green", linewidth=1.3, label="granted")
+ax.plot(t_shed, hz_shed, color="red", linewidth=1, label="shed")
+ax.text(0.97, 0.95, f"shed: {shed_pct:.1f}%",
+        transform=ax.transAxes, ha="right", va="top", fontsize=9,
+        bbox=dict(boxstyle="round,pad=0.2", facecolor="white", alpha=0.8))
+ax.set_xlim(0, xlim)
+ax.set_ylabel("Hz")
+ax.set_title("Issued / Granted / Shed", fontsize=10, fontweight="bold")
+ax.yaxis.set_major_locator(mticker.MaxNLocator(5))
+ax.grid(True, alpha=0.3)
+ax.ticklabel_format(useOffset=False, style='plain', axis='y')
+ax.legend(loc="upper left", fontsize=8)
+
+# Stats panels (rows 2-5)
+has_stats = stats_file.exists()
+if has_stats:
+    stats_df = pd.read_csv(stats_file, sep="\t")
+    stats_df = stats_df[stats_df["ts_ms"] <= DUR_MS]
+    t = stats_df["ts_ms"].values / 1000
+
+    # Row 2: Queue depth
+    ax = axes[2]
+    ax.plot(t, stats_df["queue_len"].values, color="blue", linewidth=1, label="queue total")
+    ax.plot(t, stats_df["droppable_len"].values, color="orange", linewidth=1, label="droppable")
+    ax.plot(t, stats_df["holder_count"].values, color="green", linewidth=1, label="holders")
+    ax.set_xlim(0, xlim)
+    ax.set_ylabel("count")
+    ax.set_title("Queue Depth", fontsize=10, fontweight="bold")
+    ax.grid(True, alpha=0.3)
+    ax.ticklabel_format(useOffset=False, style='plain', axis='y')
+    ax.legend(fontsize=7, loc="upper left")
+
+    # Row 3: CoDel dropping state + drop count
+    ax = axes[3]
+    dropping = stats_df["dropping"].values.astype(float)
+    max_count = stats_df["drop_count"].max() if stats_df["drop_count"].max() > 0 else 1
+    ax.fill_between(t, 0, dropping * max_count, alpha=0.15, color="red", label="dropping state")
+    ax.plot(t, stats_df["drop_count"].values, color="purple", linewidth=1, label="CoDel count")
+    ax.set_xlim(0, xlim)
+    ax.set_ylabel("count")
+    ax.set_title("CoDel State (shaded = dropping)", fontsize=10, fontweight="bold")
+    ax.grid(True, alpha=0.3)
+    ax.ticklabel_format(useOffset=False, style='plain', axis='y')
+    ax.legend(fontsize=7, loc="upper left")
+
+    # Row 4: Current interval (log scale)
+    ax = axes[4]
+    interval_ms = stats_df["current_interval_ns"].values / 1_000_000
+    ax.plot(t, interval_ms, color="darkblue", linewidth=1)
+    ax.set_yscale("log")
+    ax.set_xlim(0, xlim)
+    ax.set_ylabel("interval (ms)")
+    ax.set_title("CoDel Current Interval (log)", fontsize=10, fontweight="bold")
+    ax.grid(True, alpha=0.3)
+    ax.axhline(y=INTERVAL_MS, color="grey", linestyle="--", linewidth=0.7, alpha=0.5)
+
+    # Row 5: Cumulative unfilled slots
+    ax = axes[5]
+    holders = stats_df["holder_count"].values
+    unfilled = np.maximum(CAPACITY - holders, 0)
+    cumulative_unfilled = np.cumsum(unfilled)
+    ax.plot(t, cumulative_unfilled, color="darkorange", linewidth=1.2)
+    ax.fill_between(t, cumulative_unfilled, alpha=0.15, color="orange")
+    ax.set_xlim(0, xlim)
+    ax.set_ylabel("cumulative slots")
+    ax.set_title("Cumulative Unfilled Slots", fontsize=10, fontweight="bold")
+    ax.grid(True, alpha=0.3)
+    ax.ticklabel_format(useOffset=False, style='plain', axis='y')
+else:
+    for row in range(2, 6):
+        axes[row].text(0.5, 0.5, "no stats data", transform=axes[row].transAxes, ha="center", fontsize=12)
+        axes[row].set_xlim(0, xlim)
+
+# Row 6: Request latency (p50, p95, p99)
+ax = axes[6]
+t_lat, p50, p95, p99 = compute_latency_percentiles(df, bin_ms, max_ts)
+if t_lat is not None:
+    ax.plot(t_lat, p50, color="green", linewidth=1, label="p50")
+    ax.plot(t_lat, p95, color="orange", linewidth=1, label="p95")
+    ax.plot(t_lat, p99, color="red", linewidth=1, label="p99")
+ax.set_xlim(0, xlim)
+ax.set_ylim(bottom=0)
+ax.set_ylabel("ms")
+ax.set_xlabel("time (s)")
+ax.set_title("Request Latency (granted only)", fontsize=10, fontweight="bold")
+ax.grid(True, alpha=0.3)
+ax.ticklabel_format(useOffset=False, style='plain', axis='y')
+ax.legend(fontsize=7, loc="upper left")
+
+plt.tight_layout(rect=[0, 0, 1, 0.97])
+
+date_prefix = datetime.now().strftime("%Y-%m-%d")
+out_path = str(BASE / f"{date_prefix}_snake22_linear_ramp.png")
+plt.savefig(out_path, dpi=150, bbox_inches="tight")
+plt.close()
+print(f"Saved: {out_path}")


### PR DESCRIPTION
### Background / Why?

We need a repeatable way to exercise Snake under controlled load profiles and visualize the results. This adds a standalone Go bench harness and two Python plotting scripts under `loadshed/benchmark/`. The harness polls `Stats()` every 10ms during a linear ramp, producing TSV output to `~/snake-load-test-charts/tsv/<date>/<timestamp>/`. The plotting scripts consume those TSVs and produce date-prefixed PNGs.

### Testing

Ran the bench suite locally and confirmed TSV output lands in the expected directory structure. Both plotting scripts produce correct 7-row charts from the TSV data.

AI disclosure: Claude Code assisted with development. Every line of code was either written by or carefully reviewed by me :)