### PR TITLE
Add global soft memory limit on query consolidator responses

### DIFF
--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -48,6 +48,7 @@ Flags:
       --config-persistence-min-interval duration                         minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                               Config file type (omit to infer config type from file extension).
       --consolidator-cache-proto3-rows                                   If true, the consolidation leader pre-caches proto3-encoded rows so that waiters avoid redundant encoding work.
+      --consolidator-query-total-size int                                Soft global limit, in bytes, on in-flight consolidated (non-streaming) query responses being serialized. 0 = unlimited.
       --consolidator-query-waiter-cap int                                Configure the maximum number of clients allowed to wait on the consolidator.
       --consolidator-stream-query-size int                               Configure the stream consolidator query size in bytes. Setting to 0 disables the stream consolidator. (default 2097152)
       --consolidator-stream-total-size int                               Configure the stream consolidator total size in bytes. Setting to 0 disables the stream consolidator. (default 134217728)

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -81,6 +81,7 @@ Flags:
       --config-persistence-min-interval duration                         minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                               Config file type (omit to infer config type from file extension).
       --consolidator-cache-proto3-rows                                   If true, the consolidation leader pre-caches proto3-encoded rows so that waiters avoid redundant encoding work.
+      --consolidator-query-total-size int                                Soft global limit, in bytes, on in-flight consolidated (non-streaming) query responses being serialized. 0 = unlimited.
       --consolidator-query-waiter-cap int                                Configure the maximum number of clients allowed to wait on the consolidator.
       --consolidator-stream-query-size int                               Configure the stream consolidator query size in bytes. Setting to 0 disables the stream consolidator. (default 2097152)
       --consolidator-stream-total-size int                               Configure the stream consolidator total size in bytes. Setting to 0 disables the stream consolidator. (default 134217728)

--- a/go/sqltypes/result.go
+++ b/go/sqltypes/result.go
@@ -43,6 +43,11 @@ type Result struct {
 	// query consolidation). Not populated for the non-consolidation flow;
 	// don't depend on it being present.
 	proto3Rows []*querypb.Row
+
+	// fromConsolidator marks a Result that was produced by the query
+	// consolidator and shared across multiple waiting requests. It is used to
+	// gate response serialization under a global memory budget. Not serialized.
+	fromConsolidator bool
 }
 
 //goland:noinspection GoUnusedConst
@@ -143,6 +148,44 @@ func (result *Result) ShallowCopy() *Result {
 		Rows:                result.Rows,
 		// proto3Rows is intentionally not propagated: callers may modify Rows
 	}
