### PR TITLE
Match Vitess priority direction in loadshed shedding

### DIFF
--- a/go/vt/vttablet/tabletserver/loadshed/request.go
+++ b/go/vt/vttablet/tabletserver/loadshed/request.go
@@ -44,6 +44,19 @@ type (
 // any real priority value.
 var priorityUndroppable = math.Inf(-1)
 
+const (
+	// maxProtoPriority mirrors sqlparser.MaxPriorityValue, the upper bound of
+	// the Vitess ExecuteOptions priority range. It is duplicated here rather
+	// than imported to keep the loadshed package free of a sqlparser
+	// dependency. Kept in sync with vitessio/vitess.
+	maxProtoPriority = 100
+
+	// defaultProtoPriority is the priority assumed for callers that do not
+	// supply one. It matches tabletserver's TxThrottlerDefaultPriority default
+	// (sqlparser.MaxPriorityValue): unmarked traffic is the most sheddable.
+	defaultProtoPriority = maxProtoPriority
+)
+
 var grantSentinel = errors.New("granted") //nolint:staticcheck // not an error; sentinel for non-consuming signal state inspection
 
 func newRequest(priority float64) *Request {

--- a/go/vt/vttablet/tabletserver/loadshed/snake.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake.go
@@ -93,11 +93,19 @@ func (s *Snake) hasCapacity() bool {
 	return len(s.holders) < s.capacity()
 }
 
-// Acquire acquires a slot. It blocks until a slot is granted, the request
-// is dropped by CoDel, or the context is cancelled. The returned SafeUnlock
-// must be released via defer unlock.Release().
+// Acquire acquires a slot using the default (most-sheddable) priority. It
+// blocks until a slot is granted, the request is dropped by CoDel, or the
+// context is cancelled. The returned SafeUnlock must be released via defer
+// unlock.Release().
 func (s *Snake) Acquire(ctx context.Context, valveID string) (*SafeUnlock, error) {
-	priority := s.priority()
+	return s.AcquireWithPriority(ctx, valveID, defaultProtoPriority)
+}
+
+// AcquireWithPriority is Acquire with an explicit Vitess ExecuteOptions
+// priority (0–100, where 0 is the most important / shed last). Under
+// contention, lower-priority requests are shed before higher-priority ones.
+func (s *Snake) AcquireWithPriority(ctx context.Context, valveID string, protoPriority int) (*SafeUnlock, error) {
+	priority := s.priority(protoPriority)
 
 	s.mu.Lock()
 	req := s.q.lockedEnqueue(valveID, priority)
@@ -249,11 +257,27 @@ func (s *Snake) runReleaseCBs(excValue error) {
 	}
 }
 
-func (s *Snake) priority() float64 {
+// priority maps a Vitess ExecuteOptions priority into the CoDel queue's
+// internal drop key. This is the single boundary between the two conventions,
+// which run in OPPOSITE directions:
+//
+//   - Vitess proto convention: 0 is the HIGHEST priority (shed last) and
+//     maxProtoPriority is the LOWEST (shed first). See vitessio/vitess
+//     go/vt/sqlparser/comments.go (DirectivePriority):
+//     https://github.com/vitessio/vitess/blob/57c1e593824bc24723b5b778cfa279da721f9892/go/vt/sqlparser/comments.go#L68
+//
+//   - CoDel internal convention: lockedFindLowestPriorityDroppable sheds the
+//     LOWEST key first, so a higher key means shed last.
+//
+// Inverting here (key = maxProtoPriority - protoPriority) makes Snake honor
+// the established proto direction. Getting it backwards would silently shed
+// the MOST important traffic first under load. The inversion lives only here
+// so the CoDel layer keeps its self-consistent "lower key = shed first" rule.
+func (s *Snake) priority(protoPriority int) float64 {
 	if s.cfg.LoadsheddingAllowed != nil && !s.cfg.LoadsheddingAllowed() {
 		return priorityUndroppable
 	}
-	return 0
+	return float64(maxProtoPriority - protoPriority)
 }
 
 func (s *Snake) acquireError() error {

--- a/go/vt/vttablet/tabletserver/loadshed/snake_priority_direction_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_priority_direction_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loadshed
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSnake_PriorityDirection_MatchesVitess pins the direction of the proto
+// priority mapping: in Vitess's ExecuteOptions convention a NUMERICALLY LOWER
+// priority is MORE important and must be shed LAST, while a higher value is
+// less important and shed first. Snake's internal CoDel key runs the opposite
+// way (lowest key shed first), so Snake.priority inverts the proto value at a
+// single boundary. This test drives two requests through that real boundary
+// and asserts the less-important (proto-high) one is the one CoDel selects to
+// drop, while the more-important (proto-low) one survives.
+//
+// If the inversion were ever dropped or reversed, the queue would shed the
+// most important traffic first under load — this test fails loudly in that case.
+func TestSnake_PriorityDirection_MatchesVitess(t *testing.T) {
+	s := newTestSnake(defaultSnakeConfig())
+
+	const (
+		moreImportantProto = 0   // highest Vitess priority -> shed last
+		lessImportantProto = 100 // lowest Vitess priority  -> shed first
+	)
+
+	moreImportantKey := s.priority(moreImportantProto)
+	lessImportantKey := s.priority(lessImportantProto)
+
+	// The boundary must map "more important" to a HIGHER internal key, because
+	// CoDel sheds the lowest key first.
+	assert.Greater(t, moreImportantKey, lessImportantKey,
+		"more-important proto priority must yield a higher (shed-later) internal key")
+
+	clock := newTestClock()
+	q, _ := newTestQueue(defaultTestConfig(), clock)
+
+	moreImportant := testEnqueue(q, moreImportantKey)
+	lessImportant := testEnqueue(q, lessImportantKey)
+
+	// Under contention, CoDel drops the lowest-priority droppable request.
+	elem := q.lockedFindLowestPriorityDroppable()
+	require.NotNil(t, elem)
+	assert.Same(t, lessImportant, elem.Value.(*Request),
+		"the less-important request must be shed first")
+
+	dropped := q.lockedPopElem(elem, &DroppedRequestError{})
+	assert.Same(t, lessImportant, dropped)
+
+	// The more-important request survives the drop.
+	survivor := q.lockedFindLowestPriorityDroppable()
+	require.NotNil(t, survivor)
+	assert.Same(t, moreImportant, survivor.Value.(*Request),
+		"the more-important request must survive while less-important traffic is shed")
+}
+
+// TestSnake_PriorityDirection_OrdersAcrossRange confirms the mapping is
+// monotonic across the proto range, not just at the extremes: a strictly lower
+// (more important) proto priority is always shed after a higher one.
+func TestSnake_PriorityDirection_OrdersAcrossRange(t *testing.T) {
+	s := newTestSnake(defaultSnakeConfig())
+
+	clock := newTestClock()
+	q, _ := newTestQueue(defaultTestConfig(), clock)
+
+	// Enqueue in arbitrary order; CoDel should still pick the least important.
+	mid := testEnqueue(q, s.priority(50))
+	least := testEnqueue(q, s.priority(90))
+	most := testEnqueue(q, s.priority(10))
+
+	// proto 90 is least important -> shed first.
+	elem := q.lockedFindLowestPriorityDroppable()
+	require.NotNil(t, elem)
+	assert.Same(t, least, elem.Value.(*Request))
+	q.lockedPopElem(elem, &DroppedRequestError{})
+
+	// proto 50 is next least important -> shed next.
+	elem = q.lockedFindLowestPriorityDroppable()
+	require.NotNil(t, elem)
+	assert.Same(t, mid, elem.Value.(*Request))
+	q.lockedPopElem(elem, &DroppedRequestError{})
+
+	// proto 10 is the most important of the three -> shed last.
+	elem = q.lockedFindLowestPriorityDroppable()
+	require.NotNil(t, elem)
+	assert.Same(t, most, elem.Value.(*Request))
+}


### PR DESCRIPTION
### Background / Why?

Snake's internal CoDel queue and Vitess's `ExecuteOptions.priority` field number priority in opposite directions, and Snake was honoring the wrong one. Vitess's documented convention is that a numerically *lower* priority is *more* important: 0 is the highest priority and is shed last, while `MaxPriorityValue` (100) is the lowest and is shed first. That is stated directly in upstream `go/vt/sqlparser/comments.go` on `DirectivePriority` — "where 0 is the highest priority, and MaxPriorityValue is the lowest one" (https://github.com/vitessio/vitess/blob/57c1e593824bc24723b5b778cfa279da721f9892/go/vt/sqlparser/comments.go#L68) — and the transaction throttler enforces it in `txThrottler.Throttle`, where lower-priority-value workloads are less likely to be throttled.

Snake's CoDel layer, by contrast, sheds the *lowest* internal drop key first (`lockedFindLowestPriorityDroppable`, with a special instant-pick for key `0`). Taken together, a request's proto priority was driving drop ordering backwards relative to the established field semantics. Matching Vitess's documented convention is required even though the direction is arguably unintuitive: getting it backwards would silently shed the *most* important traffic first under load, which is the opposite of what an operator setting a low (important) priority expects.

The fix inverts the proto priority exactly once, at the single boundary where it becomes the internal drop key — `Snake.priority` — so that proto 0 (most important) maps to the highest internal key (shed last) and proto 100 maps to key 0 (shed first). The CoDel layer keeps its self-consistent "lower key = shed first" rule untouched, so there are no scattered sign flips. The inverting boundary is reached via a new `AcquireWithPriority` entry point; the existing `Acquire` delegates with the default (most-sheddable) priority, matching tabletserver's `TxThrottlerDefaultPriority` default, so current callers are unchanged.

### Testing

Added `snake_priority_direction_test.go` with two deterministic direction-assertion tests that drive proto priorities through the real `Snake.priority` boundary into a CoDel queue and assert the shedding order: the less-important (proto-high) request is shed first while the more-important (proto-low) one survives, and ordering is monotonic across the 0–100 range. No existing assertions encoded the old direction, so none needed correcting — the prior default-priority path still produces internal key `0`, so the existing suite is unaffected. Ran the full `loadshed` package suite, including under `-race`.

AI disclosure: Claude Code assisted with development. Every line of code was either written by or carefully reviewed by me :)