### PR TITLE
consultopo: add retry with backoff for transient consul errors

### DIFF
--- a/go/flags/endtoend/vtbackup.txt
+++ b/go/flags/endtoend/vtbackup.txt
@@ -236,6 +236,8 @@ Flags:
       --topo_consul_lock_session_ttl string                         TTL for consul session.
       --topo_consul_max_conns_per_host int                          Maximum number of consul connections per host.
       --topo_consul_max_idle_conns int                              Maximum number of idle consul connections. (default 100)
+      --topo_consul_retry_interval duration                         Initial interval between retries for transient consul errors. Doubles on each retry (exponential backoff). (default 250ms)
+      --topo_consul_retry_timeout duration                          Total timeout for retrying consul operations that fail with transient errors (e.g. during leader elections). (default 15s)
       --topo_consul_watch_poll_duration duration                    time of the long poll for watch queries. (default 30s)
       --topo_etcd_lease_ttl int                                     Lease TTL for locks and leader election. The client will use KeepAlive to keep the lease going. (default 30)
       --topo_etcd_tls_ca string                                     path to the ca to use to validate the server cert when connecting to the etcd topo server

--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -381,6 +381,8 @@ Flags:
       --topo_consul_lock_session_ttl string                              TTL for consul session.
       --topo_consul_max_conns_per_host int                               Maximum number of consul connections per host.
       --topo_consul_max_idle_conns int                                   Maximum number of idle consul connections. (default 100)
+      --topo_consul_retry_interval duration                              Initial interval between retries for transient consul errors. Doubles on each retry (exponential backoff). (default 250ms)
+      --topo_consul_retry_timeout duration                               Total timeout for retrying consul operations that fail with transient errors (e.g. during leader elections). (default 15s)
       --topo_consul_watch_poll_duration duration                         time of the long poll for watch queries. (default 30s)
       --topo_etcd_lease_ttl int                                          Lease TTL for locks and leader election. The client will use KeepAlive to keep the lease going. (default 30)
       --topo_etcd_tls_ca string                                          path to the ca to use to validate the server cert when connecting to the etcd topo server

--- a/go/flags/endtoend/vtctld.txt
+++ b/go/flags/endtoend/vtctld.txt
@@ -165,6 +165,8 @@ Flags:
       --topo_consul_lock_session_ttl string                              TTL for consul session.
       --topo_consul_max_conns_per_host int                               Maximum number of consul connections per host.
       --topo_consul_max_idle_conns int                                   Maximum number of idle consul connections. (default 100)
+      --topo_consul_retry_interval duration                              Initial interval between retries for transient consul errors. Doubles on each retry (exponential backoff). (default 250ms)
+      --topo_consul_retry_timeout duration                               Total timeout for retrying consul operations that fail with transient errors (e.g. during leader elections). (default 15s)
       --topo_consul_watch_poll_duration duration                         time of the long poll for watch queries. (default 30s)
       --topo_etcd_lease_ttl int                                          Lease TTL for locks and leader election. The client will use KeepAlive to keep the lease going. (default 30)
       --topo_etcd_tls_ca string                                          path to the ca to use to validate the server cert when connecting to the etcd topo server

--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -226,6 +226,8 @@ Flags:
       --topo_consul_lock_session_ttl string                              TTL for consul session.
       --topo_consul_max_conns_per_host int                               Maximum number of consul connections per host.
       --topo_consul_max_idle_conns int                                   Maximum number of idle consul connections. (default 100)
+      --topo_consul_retry_interval duration                              Initial interval between retries for transient consul errors. Doubles on each retry (exponential backoff). (default 250ms)
+      --topo_consul_retry_timeout duration                               Total timeout for retrying consul operations that fail with transient errors (e.g. during leader elections). (default 15s)
       --topo_consul_watch_poll_duration duration                         time of the long poll for watch queries. (default 30s)
       --topo_etcd_lease_ttl int                                          Lease TTL for locks and leader election. The client will use KeepAlive to keep the lease going. (default 30)
       --topo_etcd_tls_ca string                                          path to the ca to use to validate the server cert when connecting to the etcd topo server

--- a/go/flags/endtoend/vtorc.txt
+++ b/go/flags/endtoend/vtorc.txt
@@ -102,6 +102,8 @@ Flags:
       --topo_consul_lock_session_ttl string                         TTL for consul session.
       --topo_consul_max_conns_per_host int                          Maximum number of consul connections per host.
       --topo_consul_max_idle_conns int                              Maximum number of idle consul connections. (default 100)