+}
+
+// FromConsolidator reports whether this Result was produced by the query
+// consolidator and shared across multiple waiting requests.
+func (result *Result) FromConsolidator() bool {
+	return result != nil && result.fromConsolidator
+}
+
+// SetFromConsolidator marks this Result as produced by the query consolidator.
+func (result *Result) SetFromConsolidator() {
+	result.fromConsolidator = true
+}
+
+// HasProto3Rows reports whether the proto3-encoded rows have already been cached
+// on this Result (see CacheProto3Rows). When cached, serializing the result
+// reuses the shared encoding instead of copying the rows per consumer.
+func (result *Result) HasProto3Rows() bool {
+	return len(result.proto3Rows) > 0
+}
+
+// ResponseBytesEstimate returns an approximate byte size of the row payload that
+// will be copied when this Result is serialized to proto3. It sums the raw value
+// lengths across Rows (the bytes RowToProto3Inplace copies) plus a small constant
+// per value for proto framing. It intentionally excludes the cached proto3Rows
+// (which is shared, not per-consumer). It is meant as a cheap pre-serialization
+// estimate, not an exact wire size.
+func (result *Result) ResponseBytesEstimate() int64 {
+	if result == nil {
+		return 0
+	}
+	var size int64
+	for _, row := range result.Rows {
+		for _, v := range row {
+			// +1 approximates the per-value length prefix in the proto encoding.
+			size += int64(v.Len()) + 1
+		}
+	}
+	return size
 }
 
 func (result *Result) CacheProto3Rows() {

--- a/go/sqltypes/result_test.go
+++ b/go/sqltypes/result_test.go
@@ -506,3 +506,58 @@ func TestIncludeFieldsOrDefault(t *testing.T) {
 	r = IncludeFieldsOrDefault(&querypb.ExecuteOptions{IncludedFields: querypb.ExecuteOptions_TYPE_ONLY})
 	assert.Equal(t, querypb.ExecuteOptions_TYPE_ONLY, r)
 }
+
+func TestFromConsolidatorFlag(t *testing.T) {
+	r := &Result{
+		Fields: []*querypb.Field{{Name: "col1", Type: querypb.Type_VARCHAR}},
+		Rows:   [][]Value{{TestValue(querypb.Type_VARCHAR, "a")}},
+	}
+	assert.False(t, r.FromConsolidator())
+
+	r.SetFromConsolidator()
+	assert.True(t, r.FromConsolidator())
+
+	// StripMetadata copies the struct (r := *result), so the flag must survive.
+	stripped := r.StripMetadata(querypb.ExecuteOptions_TYPE_AND_NAME)
+	assert.True(t, stripped.FromConsolidator())
+
+	// The flag is internal and must not leak into the serialized proto3 form.
+	p3 := ResultToProto3(r)
+	assert.Equal(t, len(r.Rows), len(p3.Rows))
+}
+
+func TestHasProto3Rows(t *testing.T) {
+	r := &Result{
+		Fields: []*querypb.Field{{Name: "col1", Type: querypb.Type_VARCHAR}},
+		Rows:   [][]Value{{TestValue(querypb.Type_VARCHAR, "a")}},
+	}
+	assert.False(t, r.HasProto3Rows())
+
+	r.CacheProto3Rows()
+	assert.True(t, r.HasProto3Rows())
+
+	// An empty result never caches proto3 rows.
+	empty := &Result{}
+	empty.CacheProto3Rows()
+	assert.False(t, empty.HasProto3Rows())
+}
+
+func TestResponseBytesEstimate(t *testing.T) {
+	empty := &Result{}
+	assert.Zero(t, empty.ResponseBytesEstimate())
+
+	small := &Result{
+		Rows: [][]Value{{TestValue(querypb.Type_VARCHAR, "ab")}},
+	}
+	large := &Result{
+		Rows: [][]Value{{TestValue(querypb.Type_VARCHAR, "abcdefghij")}},
+	}
+	assert.Greater(t, small.ResponseBytesEstimate(), int64(0))
+	assert.Greater(t, large.ResponseBytesEstimate(), small.ResponseBytesEstimate())
+
+	// Caching proto3 rows must not change the estimate: it measures the row
+	// payload, not the shared cached encoding.
+	before := large.ResponseBytesEstimate()
+	large.CacheProto3Rows()
+	assert.Equal(t, before, large.ResponseBytesEstimate())
+}

--- a/go/vt/vttablet/grpcqueryservice/server.go
+++ b/go/vt/vttablet/grpcqueryservice/server.go
@@ -72,7 +72,15 @@ func (q *query) Execute(ctx context.Context, request *querypb.ExecuteRequest) (r
 				weight *= 2
 			}
 			release := limiter.AcquireConsolidatedResponseMemory(ctx, weight)
-			context.AfterFunc(ctx, release)
+			if ctx.Done() == nil {
+				// A non-cancelable context would never trigger context.AfterFunc,
+				// leaking the reservation forever. Release when the handler returns
+				// instead; that is slightly early (before the marshal completes) but
+				// never leaks, which is the right tradeoff for a soft limit.
+				defer release()
+			} else {
+				context.AfterFunc(ctx, release)
+			}
 		}
 	}
 	return &querypb.ExecuteResponse{

--- a/go/vt/vttablet/grpcqueryservice/server.go
+++ b/go/vt/vttablet/grpcqueryservice/server.go
@@ -41,6 +41,14 @@ type query struct {
 
 var _ queryservicepb.QueryServer = (*query)(nil)
 
+// consolidatedResponseLimiter is optionally implemented by the underlying query
+// service to pace serialization of consolidated query responses under a global
+// soft memory budget. Implementations that don't provide it (fakes, sandboxconn)
+// simply skip the gate.
+type consolidatedResponseLimiter interface {
+	AcquireConsolidatedResponseMemory(ctx context.Context, size int64) func()
+}
+
 // Execute is part of the queryservice.QueryServer interface
 func (q *query) Execute(ctx context.Context, request *querypb.ExecuteRequest) (response *querypb.ExecuteResponse, err error) {
 	defer q.server.HandlePanic(&err)
@@ -51,6 +59,21 @@ func (q *query) Execute(ctx context.Context, request *querypb.ExecuteRequest) (r
 	result, err := q.server.Execute(ctx, nil, request.Target, request.Query.Sql, request.Query.BindVariables, request.TransactionId, request.ReservedId, request.Options)
 	if err != nil {
 		return nil, vterrors.ToGRPC(err)
+	}
+	// Pace the simultaneous fan-out of consolidated responses under the global
+	// soft memory budget. Reserve before building the proto so the per-waiter copy
+	// is also covered: 2x the data when proto3 rows aren't cached (proto copy plus
+	// wire buffer), 1x when they are. The budget is released once the RPC context
+	// is cancelled, which gRPC does right after the response is sent.
+	if result.FromConsolidator() {
+		if limiter, ok := q.server.(consolidatedResponseLimiter); ok {
+			weight := result.ResponseBytesEstimate()
+			if !result.HasProto3Rows() {
+				weight *= 2
+			}
+			release := limiter.AcquireConsolidatedResponseMemory(ctx, weight)
+			context.AfterFunc(ctx, release)
+		}
 	}
 	return &querypb.ExecuteResponse{
 		Result: sqltypes.ResultToProto3(result),

--- a/go/vt/vttablet/grpcqueryservice/server_test.go
+++ b/go/vt/vttablet/grpcqueryservice/server_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpcqueryservice
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/vttablet/queryservice"
+
+	querypb "vitess.io/vitess/go/vt/proto/query"
+)
+
+// limiterFakeQueryService is a QueryService that returns a fixed result and
+// records consolidated-response memory acquisitions/releases so we can assert
+// the gRPC handler wiring.
+type limiterFakeQueryService struct {
+	queryservice.QueryService
+	result   *sqltypes.Result
+	acquired atomic.Int64 // bytes requested via AcquireConsolidatedResponseMemory
+	released atomic.Bool  // release func was invoked
+	lastSize atomic.Int64
+}
+
+func (f *limiterFakeQueryService) Execute(ctx context.Context, session queryservice.Session, target *querypb.Target, sql string, bindVariables map[string]*querypb.BindVariable, transactionID, reservedID int64, options *querypb.ExecuteOptions) (*sqltypes.Result, error) {
+	return f.result, nil
+}
+
+func (f *limiterFakeQueryService) HandlePanic(err *error) {}
+
+func (f *limiterFakeQueryService) AcquireConsolidatedResponseMemory(ctx context.Context, size int64) func() {
+	f.acquired.Add(1)
+	f.lastSize.Store(size)
+	return func() { f.released.Store(true) }
+}
+
+var _ consolidatedResponseLimiter = (*limiterFakeQueryService)(nil)
+
+func newConsolidatedResult() *sqltypes.Result {
+	r := &sqltypes.Result{
+		Fields: []*querypb.Field{{Name: "col", Type: querypb.Type_VARCHAR}},
+		Rows:   [][]sqltypes.Value{{sqltypes.NewVarChar("value")}},
+	}
+	r.SetFromConsolidator()
+	return r
+}
+
+func TestExecuteConsolidatedResponseAcquiresAndReleasesOnCtxDone(t *testing.T) {
+	result := newConsolidatedResult()
+	fake := &limiterFakeQueryService{result: result}
+	q := &query{server: fake}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	resp, err := q.Execute(ctx, &querypb.ExecuteRequest{Query: &querypb.BoundQuery{Sql: "select 1"}})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Proto3 rows are not cached, so each waiter allocates both the proto copy
+	// and the wire buffer: the reserved weight is 2x the row-byte estimate.
+	assert.Equal(t, int64(1), fake.acquired.Load())
+	assert.Equal(t, 2*result.ResponseBytesEstimate(), fake.lastSize.Load())
+
+	// Budget is still held until the RPC context is done.
+	assert.False(t, fake.released.Load(), "budget released before ctx done")
+
+	// Cancelling the RPC context (gRPC does this right after the response is
+	// sent) fires the AfterFunc release.
+	cancel()
+	assert.Eventually(t, func() bool {
+		return fake.released.Load()
+	}, 30*time.Second, time.Millisecond)
+}
+
+func TestExecuteConsolidatedResponseCachedProto3RowsWeight(t *testing.T) {
+	// When proto3 rows are cached, the per-waiter copy is eliminated, so the
+	// reserved weight is 1x the row-byte estimate (only the wire buffer).
+	result := newConsolidatedResult()
+	result.CacheProto3Rows()
+	fake := &limiterFakeQueryService{result: result}
+	q := &query{server: fake}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp, err := q.Execute(ctx, &querypb.ExecuteRequest{Query: &querypb.BoundQuery{Sql: "select 1"}})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	assert.Equal(t, int64(1), fake.acquired.Load())
+	assert.Equal(t, result.ResponseBytesEstimate(), fake.lastSize.Load())
+}
+
+func TestExecuteNonConsolidatedResponseSkipsBudget(t *testing.T) {
+	// A result not flagged by the consolidator must never touch the budget.
+	result := &sqltypes.Result{
+		Fields: []*querypb.Field{{Name: "col", Type: querypb.Type_VARCHAR}},
+		Rows:   [][]sqltypes.Value{{sqltypes.NewVarChar("value")}},
+	}
+	fake := &limiterFakeQueryService{result: result}
+	q := &query{server: fake}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp, err := q.Execute(ctx, &querypb.ExecuteRequest{Query: &querypb.BoundQuery{Sql: "select 1"}})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	assert.Equal(t, int64(0), fake.acquired.Load(), "non-consolidated response must not acquire budget")
+}

--- a/go/vt/vttablet/grpcqueryservice/server_test.go
+++ b/go/vt/vttablet/grpcqueryservice/server_test.go
@@ -70,7 +70,7 @@ func TestExecuteConsolidatedResponseAcquiresAndReleasesOnCtxDone(t *testing.T) {
 	fake := &limiterFakeQueryService{result: result}
 	q := &query{server: fake}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	resp, err := q.Execute(ctx, &querypb.ExecuteRequest{Query: &querypb.BoundQuery{Sql: "select 1"}})
 	require.NoError(t, err)
 	require.NotNil(t, resp)
@@ -99,9 +99,7 @@ func TestExecuteConsolidatedResponseCachedProto3RowsWeight(t *testing.T) {
 	fake := &limiterFakeQueryService{result: result}
 	q := &query{server: fake}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	resp, err := q.Execute(ctx, &querypb.ExecuteRequest{Query: &querypb.BoundQuery{Sql: "select 1"}})
+	resp, err := q.Execute(t.Context(), &querypb.ExecuteRequest{Query: &querypb.BoundQuery{Sql: "select 1"}})
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
@@ -118,9 +116,7 @@ func TestExecuteNonConsolidatedResponseSkipsBudget(t *testing.T) {
 	fake := &limiterFakeQueryService{result: result}
 	q := &query{server: fake}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	resp, err := q.Execute(ctx, &querypb.ExecuteRequest{Query: &querypb.BoundQuery{Sql: "select 1"}})
+	resp, err := q.Execute(t.Context(), &querypb.ExecuteRequest{Query: &querypb.BoundQuery{Sql: "select 1"}})
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 

--- a/go/vt/vttablet/grpcqueryservice/server_test.go
+++ b/go/vt/vttablet/grpcqueryservice/server_test.go
@@ -18,6 +18,7 @@ package grpcqueryservice
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -33,13 +34,15 @@ import (
 
 // limiterFakeQueryService is a QueryService that returns a fixed result and
 // records consolidated-response memory acquisitions/releases so we can assert
-// the gRPC handler wiring.
+// the gRPC handler wiring. inUse tracks net reserved bytes (acquired minus
+// released) so a leak shows up as a non-zero balance.
 type limiterFakeQueryService struct {
 	queryservice.QueryService
 	result   *sqltypes.Result
-	acquired atomic.Int64 // bytes requested via AcquireConsolidatedResponseMemory
-	released atomic.Bool  // release func was invoked
+	acquired atomic.Int64 // count of AcquireConsolidatedResponseMemory calls
+	released atomic.Bool  // release func was invoked at least once
 	lastSize atomic.Int64
+	inUse    atomic.Int64 // net reserved bytes; must return to 0 (no leak)
 }
 
 func (f *limiterFakeQueryService) Execute(ctx context.Context, session queryservice.Session, target *querypb.Target, sql string, bindVariables map[string]*querypb.BindVariable, transactionID, reservedID int64, options *querypb.ExecuteOptions) (*sqltypes.Result, error) {
@@ -51,7 +54,14 @@ func (f *limiterFakeQueryService) HandlePanic(err *error) {}
 func (f *limiterFakeQueryService) AcquireConsolidatedResponseMemory(ctx context.Context, size int64) func() {
 	f.acquired.Add(1)
 	f.lastSize.Store(size)
-	return func() { f.released.Store(true) }
+	f.inUse.Add(size)
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			f.released.Store(true)
+			f.inUse.Add(-size)
+		})
+	}
 }
 
 var _ consolidatedResponseLimiter = (*limiterFakeQueryService)(nil)
@@ -82,13 +92,33 @@ func TestExecuteConsolidatedResponseAcquiresAndReleasesOnCtxDone(t *testing.T) {
 
 	// Budget is still held until the RPC context is done.
 	assert.False(t, fake.released.Load(), "budget released before ctx done")
+	assert.Greater(t, fake.inUse.Load(), int64(0), "budget should be held while ctx is live")
 
 	// Cancelling the RPC context (gRPC does this right after the response is
-	// sent) fires the AfterFunc release.
+	// sent) fires the AfterFunc release and the budget drains back to zero.
 	cancel()
 	assert.Eventually(t, func() bool {
-		return fake.released.Load()
+		return fake.released.Load() && fake.inUse.Load() == 0
 	}, 30*time.Second, time.Millisecond)
+}
+
+func TestExecuteConsolidatedResponseNonCancelableCtxDoesNotLeak(t *testing.T) {
+	// A non-cancelable context (Done() == nil) would never trigger
+	// context.AfterFunc, so the handler must release on return instead. Otherwise
+	// the reservation would leak forever.
+	result := newConsolidatedResult()
+	fake := &limiterFakeQueryService{result: result}
+	q := &query{server: fake}
+
+	require.Nil(t, context.Background().Done(), "precondition: background ctx is non-cancelable")
+	resp, err := q.Execute(context.Background(), &querypb.ExecuteRequest{Query: &querypb.BoundQuery{Sql: "select 1"}})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// The budget was acquired and released by the time Execute returned.
+	assert.Equal(t, int64(1), fake.acquired.Load())
+	assert.True(t, fake.released.Load(), "budget must be released on return for a non-cancelable ctx")
+	assert.Equal(t, int64(0), fake.inUse.Load(), "budget leaked on non-cancelable ctx")
 }
 
 func TestExecuteConsolidatedResponseCachedProto3RowsWeight(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -28,6 +28,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/sync/semaphore"
+
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/cache/theine"
 	"vitess.io/vitess/go/mysql/sqlerror"
@@ -166,6 +168,12 @@ type QueryEngine struct {
 	// Services
 	consolidator       sync2.Consolidator
 	streamConsolidator *StreamConsolidator
+	// consolidatorResponseMem is a global soft byte budget that paces the
+	// serialization of consolidated (non-streaming) query responses. It is nil
+	// when consolidator-query-total-size is 0 (unlimited).
+	consolidatorResponseMem      *semaphore.Weighted
+	consolidatorResponseMemLimit int64
+	consolidatorResponseMemInUse atomic.Int64
 	// txSerializer protects vttablet from applications which try to concurrently
 	// UPDATE (or DELETE) a "hot" row (or range of rows).
 	// Such queries would be serialized by MySQL anyway. This serializer prevents
@@ -193,6 +201,7 @@ type QueryEngine struct {
 	// Note: queryErrorCountsWithCode is similar to queryErrorCounts except it contains error code as an additional dimension
 	queryCounts, queryCountsWithTabletType, queryTimes, queryErrorCounts, queryErrorCountsWithCode, queryRowsAffected, queryRowsReturned, queryTextCharsProcessed *stats.CountersWithMultiLabels
 	queryEnginePlanCacheHits, queryEnginePlanCacheMisses                                                                                                          *stats.CounterFunc
+	consolidatorResponseMemWaits                                                                                                                                  *stats.Counter
 
 	// stats flags
 	enablePerWorkloadTableMetrics bool
@@ -236,6 +245,10 @@ func NewQueryEngine(env tabletenv.Env, se *schema.Engine) *QueryEngine {
 	qe.streamConns = connpool.NewPool(env, "StreamConnPool", config.OlapReadPool)
 	qe.consolidatorMode.Store(config.Consolidator)
 	qe.consolidator = sync2.NewConsolidator()
+	if config.ConsolidatorQueryTotalSize > 0 {
+		qe.consolidatorResponseMemLimit = config.ConsolidatorQueryTotalSize
+		qe.consolidatorResponseMem = semaphore.NewWeighted(config.ConsolidatorQueryTotalSize)
+	}
 	if config.ConsolidatorStreamTotalSize > 0 && config.ConsolidatorStreamQuerySize > 0 {
 		log.Info(fmt.Sprintf("Stream consolidator is enabled with query size set to %d and total size set to %d.", config.ConsolidatorStreamQuerySize, config.ConsolidatorStreamTotalSize))
 		qe.streamConsolidator = NewStreamConsolidator(config.ConsolidatorStreamTotalSize, config.ConsolidatorStreamQuerySize, returnStreamResult)
@@ -273,6 +286,11 @@ func NewQueryEngine(env tabletenv.Env, se *schema.Engine) *QueryEngine {
 	env.Exporter().NewGaugeFunc("MaxResultSize", "Query engine max result size", qe.maxResultSize.Load)
 	env.Exporter().NewGaugeFunc("WarnResultSize", "Query engine warn result size", qe.warnResultSize.Load)
 	env.Exporter().NewGaugeFunc("StreamBufferSize", "Query engine stream buffer size", qe.streamBufferSize.Load)
+	env.Exporter().NewGaugeFunc("ConsolidatorQueryResponseMemoryLimit", "Soft byte limit on in-flight consolidated query responses (0 = unlimited)", func() int64 {
+		return qe.consolidatorResponseMemLimit
+	})
+	env.Exporter().NewGaugeFunc("ConsolidatorQueryResponseMemoryInUse", "Bytes currently reserved for in-flight consolidated query responses", qe.consolidatorResponseMemInUse.Load)
+	qe.consolidatorResponseMemWaits = env.Exporter().NewCounter("ConsolidatorQueryResponseMemoryWaits", "Number of consolidated query responses that blocked on the response memory budget")
 	env.Exporter().NewCounterFunc("TableACLExemptCount", "Query engine table ACL exempt count", qe.tableaclExemptCount.Load)
 
 	env.Exporter().NewGaugeFunc("QueryEnginePlanCacheLength", "Query engine query plan cache length", func() int64 {
@@ -321,6 +339,39 @@ func NewQueryEngine(env tabletenv.Env, se *schema.Engine) *QueryEngine {
 	env.Exporter().HandleFunc("/debug/acl", qe.handleHTTPAclJSON)
 
 	return qe
+}
+
+// AcquireConsolidatedResponseMemory blocks until size bytes are available in the
+// consolidated-response budget, pacing the fan-out of large shared results, and
+// returns a release func to call once serialization completes. The weight is
+// clamped to the total budget so an oversized result still proceeds alone instead
+// of deadlocking. It is a soft limit: acquire and release are no-ops when the
+// limit is disabled or the context is cancelled, and it never fails a query.
+func (qe *QueryEngine) AcquireConsolidatedResponseMemory(ctx context.Context, size int64) func() {
+	if qe.consolidatorResponseMem == nil {
+		return func() {}
+	}
+	w := min(size, qe.consolidatorResponseMemLimit)
+	if w <= 0 {
+		return func() {}
+	}
+	if !qe.consolidatorResponseMem.TryAcquire(w) {
+		qe.consolidatorResponseMemWaits.Add(1)
+		if err := qe.consolidatorResponseMem.Acquire(ctx, w); err != nil {
+			// Context cancelled before we could acquire; proceed without
+			// throttling rather than failing the query.
+			return func() {}
+		}
+	}
+	qe.consolidatorResponseMemInUse.Add(w)
+	// Guard against a double-release over-releasing the semaphore.
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			qe.consolidatorResponseMemInUse.Add(-w)
+			qe.consolidatorResponseMem.Release(w)
+		})
+	}
 }
 
 // Open must be called before sending requests to QueryEngine.

--- a/go/vt/vttablet/tabletserver/query_engine_test.go
+++ b/go/vt/vttablet/tabletserver/query_engine_test.go
@@ -39,9 +39,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/semaphore"
 
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/streamlog"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/tableacl"
@@ -894,4 +896,200 @@ func TestPlanPoolUnsafe(t *testing.T) {
 			require.EqualError(t, err, tcase.err)
 		})
 	}
+}
+
+func TestAcquireConsolidatedResponseMemoryDisabled(t *testing.T) {
+	// With no limit configured, the gate must be a no-op and never block.
+	qe := &QueryEngine{}
+	release := qe.AcquireConsolidatedResponseMemory(context.Background(), 1<<30)
+	require.NotNil(t, release)
+	release()
+}
+
+func TestAcquireConsolidatedResponseMemoryBlocks(t *testing.T) {
+	const limit = 100
+	qe := &QueryEngine{
+		consolidatorResponseMemLimit: limit,
+		consolidatorResponseMem:      semaphore.NewWeighted(limit),
+		consolidatorResponseMemWaits: stats.NewCounter("", ""),
+	}
+
+	release1 := qe.AcquireConsolidatedResponseMemory(context.Background(), limit)
+
+	acquired := make(chan struct{})
+	go func() {
+		release2 := qe.AcquireConsolidatedResponseMemory(context.Background(), limit)
+		close(acquired)
+		release2()
+	}()
+
+	// The second acquisition must block while the budget is fully held.
+	select {
+	case <-acquired:
+		assert.Fail(t, "second acquisition should have blocked while budget was held")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// Releasing the first unblocks the second.
+	release1()
+	assert.Eventually(t, func() bool {
+		select {
+		case <-acquired:
+			return true
+		default:
+			return false
+		}
+	}, 30*time.Second, 5*time.Millisecond)
+
+	// The blocked acquisition was counted as a wait.
+	assert.GreaterOrEqual(t, qe.consolidatorResponseMemWaits.Get(), int64(1))
+}
+
+func TestAcquireConsolidatedResponseMemoryOversizedClamps(t *testing.T) {
+	const limit = 100
+	qe := &QueryEngine{
+		consolidatorResponseMemLimit: limit,
+		consolidatorResponseMem:      semaphore.NewWeighted(limit),
+		consolidatorResponseMemWaits: stats.NewCounter("", ""),
+	}
+
+	// A result larger than the whole budget must still proceed (clamped),
+	// rather than deadlock.
+	release := qe.AcquireConsolidatedResponseMemory(context.Background(), limit*10)
+	require.NotNil(t, release)
+
+	// While the oversized response holds the clamped full budget, another
+	// acquisition blocks.
+	acquired := make(chan struct{})
+	go func() {
+		r := qe.AcquireConsolidatedResponseMemory(context.Background(), 1)
+		close(acquired)
+		r()
+	}()
+	select {
+	case <-acquired:
+		assert.Fail(t, "acquisition should have blocked while oversized response held the budget")
+	case <-time.After(100 * time.Millisecond):
+	}
+	release()
+	assert.Eventually(t, func() bool {
+		select {
+		case <-acquired:
+			return true
+		default:
+			return false
+		}
+	}, 30*time.Second, 5*time.Millisecond)
+}
+
+func TestAcquireConsolidatedResponseMemoryNoLeak(t *testing.T) {
+	const limit = 1000
+	qe := &QueryEngine{
+		consolidatorResponseMemLimit: limit,
+		consolidatorResponseMem:      semaphore.NewWeighted(limit),
+		consolidatorResponseMemWaits: stats.NewCounter("", ""),
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 200; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			release := qe.AcquireConsolidatedResponseMemory(context.Background(), 50)
+			release()
+		}()
+	}
+	wg.Wait()
+
+	// After all acquisitions drained, the full budget must be available again.
+	assert.True(t, qe.consolidatorResponseMem.TryAcquire(limit), "budget leaked: full capacity not available after drain")
+	assert.Equal(t, int64(0), qe.consolidatorResponseMemInUse.Load(), "in-use gauge leaked")
+}
+
+func TestAcquireConsolidatedResponseMemoryReleaseIdempotent(t *testing.T) {
+	const limit = 100
+	qe := &QueryEngine{
+		consolidatorResponseMemLimit: limit,
+		consolidatorResponseMem:      semaphore.NewWeighted(limit),
+		consolidatorResponseMemWaits: stats.NewCounter("", ""),
+	}
+
+	release := qe.AcquireConsolidatedResponseMemory(context.Background(), 40)
+	assert.Equal(t, int64(40), qe.consolidatorResponseMemInUse.Load())
+
+	// Calling release multiple times must release exactly once (no over-release
+	// panic from the underlying semaphore, in-use returns to 0 not negative).
+	release()
+	release()
+	release()
+	assert.Equal(t, int64(0), qe.consolidatorResponseMemInUse.Load())
+	// Full budget is available, proving we released exactly 40 (not 120).
+	assert.True(t, qe.consolidatorResponseMem.TryAcquire(limit))
+}
+
+func TestAcquireConsolidatedResponseMemoryLargeNotStarved(t *testing.T) {
+	// Documents the verified x/sync/semaphore fairness: once a large waiter is
+	// queued, later small requests queue behind it (the fast path requires an
+	// empty waiter list), so the large request is not starved.
+	const limit = 10
+	qe := &QueryEngine{
+		consolidatorResponseMemLimit: limit,
+		consolidatorResponseMem:      semaphore.NewWeighted(limit),
+		consolidatorResponseMemWaits: stats.NewCounter("", ""),
+	}
+
+	// A holds 1 of 10.
+	releaseA := qe.AcquireConsolidatedResponseMemory(context.Background(), 1)
+
+	// B wants the full 10 → must wait (9 free < 10), enqueues as the sole waiter.
+	// B holds the budget until released via bRelease so we can observe C blocked.
+	bAcquired := make(chan struct{})
+	bRelease := make(chan struct{})
+	go func() {
+		r := qe.AcquireConsolidatedResponseMemory(context.Background(), limit)
+		close(bAcquired)
+		<-bRelease
+		r()
+	}()
+	// Give B time to enqueue before C arrives.
+	assert.Eventually(t, func() bool {
+		return qe.consolidatorResponseMemWaits.Get() >= 1
+	}, 30*time.Second, time.Millisecond)
+
+	// C wants only 1; 9 are free, but B is queued ahead, so C must NOT jump in.
+	cAcquired := make(chan struct{})
+	go func() {
+		r := qe.AcquireConsolidatedResponseMemory(context.Background(), 1)
+		close(cAcquired)
+		r()
+	}()
+
+	// Release A: B becomes satisfiable (10 free >= 10) and acquires; C stays
+	// blocked behind it because B holds the entire budget.
+	releaseA()
+	assert.Eventually(t, func() bool {
+		select {
+		case <-bAcquired:
+			return true
+		default:
+			return false
+		}
+	}, 30*time.Second, time.Millisecond)
+	// While B holds the full budget, C cannot have acquired (no tokens free) —
+	// and, crucially, C never jumped ahead of B while A's token was free.
+	select {
+	case <-cAcquired:
+		assert.Fail(t, "C should not acquire before B; large request must not be starved")
+	case <-time.After(100 * time.Millisecond):
+	}
+	// Once B releases, C proceeds.
+	close(bRelease)
+	assert.Eventually(t, func() bool {
+		select {
+		case <-cAcquired:
+			return true
+		default:
+			return false
+		}
+	}, 30*time.Second, time.Millisecond)
 }

--- a/go/vt/vttablet/tabletserver/query_engine_test.go
+++ b/go/vt/vttablet/tabletserver/query_engine_test.go
@@ -991,13 +991,11 @@ func TestAcquireConsolidatedResponseMemoryNoLeak(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
-	for i := 0; i < 200; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 200 {
+		wg.Go(func() {
 			release := qe.AcquireConsolidatedResponseMemory(context.Background(), 50)
 			release()
-		}()
+		})
 	}
 	wg.Wait()
 

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -762,8 +762,15 @@ func (qre *QueryExecutor) execSelect() (*sqltypes.Result, error) {
 			} else {
 				defer conn.Recycle()
 				res, err := qre.execDBConn(conn.Conn, sql, true)
-				if qre.tsv.config.ConsolidatorCacheProto3Rows && q.HasWaiters() {
-					res.CacheProto3Rows()
+				if q.HasWaiters() {
+					if qre.tsv.config.ConsolidatorCacheProto3Rows {
+						res.CacheProto3Rows()
+					}
+					// When a global response-memory budget is configured, mark
+					// the shared result so its fan-out serialization is paced.
+					if qre.tsv.config.ConsolidatorQueryTotalSize > 0 && res != nil {
+						res.SetFromConsolidator()
+					}
 				}
 				q.SetResult(res)
 				q.SetErr(err)

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1697,6 +1697,66 @@ func TestQueryExecutorConsolidatorWaiterCapFallback(t *testing.T) {
 	db.VerifyAllExecutedOrFail()
 }
 
+func TestQueryExecutorConsolidatorResponseMemoryFlag(t *testing.T) {
+	// The leader of a consolidation marks its shared result as
+	// fromConsolidator only when there are waiters AND a response-memory budget
+	// is configured. The flag gates response serialization pacing downstream.
+	testCases := []struct {
+		name        string
+		totalSize   int64
+		waiterCount int64
+		expectFlag  bool
+	}{
+		{name: "limit set, has waiters", totalSize: 1 << 20, waiterCount: 3, expectFlag: true},
+		{name: "limit unset, has waiters", totalSize: 0, waiterCount: 3, expectFlag: false},
+		{name: "limit set, no waiters", totalSize: 1 << 20, waiterCount: 0, expectFlag: false},
+	}
+	for _, tcase := range testCases {
+		t.Run(tcase.name, func(t *testing.T) {
+			db := setUpQueryExecutorTest(t)
+			defer db.Close()
+
+			ctx := t.Context()
+			tsv := newTestTabletServer(ctx, enableConsolidator, db)
+			defer tsv.StopService()
+
+			tsv.config.ConsolidatorQueryTotalSize = tcase.totalSize
+
+			fakeConsolidator := sync2.NewFakeConsolidator()
+			tsv.qe.consolidator = fakeConsolidator
+
+			input := "select * from t limit 10001"
+			result := &sqltypes.Result{
+				Fields: getTestTableFields(),
+				Rows: [][]sqltypes.Value{{
+					sqltypes.NewInt32(1),
+					sqltypes.NewInt32(100),
+					sqltypes.NewInt32(200),
+				}},
+			}
+
+			// Leader path: Created=true. Simulate waiters via WaiterCount.
+			fakePendingResult := &sync2.FakePendingResult{Consolidator: fakeConsolidator}
+			fakePendingResult.WaiterCount = tcase.waiterCount
+			fakeConsolidator.CreateReturn = &sync2.FakeConsolidatorCreateReturn{
+				Created:       true,
+				PendingResult: fakePendingResult,
+			}
+
+			db.AddQuery(input, result)
+
+			qre := newTestQueryExecutor(ctx, tsv, input, 0)
+			qre.options = &querypb.ExecuteOptions{Consolidator: querypb.ExecuteOptions_CONSOLIDATOR_ENABLED}
+
+			actualResult, err := qre.Execute()
+			require.NoError(t, err)
+			require.NotNil(t, actualResult)
+
+			assert.Equal(t, tcase.expectFlag, actualResult.FromConsolidator())
+		})
+	}
+}
+
 func TestGetConnectionLogStats(t *testing.T) {
 	db := setUpQueryExecutorTest(t)
 	defer db.Close()

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -206,6 +206,7 @@ func registerTabletEnvFlags(fs *pflag.FlagSet) {
 	fs.Int64Var(&currentConfig.ConsolidatorStreamTotalSize, "consolidator-stream-total-size", defaultConfig.ConsolidatorStreamTotalSize, "Configure the stream consolidator total size in bytes. Setting to 0 disables the stream consolidator.")
 
 	fs.Int64Var(&currentConfig.ConsolidatorQueryWaiterCap, "consolidator-query-waiter-cap", 0, "Configure the maximum number of clients allowed to wait on the consolidator.")
+	fs.Int64Var(&currentConfig.ConsolidatorQueryTotalSize, "consolidator-query-total-size", defaultConfig.ConsolidatorQueryTotalSize, "Soft global limit, in bytes, on in-flight consolidated (non-streaming) query responses being serialized. 0 = unlimited.")
 	fs.BoolVar(&currentConfig.ConsolidatorCacheProto3Rows, "consolidator-cache-proto3-rows", defaultConfig.ConsolidatorCacheProto3Rows, "If true, the consolidation leader pre-caches proto3-encoded rows so that waiters avoid redundant encoding work.")
 	utils.SetFlagDurationVar(fs, &healthCheckInterval, "health-check-interval", defaultConfig.Healthcheck.Interval, "Interval between health checks")
 	utils.SetFlagDurationVar(fs, &degradedThreshold, "degraded-threshold", defaultConfig.Healthcheck.DegradedThreshold, "replication lag after which a replica is considered degraded")
@@ -342,6 +343,7 @@ type TabletConfig struct {
 	ConsolidatorStreamTotalSize int64         `json:"consolidatorStreamTotalSize,omitempty"`
 	ConsolidatorStreamQuerySize int64         `json:"consolidatorStreamQuerySize,omitempty"`
 	ConsolidatorQueryWaiterCap  int64         `json:"consolidatorMaxQueryWait,omitempty"`
+	ConsolidatorQueryTotalSize  int64         `json:"consolidatorQueryTotalSize,omitempty"`
 	ConsolidatorCacheProto3Rows bool          `json:"consolidatorCacheProto3Rows,omitempty"`
 	QueryCacheMemory            int64         `json:"queryCacheMemory,omitempty"`
 	QueryCacheDoorkeeper        bool          `json:"queryCacheDoorkeeper,omitempty"`

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -2058,6 +2058,14 @@ func (tsv *TabletServer) HandlePanic(err *error) {
 	}
 }
 
+// AcquireConsolidatedResponseMemory reserves response-serialization memory for a
+// consolidated query response under the global soft byte budget, returning a
+// release func that must be called once serialization completes. It is a no-op
+// when the budget is disabled. See QueryEngine.AcquireConsolidatedResponseMemory.
+func (tsv *TabletServer) AcquireConsolidatedResponseMemory(ctx context.Context, size int64) func() {
+	return tsv.qe.AcquireConsolidatedResponseMemory(ctx, size)
+}
+
 // Close shuts down any remaining go routines
 func (tsv *TabletServer) Close(ctx context.Context) error {
 	tsv.sm.closeAll()


### PR DESCRIPTION
## What's this?

The (non-streaming) query consolidator dedupes identical concurrent queries: one leader runs against MySQL and N waiters share the same `*sqltypes.Result` by reference. The memory issue isn't the shared result — it's the response path. Each waiter is its own gRPC request and serializes the result independently (a per-waiter `RowsToProto3` copy when proto3 rows aren't cached, plus the codec wire buffer always), so when a large result fans out to many waiters at `Broadcast()`, peak memory spikes ~linearly with the waiter count.

gRPC's flow control only bounds in-flight buffers *per HTTP/2 connection*, so with the many vtgate connections a tablet serves, nothing caps the aggregate. This adds an opt-in, process-global soft byte budget to pace that fan-out.

## How it works

- New `--consolidator-query-total-size` flag (default `0` = unlimited, so existing behavior is unchanged) sizes a weighted semaphore on `QueryEngine`.
- The consolidator leader tags the shared result (`Result.SetFromConsolidator`) when it has waiters and the limit is set.
- The gRPC `Execute` handler, for tagged results, reserves a pre-build size estimate **before** `ResultToProto3` (so the row-copy fan-out is gated too), weighting `2x` when proto3 rows aren't cached (proto copy + wire buffer) and `1x` when they are.
- The reservation is held until the RPC context is cancelled — which gRPC does right after the response is sent — via `context.AfterFunc`; the release is idempotent.

New stats: `ConsolidatorQueryResponseMemoryLimit` / `...InUse` gauges and a `...Waits` counter.

## Notes

- Soft limit: it never fails a query. An oversized result is clamped to the full budget so it proceeds alone rather than deadlocking; `x/sync/semaphore` is FIFO-fair, so large responses aren't starved by small ones.
- Default `0` is a no-op on the hot path (no flag set, no estimate computed).

---
_Most of this was written by Claude Code — I just provided direction._