### PR TITLE
Lower CoDel control law interval floor from 100ns to 1ns

### DIFF
--- a/go/vt/vttablet/tabletserver/loadshed/codelq.go
+++ b/go/vt/vttablet/tabletserver/loadshed/codelq.go
@@ -375,8 +375,8 @@ func (q *CoDelQueue) lockedCurrentInterval() int64 {
 	}
 	exp := q.cfg.Exponent()
 	result := int64(float64(interval) / math.Pow(float64(q.count), exp))
-	// Floor to avoid extreme cases and floating point precision issues.
-	return max(result, 100)
+	// Floor of 1ns ensures lockedControlLaw always makes forward progress.
+	return max(result, 1)
 }
 
 func (q *CoDelQueue) lockedArmDropTimer() {


### PR DESCRIPTION
### Background / Why?

The control law floor (`max(result, 100)`) was arbitrarily set to 100ns as a guard against floating point precision issues. Since the interval is `int64` nanoseconds, there's no precision concern — a floor of 1ns is sufficient to ensure `lockedControlLaw` always makes forward progress (i.e. `dropNextNs` always advances).

The practical effect is negligible in isolation (at 80x overload both 100ns and 1ns produce the same behavior), but it removes an unnecessary artificial constraint on how tightly the control law can schedule drops.

### Testing

Ran the bench suite at 80x overload with this change alone (loop cap still at 100). Behavior is indistinguishable from baseline, confirming this is a correctness cleanup rather than a behavioral change at current overload levels.

AI disclosure: Claude Code assisted with development. Every line of code was either written by or carefully reviewed by me :)