+      --topo_consul_retry_interval duration                         Initial interval between retries for transient consul errors. Doubles on each retry (exponential backoff). (default 250ms)
+      --topo_consul_retry_timeout duration                          Total timeout for retrying consul operations that fail with transient errors (e.g. during leader elections). (default 15s)
       --topo_consul_watch_poll_duration duration                    time of the long poll for watch queries. (default 30s)
       --topo_etcd_lease_ttl int                                     Lease TTL for locks and leader election. The client will use KeepAlive to keep the lease going. (default 30)
       --topo_etcd_tls_ca string                                     path to the ca to use to validate the server cert when connecting to the etcd topo server

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -384,6 +384,8 @@ Flags:
       --topo_consul_lock_session_ttl string                              TTL for consul session.
       --topo_consul_max_conns_per_host int                               Maximum number of consul connections per host.
       --topo_consul_max_idle_conns int                                   Maximum number of idle consul connections. (default 100)
+      --topo_consul_retry_interval duration                              Initial interval between retries for transient consul errors. Doubles on each retry (exponential backoff). (default 250ms)
+      --topo_consul_retry_timeout duration                               Total timeout for retrying consul operations that fail with transient errors (e.g. during leader elections). (default 15s)
       --topo_consul_watch_poll_duration duration                         time of the long poll for watch queries. (default 30s)
       --topo_etcd_lease_ttl int                                          Lease TTL for locks and leader election. The client will use KeepAlive to keep the lease going. (default 30)
       --topo_etcd_tls_ca string                                          path to the ca to use to validate the server cert when connecting to the etcd topo server

--- a/go/flags/endtoend/vttestserver.txt
+++ b/go/flags/endtoend/vttestserver.txt
@@ -149,6 +149,8 @@ Flags:
       --topo_consul_lock_session_ttl string                              TTL for consul session.
       --topo_consul_max_conns_per_host int                               Maximum number of consul connections per host.
       --topo_consul_max_idle_conns int                                   Maximum number of idle consul connections. (default 100)
+      --topo_consul_retry_interval duration                              Initial interval between retries for transient consul errors. Doubles on each retry (exponential backoff). (default 250ms)
+      --topo_consul_retry_timeout duration                               Total timeout for retrying consul operations that fail with transient errors (e.g. during leader elections). (default 15s)
       --topo_consul_watch_poll_duration duration                         time of the long poll for watch queries. (default 30s)
       --topo_zk_auth_file string                                         auth to use when connecting to the zk topo server, file contents should be <scheme>:<auth>, e.g., digest:user:pass
       --topo_zk_base_timeout duration                                    zk base timeout (see zk.Connect) (default 30s)

--- a/go/vt/topo/consultopo/file.go
+++ b/go/vt/topo/consultopo/file.go
@@ -17,9 +17,8 @@ limitations under the License.
 package consultopo
 
 import (
-	"path"
-
 	"context"
+	"path"
 
 	"github.com/hashicorp/consul/api"
 
@@ -41,9 +40,17 @@ func (s *Server) Create(ctx context.Context, filePath string, contents []byte) (
 			Index: 0,
 		},
 	}
