### PR TITLE
Remove 100-iteration safety cap from CoDel drop loop

### DIFF
--- a/go/vt/vttablet/tabletserver/loadshed/codelq.go
+++ b/go/vt/vttablet/tabletserver/loadshed/codelq.go
@@ -316,12 +316,7 @@ func (q *CoDelQueue) lockedRunScheduledDrop(dropFn func() bool) {
 		q.lockedEnterDroppingState()
 	}
 
-	loopCount := 0
 	for q.droppableLen > 0 && now >= q.dropNextNs {
-		loopCount++
-		if loopCount > 100 {
-			break
-		}
 		// Safe to break: the mutex serializes cancellation with the drop
 		// timer, so droppableLen > 0 reliably means the scan will find
 		// something. This can only fail on a bookkeeping bug.


### PR DESCRIPTION
### Background / Why?

The CoDel drop loop had a 100-iteration safety cap to prevent CPU burn if the timer fired late (e.g. after a GC pause pushed `now` far past many `dropNextNs` checkpoints). In practice, this cap prevented the system from catching up under sustained overload — if more than 100 drops were overdue, the remainder waited for the next timer fire. The result was the queue couldn't drain fast enough, keeping the system in a perpetual dropping state rather than shedding decisively and recovering.

Without the cap, the loop drains all overdue drops in one pass. Benchmarks show this produces a healthy oscillation: shed burst → droppableLen hits 0 → exit dropping → new arrivals refill → re-enter dropping. The original CPU burn concern is mitigated by each iteration doing O(n) work in `findLowestPriorityDroppable` which bounds the realistic iteration count, and the queue length itself is bounded by arrival rate × interval.

### Testing

Ran the bench suite (`go run bench_suite.go`) with and without this change at 80x capacity overload. The sawtooth pattern (decisive shedding + recovery) is produced solely by removing the cap — confirmed by isolating it from the control law floor change.

AI disclosure: Claude Code assisted with development. Every line of code was either written by or carefully reviewed by me :)