-	ok, resp, _, err := s.kv.Txn(ops, nil)
+
+	var (
+		ok   bool
+		resp *api.KVTxnResponse
+	)
+	err := retryOnTransientError(ctx, func() error {
+		var txnErr error
+		ok, resp, _, txnErr = s.kv.Txn(ops, nil)
+		return txnErr
+	})
 	if err != nil {
-		// Communication error.
 		return nil, err
 	}
 	if !ok {
@@ -70,9 +77,17 @@ func (s *Server) Update(ctx context.Context, filePath string, contents []byte, v
 		ops[0].Verb = api.KVCAS
 		ops[0].Index = uint64(version.(ConsulVersion))
 	}
-	ok, resp, _, err := s.kv.Txn(ops, nil)
+
+	var (
+		ok   bool
+		resp *api.KVTxnResponse
+	)
+	err := retryOnTransientError(ctx, func() error {
+		var txnErr error
+		ok, resp, _, txnErr = s.kv.Txn(ops, nil)
+		return txnErr
+	})
 	if err != nil {
-		// Communication error.
 		return nil, err
 	}
 	if !ok {
@@ -87,7 +102,12 @@ func (s *Server) Update(ctx context.Context, filePath string, contents []byte, v
 func (s *Server) Get(ctx context.Context, filePath string) ([]byte, topo.Version, error) {
 	nodePath := path.Join(s.root, filePath)
 
-	pair, _, err := s.kv.Get(nodePath, nil)
+	var pair *api.KVPair
+	err := retryOnTransientError(ctx, func() error {
+		var getErr error
+		pair, _, getErr = s.kv.Get(nodePath, nil)
+		return getErr
+	})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -107,7 +127,12 @@ func (s *Server) GetVersion(ctx context.Context, filePath string, version int64)
 func (s *Server) List(ctx context.Context, filePathPrefix string) ([]topo.KVInfo, error) {
 	nodePathPrefix := path.Join(s.root, filePathPrefix)
 
-	pairs, _, err := s.kv.List(nodePathPrefix, nil)
+	var pairs api.KVPairs
+	err := retryOnTransientError(ctx, func() error {
+		var listErr error
+		pairs, _, listErr = s.kv.List(nodePathPrefix, nil)
+		return listErr
+	})
 	if err != nil {
 		return []topo.KVInfo{}, err
 	}
@@ -150,9 +175,17 @@ func (s *Server) Delete(ctx context.Context, filePath string, version topo.Versi
 		ops[1].Verb = api.KVDeleteCAS
 		ops[1].Index = uint64(version.(ConsulVersion))
 	}
-	ok, resp, _, err := s.kv.Txn(ops, nil)
+
+	var (
+		ok   bool
+		resp *api.KVTxnResponse
+	)
+	err := retryOnTransientError(ctx, func() error {
+		var txnErr error
+		ok, resp, _, txnErr = s.kv.Txn(ops, nil)
+		return txnErr
+	})
 	if err != nil {
-		// Communication error.
 		return err
 	}
 	if !ok {

--- a/go/vt/topo/consultopo/retry.go
+++ b/go/vt/topo/consultopo/retry.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package consultopo
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/spf13/pflag"
+
+	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/servenv"
+)
+
+var (
+	consulRetryTimeout  = 15 * time.Second
+	consulRetryInterval = 250 * time.Millisecond
+)
+
+func init() {
+	servenv.RegisterFlagsForTopoBinaries(registerRetryFlags)
+}
+
+func registerRetryFlags(fs *pflag.FlagSet) {
+	fs.DurationVar(&consulRetryTimeout, "topo_consul_retry_timeout", consulRetryTimeout, "Total timeout for retrying consul operations that fail with transient errors (e.g. during leader elections).")
+	fs.DurationVar(&consulRetryInterval, "topo_consul_retry_interval", consulRetryInterval, "Initial interval between retries for transient consul errors. Doubles on each retry (exponential backoff).")
+}
+
+// isTransientError returns true if the error is a transient consul error
+// that should be retried, such as 500 "No cluster leader" during leader elections.
+func isTransientError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if _, ok := err.(net.Error); ok {
+		return true
+	}
+	if se, ok := err.(api.StatusError); ok {
+		return se.Code == 500
+	}
+	return api.IsRetryableError(err)
+}
+
+// retryOnTransientError retries the given function with exponential backoff
+// when it returns a transient error. It respects the provided context for
+// cancellation.
+func retryOnTransientError(ctx context.Context, fn func() error) error {
+	err := fn()
+	if err == nil || !isTransientError(err) {
+		return err
+	}
+
+	deadline := time.Now().Add(consulRetryTimeout)
+	interval := consulRetryInterval
+
+	for {
+		if time.Now().After(deadline) {
+			return err
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(interval):
+		}
+
+		log.Warningf("consultopo: retrying after transient error: %v", err)
+
+		err = fn()
+		if err == nil || !isTransientError(err) {
+			return err
+		}
+
+		interval = interval * 2
+		if interval > 2*time.Second {
+			interval = 2 * time.Second
+		}
+	}
+}

--- a/go/vt/topo/consultopo/retry_test.go
+++ b/go/vt/topo/consultopo/retry_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package consultopo
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsTransientError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "non-transient error",
+			err:      errors.New("some random error"),
+			expected: false,
+		},
+		{
+			name:     "500 status error",
+			err:      api.StatusError{Code: 500, Body: "No cluster leader"},
+			expected: true,
+		},
+		{
+			name:     "403 status error is not transient",
+			err:      api.StatusError{Code: 403, Body: "Permission denied"},
+			expected: false,
+		},
+		{
+			name:     "404 status error is not transient",
+			err:      api.StatusError{Code: 404, Body: "Not found"},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isTransientError(tt.err))
+		})
+	}
+}
+
+func TestRetryOnTransientError_ImmediateSuccess(t *testing.T) {
+	calls := 0
+	err := retryOnTransientError(context.Background(), func() error {
+		calls++
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+}
+
+func TestRetryOnTransientError_NonTransientError(t *testing.T) {
+	calls := 0
+	expectedErr := errors.New("permanent error")
+	err := retryOnTransientError(context.Background(), func() error {
+		calls++
+		return expectedErr
+	})
+	assert.Equal(t, expectedErr, err)
+	assert.Equal(t, 1, calls)
+}
+
+func TestRetryOnTransientError_TransientThenSuccess(t *testing.T) {
+	origInterval := consulRetryInterval
+	consulRetryInterval = 10 * time.Millisecond
+	defer func() { consulRetryInterval = origInterval }()
+
+	calls := 0
+	err := retryOnTransientError(context.Background(), func() error {
+		calls++
+		if calls < 3 {
+			return api.StatusError{Code: 500, Body: "No cluster leader"}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 3, calls)
+}
+
+func TestRetryOnTransientError_TransientUntilTimeout(t *testing.T) {
+	origInterval := consulRetryInterval
+	origTimeout := consulRetryTimeout
+	consulRetryInterval = 10 * time.Millisecond
+	consulRetryTimeout = 100 * time.Millisecond
+	defer func() {
+		consulRetryInterval = origInterval
+		consulRetryTimeout = origTimeout
+	}()
+
+	transientErr := api.StatusError{Code: 500, Body: "No cluster leader"}
+	err := retryOnTransientError(context.Background(), func() error {
+		return transientErr
+	})
+	assert.Equal(t, transientErr, err)
+}
+
+func TestRetryOnTransientError_ContextCanceled(t *testing.T) {
+	origInterval := consulRetryInterval
+	consulRetryInterval = 10 * time.Millisecond
+	defer func() { consulRetryInterval = origInterval }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	calls := 0
+	err := retryOnTransientError(ctx, func() error {
+		calls++
+		if calls == 2 {
+			cancel()
+		}
+		return api.StatusError{Code: 500, Body: "No cluster leader"}
+	})
+	assert.Equal(t, context.Canceled, err)
+}

--- a/go/vt/topo/consultopo/watch.go
+++ b/go/vt/topo/consultopo/watch.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/consul/api"
 	"github.com/spf13/pflag"
 
+	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/topo"
 )
@@ -75,6 +76,8 @@ func (s *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <
 
 		defer cancelGetCtx()
 
+		var watchRetries int
+
 		for {
 			// Wait/poll until we get a new version.
 			// Get with a WaitIndex and WaitTime will return
@@ -97,13 +100,32 @@ func (s *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <
 
 			pair, _, err = s.kv.Get(nodePath, opts.WithContext(getCtx))
 			if err != nil {
-				// Serious error or context timeout/cancelled.
+				if isTransientError(err) && watchRetries < 10 {
+					watchRetries++
+					backoff := time.Duration(watchRetries) * consulRetryInterval
+					if backoff > 2*time.Second {
+						backoff = 2 * time.Second
+					}
+					log.Warningf("consultopo: watch %v got transient error (retry %d): %v", nodePath, watchRetries, err)
+					select {
+					case <-ctx.Done():
+						notifications <- &topo.WatchData{
+							Err: convertError(ctx.Err(), nodePath),
+						}
+						cancelGetCtx()
+						return
+					case <-time.After(backoff):
+						continue
+					}
+				}
 				notifications <- &topo.WatchData{
 					Err: convertError(err, nodePath),
 				}
 				cancelGetCtx()
 				return
 			}
+
+			watchRetries = 0
 
 			// If the node disappeared, pair is nil.
 			if pair == nil {

--- a/go/vt/topo/consultopo/watch.go
+++ b/go/vt/topo/consultopo/watch.go
@@ -98,7 +98,7 @@ func (s *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <
 			cancelGetCtx()
 			getCtx, cancelGetCtx = context.WithTimeout(ctx, 2*opts.WaitTime)
 
-			pair, _, err = s.kv.Get(nodePath, opts.WithContext(getCtx))
+			newPair, _, err := s.kv.Get(nodePath, opts.WithContext(getCtx))
 			if err != nil {
 				if isTransientError(err) && watchRetries < 10 {
 					watchRetries++
@@ -124,6 +124,7 @@ func (s *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <
 				cancelGetCtx()
 				return
 			}
+			pair = newPair
 
 			watchRetries = 0
 


### PR DESCRIPTION
## What's this?

During consul leader elections (~5-7s window), all consultopo operations fail immediately with HTTP 500 "No cluster leader". Unlike etcd2topo which has built-in retry logic, consultopo returns the error straight to the caller. This has caused PRS failures during v19->v22 upgrades when a topo Update call to set the new shard primary hits a leaderless window.

## How it works

- Adds retryOnTransientError() helper with exponential backoff (250ms initial, 2s cap, 15s total timeout)
- Wraps all KV operations (Create, Update, Get, List, Delete) with the retry logic
- Adds retry loop to the Watch goroutine (up to 10 retries before giving up)
- Detects transient errors via api.StatusError{Code: 500} and network errors

Configurable flags:
- --topo_consul_retry_timeout (default 15s)
- --topo_consul_retry_interval (default 250ms)

## Context

Thread: https://slack-ce.slack.com/archives/C09V5BWRY0K/p1781829856313769

---
_Most of this was written by Claude Code - I provided direction._