### PR TITLE
Wire `ExecuteOptions` priority into Snake load shedding

### DIFF
--- a/go/vt/vttablet/tabletserver/loadshed/snake.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake.go
@@ -96,8 +96,17 @@ func (s *Snake) hasCapacity() bool {
 // Acquire acquires a slot. It blocks until a slot is granted, the request
 // is dropped by CoDel, or the context is cancelled. The returned SafeUnlock
 // must be released via defer unlock.Release().
-func (s *Snake) Acquire(ctx context.Context, valveID string) (*SafeUnlock, error) {
-	priority := s.priority()
+//
+// priority is in Snake's own convention: under contention the LOWEST priority
+// is shed first and the highest is shed last. Snake is agnostic to any caller's
+// priority scheme — callers translate their convention into this one before
+// calling. For Vitess ExecuteOptions priorities (0 = most important,
+// sqlparser.MaxPriorityValue = least important) the caller passes
+// MaxPriorityValue - protoPriority, so the most important traffic gets the
+// highest priority and is shed last. When LoadsheddingAllowed() reports false,
+// the supplied priority is ignored and the request is made undroppable.
+func (s *Snake) Acquire(ctx context.Context, valveID string, priority float64) (*SafeUnlock, error) {
+	priority = s.priority(priority)
 
 	s.mu.Lock()
 	req := s.q.lockedEnqueue(valveID, priority)
@@ -249,11 +258,15 @@ func (s *Snake) runReleaseCBs(excValue error) {
 	}
 }
 
-func (s *Snake) priority() float64 {
+// priority returns the priority Snake will enqueue for a request. It honors the
+// caller-supplied priority unless load shedding is disallowed, in which case the
+// request is made undroppable. This is the one place the LoadsheddingAllowed
+// gate is applied; the caller's priority convention is otherwise opaque to Snake.
+func (s *Snake) priority(priority float64) float64 {
 	if s.cfg.LoadsheddingAllowed != nil && !s.cfg.LoadsheddingAllowed() {
 		return priorityUndroppable
 	}
-	return 0
+	return priority
 }
 
 func (s *Snake) acquireError() error {

--- a/go/vt/vttablet/tabletserver/loadshed/snake.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake.go
@@ -97,14 +97,8 @@ func (s *Snake) hasCapacity() bool {
 // is dropped by CoDel, or the context is cancelled. The returned SafeUnlock
 // must be released via defer unlock.Release().
 //
-// priority is in Snake's own convention: under contention the LOWEST priority
-// is shed first and the highest is shed last. Snake is agnostic to any caller's
-// priority scheme — callers translate their convention into this one before
-// calling. For Vitess ExecuteOptions priorities (0 = most important,
-// sqlparser.MaxPriorityValue = least important) the caller passes
-// MaxPriorityValue - protoPriority, so the most important traffic gets the
-// highest priority and is shed last. When LoadsheddingAllowed() reports false,
-// the supplied priority is ignored and the request is made undroppable.
+// The priority ordering convention is that lower-valued priorities indicate
+// less important requests. Lower values are shed first.
 func (s *Snake) Acquire(ctx context.Context, valveID string, priority float64) (*SafeUnlock, error) {
 	priority = s.priority(priority)
 
@@ -258,10 +252,6 @@ func (s *Snake) runReleaseCBs(excValue error) {
 	}
 }
 
-// priority returns the priority Snake will enqueue for a request. It honors the
-// caller-supplied priority unless load shedding is disallowed, in which case the
-// request is made undroppable. This is the one place the LoadsheddingAllowed
-// gate is applied; the caller's priority convention is otherwise opaque to Snake.
 func (s *Snake) priority(priority float64) float64 {
 	if s.cfg.LoadsheddingAllowed != nil && !s.cfg.LoadsheddingAllowed() {
 		return priorityUndroppable

--- a/go/vt/vttablet/tabletserver/loadshed/snake_bench_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_bench_test.go
@@ -33,7 +33,7 @@ func BenchmarkSnake_Uncontended(b *testing.B) {
 
 	b.ResetTimer()
 	for range b.N {
-		u, err := s.Acquire(ctx, "")
+		u, err := s.Acquire(ctx, "", 0)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -47,7 +47,7 @@ func BenchmarkSnake_Uncontended_WithValveID(b *testing.B) {
 
 	b.ResetTimer()
 	for range b.N {
-		u, err := s.Acquire(ctx, "valve-1")
+		u, err := s.Acquire(ctx, "valve-1", 0)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -67,7 +67,7 @@ func BenchmarkSnake_Contended(b *testing.B) {
 			b.ResetTimer()
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
-					u, err := s.Acquire(ctx, "")
+					u, err := s.Acquire(ctx, "", 0)
 					if err != nil {
 						continue
 					}
@@ -87,7 +87,7 @@ func BenchmarkSnake_ValveOverhead(b *testing.B) {
 
 		b.ResetTimer()
 		for range b.N {
-			u, err := s.Acquire(ctx, "")
+			u, err := s.Acquire(ctx, "", 0)
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -101,7 +101,7 @@ func BenchmarkSnake_ValveOverhead(b *testing.B) {
 
 		b.ResetTimer()
 		for range b.N {
-			u, err := s.Acquire(ctx, "single-id")
+			u, err := s.Acquire(ctx, "single-id", 0)
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -124,7 +124,7 @@ func BenchmarkSnake_ValveIDScaling(b *testing.B) {
 
 			b.ResetTimer()
 			for i := range b.N {
-				u, err := s.Acquire(ctx, ids[i%numIDs])
+				u, err := s.Acquire(ctx, ids[i%numIDs], 0)
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -149,7 +149,7 @@ func BenchmarkSnake_GOMAXPROCS(b *testing.B) {
 			b.ResetTimer()
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
-					u, err := s.Acquire(ctx, "")
+					u, err := s.Acquire(ctx, "", 0)
 					if err != nil {
 						continue
 					}
@@ -257,7 +257,7 @@ func BenchmarkSnake_Allocs_Uncontended(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for range b.N {
-		u, err := s.Acquire(ctx, "")
+		u, err := s.Acquire(ctx, "", 0)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -272,7 +272,7 @@ func BenchmarkSnake_Allocs_WithValve(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for range b.N {
-		u, err := s.Acquire(ctx, "valve-1")
+		u, err := s.Acquire(ctx, "valve-1", 0)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -295,7 +295,7 @@ func BenchmarkSnake_Allocs_Contended(b *testing.B) {
 		go func() {
 			defer wg.Done()
 			for range opsPerWorker {
-				u, err := s.Acquire(ctx, "")
+				u, err := s.Acquire(ctx, "", 0)
 				if err != nil {
 					continue
 				}
@@ -318,7 +318,7 @@ func BenchmarkSnake_Throughput_SelfContention(b *testing.B) {
 			b.ResetTimer()
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
-					u, err := s.Acquire(ctx, "shared-id")
+					u, err := s.Acquire(ctx, "shared-id", 0)
 					if err != nil {
 						continue
 					}
@@ -343,7 +343,7 @@ func BenchmarkSnake_NHolder_Throughput(b *testing.B) {
 			b.ResetTimer()
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
-					u, err := s.Acquire(ctx, "")
+					u, err := s.Acquire(ctx, "", 0)
 					if err != nil {
 						continue
 					}
@@ -366,7 +366,7 @@ func BenchmarkSnake_NHolder_Uncontended(b *testing.B) {
 
 			b.ResetTimer()
 			for range b.N {
-				u, err := s.Acquire(ctx, "")
+				u, err := s.Acquire(ctx, "", 0)
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -390,7 +390,7 @@ func BenchmarkSnake_NHolder_Saturated(b *testing.B) {
 			b.ResetTimer()
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
-					u, err := s.Acquire(ctx, "")
+					u, err := s.Acquire(ctx, "", 0)
 					if err != nil {
 						continue
 					}
@@ -423,7 +423,7 @@ func BenchmarkSnake_NHolder_WithValve(b *testing.B) {
 				idx := int(counter.Add(1) - 1)
 				id := ids[idx%len(ids)]
 				for pb.Next() {
-					u, err := s.Acquire(ctx, id)
+					u, err := s.Acquire(ctx, id, 0)
 					if err != nil {
 						continue
 					}
@@ -447,7 +447,7 @@ func BenchmarkSnake_NHolder_Allocs(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			for range b.N {
-				u, err := s.Acquire(ctx, "")
+				u, err := s.Acquire(ctx, "", 0)
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/go/vt/vttablet/tabletserver/loadshed/snake_nholder_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_nholder_test.go
@@ -39,7 +39,7 @@ func TestSnake_NHolder_ConcurrentGrants(t *testing.T) {
 
 			unlocks := make([]*SafeUnlock, cap)
 			for i := range cap {
-				u, err := s.Acquire(t.Context(), "")
+				u, err := s.Acquire(t.Context(), "", 0)
 				require.NoError(t, err, "acquire %d should succeed (capacity=%d)", i, cap)
 				unlocks[i] = u
 			}
@@ -63,14 +63,14 @@ func TestSnake_NHolder_BlocksAtCapacity(t *testing.T) {
 
 	unlocks := make([]*SafeUnlock, 3)
 	for i := range 3 {
-		u, err := s.Acquire(t.Context(), "")
+		u, err := s.Acquire(t.Context(), "", 0)
 		require.NoError(t, err)
 		unlocks[i] = u
 	}
 
 	acquired := make(chan struct{})
 	go func() {
-		u, err := s.Acquire(t.Context(), "")
+		u, err := s.Acquire(t.Context(), "", 0)
 		if err == nil {
 			close(acquired)
 			u.Release()
@@ -112,7 +112,7 @@ func TestSnake_NHolder_ParallelThroughput(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for range opsPerWorker {
-				u, err := s.Acquire(t.Context(), "")
+				u, err := s.Acquire(t.Context(), "", 0)
 				if err != nil {
 					continue
 				}
@@ -145,12 +145,12 @@ func TestSnake_NHolder_DynamicCapacityIncrease(t *testing.T) {
 	cfg.Capacity = func() int { return int(cap.Load()) }
 	s := NewSnake(cfg)
 
-	u1, err := s.Acquire(t.Context(), "")
+	u1, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 
 	acquired := make(chan struct{})
 	go func() {
-		u, err := s.Acquire(t.Context(), "")
+		u, err := s.Acquire(t.Context(), "", 0)
 		if err == nil {
 			close(acquired)
 			u.Release()
@@ -185,7 +185,7 @@ func TestSnake_NHolder_DynamicCapacityDecrease(t *testing.T) {
 
 	unlocks := make([]*SafeUnlock, 4)
 	for i := range 4 {
-		u, err := s.Acquire(t.Context(), "")
+		u, err := s.Acquire(t.Context(), "", 0)
 		require.NoError(t, err)
 		unlocks[i] = u
 	}
@@ -195,7 +195,7 @@ func TestSnake_NHolder_DynamicCapacityDecrease(t *testing.T) {
 
 	acquired := make(chan struct{})
 	go func() {
-		u, err := s.Acquire(t.Context(), "")
+		u, err := s.Acquire(t.Context(), "", 0)
 		if err == nil {
 			close(acquired)
 			u.Release()
@@ -229,11 +229,11 @@ func TestSnake_NHolder_ValveSerialization(t *testing.T) {
 	cfg.Capacity = func() int { return 3 }
 	s := NewSnake(cfg)
 
-	u1, err := s.Acquire(t.Context(), "valve-a")
+	u1, err := s.Acquire(t.Context(), "valve-a", 0)
 	require.NoError(t, err)
-	u2, err := s.Acquire(t.Context(), "valve-b")
+	u2, err := s.Acquire(t.Context(), "valve-b", 0)
 	require.NoError(t, err)
-	u3, err := s.Acquire(t.Context(), "valve-c")
+	u3, err := s.Acquire(t.Context(), "valve-c", 0)
 	require.NoError(t, err)
 	assert.Equal(t, 3, s.nGranted())
 
@@ -245,7 +245,7 @@ func TestSnake_NHolder_ValveSerialization(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				u, err := s.Acquire(t.Context(), vid)
+				u, err := s.Acquire(t.Context(), vid, 0)
 				if err == nil {
 					results <- vid
 					u.Release()
@@ -284,7 +284,7 @@ func TestSnake_NHolder_NGrantedAccuracy(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			u, err := s.Acquire(t.Context(), "")
+			u, err := s.Acquire(t.Context(), "", 0)
 			if err != nil {
 				return
 			}
@@ -308,15 +308,15 @@ func TestSnake_NHolder_ContextCancelFreesSlot(t *testing.T) {
 	s := NewSnake(cfg)
 
 	ctx1, cancel1 := context.WithCancel(t.Context())
-	u1, err := s.Acquire(ctx1, "")
+	u1, err := s.Acquire(ctx1, "", 0)
 	require.NoError(t, err)
 
-	u2, err := s.Acquire(t.Context(), "")
+	u2, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 
 	waiterDone := make(chan error, 1)
 	go func() {
-		u, err := s.Acquire(t.Context(), "")
+		u, err := s.Acquire(t.Context(), "", 0)
 		if err == nil {
 			u.Release()
 		}
@@ -345,14 +345,14 @@ func TestSnake_NHolder_MaxAge_MultipleHolders(t *testing.T) {
 	cfg.MaxAge = func() time.Duration { return 20 * time.Millisecond }
 	s := NewSnake(cfg)
 
-	u1, err := s.Acquire(t.Context(), "")
+	u1, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
-	u2, err := s.Acquire(t.Context(), "")
+	u2, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 
 	waiterDone := make(chan struct{})
 	go func() {
-		u, err := s.Acquire(t.Context(), "")
+		u, err := s.Acquire(t.Context(), "", 0)
 		if err == nil {
 			close(waiterDone)
 			u.Release()
@@ -386,7 +386,7 @@ func TestSnake_NHolder_ReleaseCallbacks(t *testing.T) {
 
 	unlocks := make([]*SafeUnlock, 3)
 	for i := range 3 {
-		u, err := s.Acquire(t.Context(), "")
+		u, err := s.Acquire(t.Context(), "", 0)
 		require.NoError(t, err)
 		unlocks[i] = u
 	}
@@ -411,7 +411,7 @@ func TestSnake_NHolder_ValveInvariant_AllGranted(t *testing.T) {
 	unlocks := make([]*SafeUnlock, M)
 	for i := range M {
 		ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
-		u, err := s.Acquire(ctx, "foo")
+		u, err := s.Acquire(ctx, "foo", 0)
 		cancel()
 		require.NoError(t, err, "request %d should be granted (capacity=%d, holders=%d)", i, capacity, i)
 		unlocks[i] = u
@@ -437,7 +437,7 @@ func TestSnake_NHolder_ValveInvariant_CapacityExhausted(t *testing.T) {
 	unlocks := make([]*SafeUnlock, capacity)
 	for i := range capacity {
 		ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
-		u, err := s.Acquire(ctx, "foo")
+		u, err := s.Acquire(ctx, "foo", 0)
 		cancel()
 		require.NoError(t, err, "request %d should be granted", i)
 		unlocks[i] = u
@@ -448,7 +448,7 @@ func TestSnake_NHolder_ValveInvariant_CapacityExhausted(t *testing.T) {
 	granted := make(chan *SafeUnlock, 1)
 	go func() {
 		close(blocked)
-		u, err := s.Acquire(context.Background(), "foo")
+		u, err := s.Acquire(context.Background(), "foo", 0)
 		if err == nil {
 			granted <- u
 		}
@@ -487,7 +487,7 @@ func TestSnake_NHolder_MemoryCleanup(t *testing.T) {
 	for range 500 {
 		unlocks := make([]*SafeUnlock, 5)
 		for i := range 5 {
-			u, err := s.Acquire(t.Context(), fmt.Sprintf("id-%d", i))
+			u, err := s.Acquire(t.Context(), fmt.Sprintf("id-%d", i), 0)
 			require.NoError(t, err)
 			unlocks[i] = u
 		}

--- a/go/vt/vttablet/tabletserver/loadshed/snake_overload_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_overload_test.go
@@ -38,7 +38,7 @@ func TestSnake_Overload_RecoveryToHealthy(t *testing.T) {
 	s := NewSnake(cfg)
 
 	// Phase 1: overload — hold lock for a long time with waiters
-	unlock, err := s.Acquire(t.Context(), "")
+	unlock, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 
 	var wg sync.WaitGroup
@@ -46,7 +46,7 @@ func TestSnake_Overload_RecoveryToHealthy(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			u, err := s.Acquire(t.Context(), "")
+			u, err := s.Acquire(t.Context(), "", 0)
 			if err == nil {
 				u.Release()
 			}
@@ -66,7 +66,7 @@ func TestSnake_Overload_RecoveryToHealthy(t *testing.T) {
 	// Phase 3: verify function — uncontended acquires should succeed immediately
 	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
 	defer cancel()
-	u, err := s.Acquire(ctx, "")
+	u, err := s.Acquire(ctx, "", 0)
 	require.NoError(t, err, "post-recovery acquire should succeed quickly")
 	u.Release()
 }
@@ -76,7 +76,7 @@ func TestSnake_Overload_RecoveryToHealthy(t *testing.T) {
 func TestSnake_Overload_HolderKeepsQueueNonEmpty(t *testing.T) {
 	s := NewSnake(defaultSnakeConfig())
 
-	unlock, err := s.Acquire(t.Context(), "")
+	unlock, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 
 	// The holder stays at the head — queue length should be 1 even though
@@ -99,7 +99,7 @@ func TestSnake_Overload_HolderKeepsQueueNonEmpty(t *testing.T) {
 func TestSnake_Overload_MassCancel(t *testing.T) {
 	s := NewSnake(defaultSnakeConfig())
 
-	unlock, err := s.Acquire(t.Context(), "mass-cancel")
+	unlock, err := s.Acquire(t.Context(), "mass-cancel", 0)
 	require.NoError(t, err)
 
 	const n = 30
@@ -115,7 +115,7 @@ func TestSnake_Overload_MassCancel(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			u, err := s.Acquire(ctxs[idx], "mass-cancel")
+			u, err := s.Acquire(ctxs[idx], "mass-cancel", 0)
 			if err == nil {
 				u.Release()
 			}
@@ -143,7 +143,7 @@ func TestSnake_Overload_MassCancel(t *testing.T) {
 	assert.True(t, s.isIdle())
 
 	// Verify the lock is still usable
-	u, err := s.Acquire(t.Context(), "mass-cancel")
+	u, err := s.Acquire(t.Context(), "mass-cancel", 0)
 	require.NoError(t, err)
 	u.Release()
 }
@@ -194,7 +194,7 @@ func TestSnake_Overload_DropOnlyDroppable(t *testing.T) {
 		cfg.LoadsheddingAllowed = func() bool { return true }
 		s := NewSnake(cfg)
 
-		unlock, err := s.Acquire(t.Context(), "")
+		unlock, err := s.Acquire(t.Context(), "", 0)
 		require.NoError(t, err)
 
 		var wg sync.WaitGroup
@@ -203,7 +203,7 @@ func TestSnake_Overload_DropOnlyDroppable(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				u, err := s.Acquire(t.Context(), "")
+				u, err := s.Acquire(t.Context(), "", 0)
 				if err != nil {
 					dropped.Add(1)
 					return
@@ -227,7 +227,7 @@ func TestSnake_Overload_DropOnlyDroppable(t *testing.T) {
 		cfg.LoadsheddingAllowed = func() bool { return false }
 		s := NewSnake(cfg)
 
-		unlock, err := s.Acquire(t.Context(), "")
+		unlock, err := s.Acquire(t.Context(), "", 0)
 		require.NoError(t, err)
 
 		var wg sync.WaitGroup
@@ -236,7 +236,7 @@ func TestSnake_Overload_DropOnlyDroppable(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				u, err := s.Acquire(t.Context(), "")
+				u, err := s.Acquire(t.Context(), "", 0)
 				if err != nil {
 					dropped.Add(1)
 					return
@@ -309,7 +309,7 @@ func TestSnake_Overload_SelfContention_CrossIDDrops(t *testing.T) {
 	s := NewSnake(cfg)
 
 	// Hold the lock
-	unlock, err := s.Acquire(t.Context(), "holder")
+	unlock, err := s.Acquire(t.Context(), "holder", 0)
 	require.NoError(t, err)
 
 	const numIDs = 10
@@ -330,7 +330,7 @@ func TestSnake_Overload_SelfContention_CrossIDDrops(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				u, err := s.Acquire(t.Context(), results[idx].valveID)
+				u, err := s.Acquire(t.Context(), results[idx].valveID, 0)
 				if err != nil {
 					atomic.AddInt64(&results[idx].dropped, 1)
 					return
@@ -367,7 +367,7 @@ func TestSnake_Memory_CleanBaseline(t *testing.T) {
 
 	// Run many acquire/release cycles
 	for range 1000 {
-		u, err := s.Acquire(t.Context(), "cycle-id")
+		u, err := s.Acquire(t.Context(), "cycle-id", 0)
 		require.NoError(t, err)
 		u.Release()
 	}
@@ -392,7 +392,7 @@ func TestSnake_Memory_ManyDistinctValveIDs_Cleanup(t *testing.T) {
 
 	// Use many distinct valve IDs
 	for i := range 500 {
-		u, err := s.Acquire(t.Context(), fmt.Sprintf("distinct-%d", i))
+		u, err := s.Acquire(t.Context(), fmt.Sprintf("distinct-%d", i), 0)
 		require.NoError(t, err)
 		u.Release()
 	}
@@ -418,7 +418,7 @@ func TestSnake_Memory_CoDelStateTransition(t *testing.T) {
 	assert.True(t, s.IsHealthy())
 
 	// Create overload
-	unlock, err := s.Acquire(t.Context(), "")
+	unlock, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 
 	var wg sync.WaitGroup
@@ -426,7 +426,7 @@ func TestSnake_Memory_CoDelStateTransition(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			u, err := s.Acquire(t.Context(), "")
+			u, err := s.Acquire(t.Context(), "", 0)
 			if err == nil {
 				u.Release()
 			}
@@ -446,7 +446,7 @@ func TestSnake_Memory_CoDelStateTransition(t *testing.T) {
 	}, 2*time.Second, 10*time.Millisecond, "should recover to healthy after overload resolves")
 
 	// And still usable
-	u, err := s.Acquire(t.Context(), "")
+	u, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 	u.Release()
 }
@@ -462,7 +462,7 @@ func TestSnake_MaxAge_VsContextCancel_Race(t *testing.T) {
 	for range iterations {
 		ctx, cancel := context.WithTimeout(t.Context(), 4*time.Millisecond)
 
-		u, err := s.Acquire(ctx, "")
+		u, err := s.Acquire(ctx, "", 0)
 		if err != nil {
 			cancel()
 			continue
@@ -490,7 +490,7 @@ func TestSnake_Overload_GrantStall_ShedsDuringStall(t *testing.T) {
 	// Acquire the only slot (capacity defaults to 1). Once granted, this
 	// holder becomes undroppable and never releases — a stuck in-flight query
 	// that pins the semaphore.
-	holder, err := s.Acquire(t.Context(), "")
+	holder, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 
 	// Enqueue droppable waiters that can never be granted (capacity pinned)
@@ -502,7 +502,7 @@ func TestSnake_Overload_GrantStall_ShedsDuringStall(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			u, err := s.Acquire(t.Context(), "")
+			u, err := s.Acquire(t.Context(), "", 0)
 			if err != nil {
 				dropped.Add(1)
 				return
@@ -530,7 +530,7 @@ func TestSnake_Overload_GrantStall_ShedsDuringStall(t *testing.T) {
 func TestSnake_NoPanicOnConcurrentCancel(t *testing.T) {
 	s := NewSnake(defaultSnakeConfig())
 
-	unlock, err := s.Acquire(t.Context(), "no-panic")
+	unlock, err := s.Acquire(t.Context(), "no-panic", 0)
 	require.NoError(t, err)
 
 	const n = 50
@@ -542,7 +542,7 @@ func TestSnake_NoPanicOnConcurrentCancel(t *testing.T) {
 			defer wg.Done()
 			ctx, cancel := context.WithTimeout(t.Context(), 2*time.Millisecond)
 			defer cancel()
-			u, err := s.Acquire(ctx, "no-panic")
+			u, err := s.Acquire(ctx, "no-panic", 0)
 			if err == nil {
 				u.Release()
 			}

--- a/go/vt/vttablet/tabletserver/loadshed/snake_race_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_race_test.go
@@ -47,7 +47,7 @@ func TestSnake_CancelVsGrant_Race(t *testing.T) {
 	for range iterations {
 		s := newTestSnake(cfg)
 
-		unlockA, err := s.Acquire(t.Context(), "")
+		unlockA, err := s.Acquire(t.Context(), "", 0)
 		require.NoError(t, err)
 
 		ctx, cancel := context.WithCancel(t.Context())
@@ -60,7 +60,7 @@ func TestSnake_CancelVsGrant_Race(t *testing.T) {
 
 		go func() {
 			defer wg.Done()
-			unlockB, acquireErr = s.Acquire(ctx, "")
+			unlockB, acquireErr = s.Acquire(ctx, "", 0)
 		}()
 
 		runtime.Gosched()
@@ -83,7 +83,7 @@ func TestSnake_CancelVsGrant_Race(t *testing.T) {
 
 			// Verify lock is still usable.
 			ctx2, cancel2 := context.WithTimeout(t.Context(), 10*time.Millisecond)
-			unlockC, err2 := s.Acquire(ctx2, "")
+			unlockC, err2 := s.Acquire(ctx2, "", 0)
 			cancel2()
 			if assert.NoError(t, err2, "lock must remain acquirable") {
 				unlockC.Release()

--- a/go/vt/vttablet/tabletserver/loadshed/snake_stress_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_stress_test.go
@@ -43,7 +43,7 @@ func TestSnake_Stress_HighContention(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			u, err := s.Acquire(t.Context(), "")
+			u, err := s.Acquire(t.Context(), "", 0)
 			if err != nil {
 				return
 			}
@@ -78,7 +78,7 @@ func TestSnake_Stress_ContextCancellation(t *testing.T) {
 				time.Duration(1+rand.IntN(5))*time.Millisecond)
 			defer cancel()
 
-			u, err := s.Acquire(ctx, "")
+			u, err := s.Acquire(ctx, "", 0)
 			if err != nil {
 				cancelled.Add(1)
 				return
@@ -111,7 +111,7 @@ func TestSnake_Stress_MixedPriorities(t *testing.T) {
 	undroppableCfg.LoadsheddingAllowed = func() bool { return false }
 	undroppableSnake := NewSnake(undroppableCfg)
 
-	unlock, err := droppableSnake.Acquire(t.Context(), "")
+	unlock, err := droppableSnake.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 
 	var wg sync.WaitGroup
@@ -121,7 +121,7 @@ func TestSnake_Stress_MixedPriorities(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			u, err := droppableSnake.Acquire(t.Context(), "")
+			u, err := droppableSnake.Acquire(t.Context(), "", 0)
 			if err != nil {
 				droppableFailed.Add(1)
 				return
@@ -138,7 +138,7 @@ func TestSnake_Stress_MixedPriorities(t *testing.T) {
 	assert.Equal(t, int64(50), droppableSuccess.Load()+droppableFailed.Load())
 	assert.True(t, droppableSnake.isIdle())
 
-	unlock2, err := undroppableSnake.Acquire(t.Context(), "")
+	unlock2, err := undroppableSnake.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 
 	var undroppableSuccess atomic.Int64
@@ -146,7 +146,7 @@ func TestSnake_Stress_MixedPriorities(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			u, err := undroppableSnake.Acquire(t.Context(), "")
+			u, err := undroppableSnake.Acquire(t.Context(), "", 0)
 			if err != nil {
 				return
 			}
@@ -189,7 +189,7 @@ func TestSnake_Stress_SelfContention_MutualExclusion(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				u, err := s.Acquire(t.Context(), cid)
+				u, err := s.Acquire(t.Context(), cid, 0)
 				if err != nil {
 					return
 				}
@@ -226,7 +226,7 @@ func TestSnake_Stress_SelfContention_MutualExclusion(t *testing.T) {
 func TestSnake_Stress_SelfContention_ValveSerializationOrder(t *testing.T) {
 	s := NewSnake(defaultSnakeConfig())
 
-	unlock, err := s.Acquire(t.Context(), "order-test")
+	unlock, err := s.Acquire(t.Context(), "order-test", 0)
 	require.NoError(t, err)
 
 	const n = 20
@@ -240,7 +240,7 @@ func TestSnake_Stress_SelfContention_ValveSerializationOrder(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			u, err := s.Acquire(t.Context(), "order-test")
+			u, err := s.Acquire(t.Context(), "order-test", 0)
 			if err != nil {
 				return
 			}
@@ -270,7 +270,7 @@ func TestSnake_Stress_SelfContention_DropPromotionChain(t *testing.T) {
 	cfg.CoDel.MinDropDelayNs = func() int64 { return 1_000 } // 1us
 	s := NewSnake(cfg)
 
-	unlock, err := s.Acquire(t.Context(), "holder")
+	unlock, err := s.Acquire(t.Context(), "holder", 0)
 	require.NoError(t, err)
 
 	const numIDs = 5
@@ -289,7 +289,7 @@ func TestSnake_Stress_SelfContention_DropPromotionChain(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				u, err := s.Acquire(t.Context(), cid)
+				u, err := s.Acquire(t.Context(), cid, 0)
 				if err != nil {
 					results <- result{id: idx, granted: false}
 					return
@@ -328,7 +328,7 @@ func TestSnake_Stress_SelfContention_DropPromotionChain(t *testing.T) {
 func TestSnake_Stress_SelfContention_CancelInValve(t *testing.T) {
 	s := NewSnake(defaultSnakeConfig())
 
-	unlock, err := s.Acquire(t.Context(), "cancel-test")
+	unlock, err := s.Acquire(t.Context(), "cancel-test", 0)
 	require.NoError(t, err)
 
 	const n = 20
@@ -344,7 +344,7 @@ func TestSnake_Stress_SelfContention_CancelInValve(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			u, err := s.Acquire(ctxs[idx], "cancel-test")
+			u, err := s.Acquire(ctxs[idx], "cancel-test", 0)
 			if err != nil {
 				results[idx] <- err
 				return
@@ -408,7 +408,7 @@ func TestSnake_Stress_SelfContention_MixedCancelDropGrant(t *testing.T) {
 				ctx, cancel := context.WithTimeout(t.Context(), timeout)
 				defer cancel()
 
-				u, err := s.Acquire(ctx, cid)
+				u, err := s.Acquire(ctx, cid, 0)
 				if err != nil {
 					if ctx.Err() != nil {
 						cancelled.Add(1)
@@ -451,7 +451,7 @@ func TestSnake_Stress_SelfContention_HighConcurrency_Sustained(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				for time.Now().Before(deadline) {
-					u, err := s.Acquire(t.Context(), cid)
+					u, err := s.Acquire(t.Context(), cid, 0)
 					if err != nil {
 						continue
 					}
@@ -489,7 +489,7 @@ func TestSnake_Stress_RapidAcquireRelease(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for range 100 {
-				u, err := s.Acquire(t.Context(), "")
+				u, err := s.Acquire(t.Context(), "", 0)
 				if err != nil {
 					continue
 				}
@@ -518,7 +518,7 @@ func TestSnake_Stress_CancelAndGrant_Race(t *testing.T) {
 				cancel()
 			}()
 
-			u, err := s.Acquire(ctx, "")
+			u, err := s.Acquire(ctx, "", 0)
 			if err == nil {
 				time.Sleep(100 * time.Microsecond)
 				u.Release()
@@ -539,7 +539,7 @@ func TestSnake_Stress_DropTimerAndCancel_Race(t *testing.T) {
 	cfg.CoDel.MinDropDelayNs = func() int64 { return 1_000 } // 1us
 	s := NewSnake(cfg)
 
-	unlock, err := s.Acquire(t.Context(), "")
+	unlock, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 
 	var wg sync.WaitGroup
@@ -550,7 +550,7 @@ func TestSnake_Stress_DropTimerAndCancel_Race(t *testing.T) {
 			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Millisecond)
 			defer cancel()
 
-			u, err := s.Acquire(ctx, "")
+			u, err := s.Acquire(ctx, "", 0)
 			if err == nil {
 				u.Release()
 			}
@@ -578,7 +578,7 @@ func TestSnake_Stress_MaxAge_UnderLoad(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			u, err := s.Acquire(t.Context(), "")
+			u, err := s.Acquire(t.Context(), "", 0)
 			if err != nil {
 				return
 			}
@@ -609,7 +609,7 @@ func TestSnake_Stress_SelfContention_WithDrops(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			u, err := s.Acquire(t.Context(), cid)
+			u, err := s.Acquire(t.Context(), cid, 0)
 			if err != nil {
 				return
 			}
@@ -636,7 +636,7 @@ func TestSnake_Stress_GoroutineLeakDetector(t *testing.T) {
 			defer wg.Done()
 			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
 			defer cancel()
-			u, err := s.Acquire(ctx, "")
+			u, err := s.Acquire(ctx, "", 0)
 			if err == nil {
 				time.Sleep(time.Millisecond)
 				u.Release()
@@ -669,7 +669,7 @@ func TestSnake_Stress_NoStarvation(t *testing.T) {
 			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 			defer cancel()
 
-			u, err := s.Acquire(ctx, "")
+			u, err := s.Acquire(ctx, "", 0)
 			if err != nil {
 				return
 			}
@@ -695,7 +695,7 @@ func TestSnake_Stress_NoStarvation(t *testing.T) {
 func TestSnake_Stress_PromotionDuringCancel(t *testing.T) {
 	s := NewSnake(defaultSnakeConfig())
 
-	unlock, err := s.Acquire(t.Context(), "id1")
+	unlock, err := s.Acquire(t.Context(), "id1", 0)
 	require.NoError(t, err)
 
 	var wg sync.WaitGroup
@@ -707,7 +707,7 @@ func TestSnake_Stress_PromotionDuringCancel(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			u, err := s.Acquire(ctx, "id1")
+			u, err := s.Acquire(ctx, "id1", 0)
 			if err == nil {
 				time.Sleep(time.Millisecond)
 				u.Release()

--- a/go/vt/vttablet/tabletserver/loadshed/snake_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_test.go
@@ -879,10 +879,10 @@ func TestNewSnake_DefaultClock(t *testing.T) {
 	assert.True(t, s.isIdle())
 }
 
-// TestSnake_Priority_HonorsCallerKey confirms Snake enqueues the caller's
+// TestSnake_Priority_HonorsCallerPriority confirms Snake enqueues the caller's
 // priority unchanged when shedding is allowed. Snake is agnostic to the
 // caller's priority scheme; it only applies the LoadsheddingAllowed gate.
-func TestSnake_Priority_HonorsCallerKey(t *testing.T) {
+func TestSnake_Priority_HonorsCallerPriority(t *testing.T) {
 	s := newTestSnake(defaultSnakeConfig())
 
 	for _, priority := range []float64{0, 50, 100} {

--- a/go/vt/vttablet/tabletserver/loadshed/snake_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_test.go
@@ -62,7 +62,7 @@ func TestSnake_AcquireRelease_Basic(t *testing.T) {
 
 	assert.True(t, s.isIdle())
 
-	unlock, err := s.Acquire(t.Context(), "")
+	unlock, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 	assert.False(t, s.isIdle())
 
@@ -75,7 +75,7 @@ func TestSnake_AcquireRelease_Sequential(t *testing.T) {
 	s := newTestSnake(defaultSnakeConfig())
 
 	for range 10 {
-		unlock, err := s.Acquire(t.Context(), "")
+		unlock, err := s.Acquire(t.Context(), "", 0)
 		require.NoError(t, err)
 		assert.False(t, s.isIdle())
 
@@ -97,7 +97,7 @@ func TestSnake_MutualExclusion(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			unlock, err := s.Acquire(t.Context(), "")
+			unlock, err := s.Acquire(t.Context(), "", 0)
 			if err != nil {
 				return
 			}
@@ -119,7 +119,7 @@ func TestSnake_MutualExclusion(t *testing.T) {
 func TestSnake_FIFO_Order(t *testing.T) {
 	s := newTestSnake(defaultSnakeConfig())
 
-	unlock1, err := s.Acquire(t.Context(), "")
+	unlock1, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 
 	var mu sync.Mutex
@@ -132,7 +132,7 @@ func TestSnake_FIFO_Order(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			u, err := s.Acquire(t.Context(), "")
+			u, err := s.Acquire(t.Context(), "", 0)
 			if err != nil {
 				return
 			}
@@ -156,12 +156,12 @@ func TestSnake_FIFO_Order(t *testing.T) {
 func TestSnake_ReleaseWakesNext(t *testing.T) {
 	s := newTestSnake(defaultSnakeConfig())
 
-	unlock1, err := s.Acquire(t.Context(), "")
+	unlock1, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 
 	acquired := make(chan struct{})
 	go func() {
-		u, err := s.Acquire(t.Context(), "")
+		u, err := s.Acquire(t.Context(), "", 0)
 		if err == nil {
 			close(acquired)
 			u.Release()
@@ -188,14 +188,14 @@ func TestSnake_ReleaseWakesNext(t *testing.T) {
 func TestSnake_ContextCancellation(t *testing.T) {
 	s := newTestSnake(defaultSnakeConfig())
 
-	unlock, err := s.Acquire(t.Context(), "")
+	unlock, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(t.Context())
 
 	errCh := make(chan error, 1)
 	go func() {
-		_, err := s.Acquire(ctx, "")
+		_, err := s.Acquire(ctx, "", 0)
 		errCh <- err
 	}()
 
@@ -217,13 +217,13 @@ func TestSnake_ContextCancellation(t *testing.T) {
 func TestSnake_ContextTimeout(t *testing.T) {
 	s := newTestSnake(defaultSnakeConfig())
 
-	unlock, err := s.Acquire(t.Context(), "")
+	unlock, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
 	defer cancel()
 
-	_, err = s.Acquire(ctx, "")
+	_, err = s.Acquire(ctx, "", 0)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 
 	unlock.Release()
@@ -234,14 +234,14 @@ func TestSnake_ContextTimeout(t *testing.T) {
 func TestSnake_ContextCancel_RaceWithGrant(t *testing.T) {
 	s := newTestSnake(defaultSnakeConfig())
 
-	unlock1, err := s.Acquire(t.Context(), "")
+	unlock1, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(t.Context())
 
 	waiter2Done := make(chan error, 1)
 	go func() {
-		u, err := s.Acquire(ctx, "")
+		u, err := s.Acquire(ctx, "", 0)
 		if err == nil {
 			u.Release()
 		}
@@ -250,7 +250,7 @@ func TestSnake_ContextCancel_RaceWithGrant(t *testing.T) {
 
 	waiter3Done := make(chan struct{})
 	go func() {
-		u, err := s.Acquire(t.Context(), "")
+		u, err := s.Acquire(t.Context(), "", 0)
 		if err == nil {
 			u.Release()
 		}
@@ -282,7 +282,7 @@ func TestSnake_ContextCancel_RaceWithGrant(t *testing.T) {
 func TestSnake_SelfContention_Serialized(t *testing.T) {
 	s := newTestSnake(defaultSnakeConfig())
 
-	unlock1, err := s.Acquire(t.Context(), "id1")
+	unlock1, err := s.Acquire(t.Context(), "id1", 0)
 	require.NoError(t, err)
 
 	var mu sync.Mutex
@@ -295,7 +295,7 @@ func TestSnake_SelfContention_Serialized(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			u, err := s.Acquire(t.Context(), "id1")
+			u, err := s.Acquire(t.Context(), "id1", 0)
 			if err != nil {
 				return
 			}
@@ -316,7 +316,7 @@ func TestSnake_SelfContention_Serialized(t *testing.T) {
 func TestSnake_SelfContention_DifferentIDs_Independent(t *testing.T) {
 	s := newTestSnake(defaultSnakeConfig())
 
-	unlock1, err := s.Acquire(t.Context(), "")
+	unlock1, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 
 	acquired := make(chan struct{}, 2)
@@ -326,7 +326,7 @@ func TestSnake_SelfContention_DifferentIDs_Independent(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			u, err := s.Acquire(t.Context(), valveID)
+			u, err := s.Acquire(t.Context(), valveID, 0)
 			if err != nil {
 				return
 			}
@@ -351,13 +351,13 @@ func TestSnake_DroppedRequest(t *testing.T) {
 	cfg.CoDel.MinDropDelayNs = func() int64 { return 1 }
 	s := newTestSnake(cfg)
 
-	unlock, err := s.Acquire(t.Context(), "")
+	unlock, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 
 	errCh := make(chan error, 5)
 	for range 5 {
 		go func() {
-			_, err := s.Acquire(t.Context(), "")
+			_, err := s.Acquire(t.Context(), "", 0)
 			errCh <- err
 		}()
 	}
@@ -393,13 +393,13 @@ func TestSnake_SelfContention_NoDrop(t *testing.T) {
 	cfg.CoDel.MinDropDelayNs = func() int64 { return 1_000_000 } // 1ms
 	s := newTestSnake(cfg)
 
-	unlock, err := s.Acquire(t.Context(), "same-id")
+	unlock, err := s.Acquire(t.Context(), "same-id", 0)
 	require.NoError(t, err)
 
 	results := make(chan error, 3)
 	for range 3 {
 		go func() {
-			u, err := s.Acquire(t.Context(), "same-id")
+			u, err := s.Acquire(t.Context(), "same-id", 0)
 			if err == nil {
 				time.Sleep(1 * time.Millisecond)
 				u.Release()
@@ -428,12 +428,12 @@ func TestSnake_MaxAge_Timeout(t *testing.T) {
 	cfg.MaxAge = func() time.Duration { return 20 * time.Millisecond }
 	s := newTestSnake(cfg)
 
-	unlock1, err := s.Acquire(t.Context(), "")
+	unlock1, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 
 	acquired := make(chan struct{})
 	go func() {
-		u, err := s.Acquire(t.Context(), "")
+		u, err := s.Acquire(t.Context(), "", 0)
 		if err == nil {
 			close(acquired)
 			u.Release()
@@ -456,7 +456,7 @@ func TestSnake_MaxAge_CancelledOnRelease(t *testing.T) {
 	cfg.MaxAge = func() time.Duration { return 100 * time.Millisecond }
 	s := newTestSnake(cfg)
 
-	unlock, err := s.Acquire(t.Context(), "")
+	unlock, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 
 	unlock.Release()
@@ -470,7 +470,7 @@ func TestSnake_MaxAge_Zero_NoTimeout(t *testing.T) {
 	cfg.MaxAge = func() time.Duration { return 0 }
 	s := newTestSnake(cfg)
 
-	unlock, err := s.Acquire(t.Context(), "")
+	unlock, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 
 	time.Sleep(50 * time.Millisecond)
@@ -484,7 +484,7 @@ func TestSnake_MaxAge_Zero_NoTimeout(t *testing.T) {
 func TestSnake_SafeUnlock_DoubleRelease(t *testing.T) {
 	s := newTestSnake(defaultSnakeConfig())
 
-	unlock, err := s.Acquire(t.Context(), "")
+	unlock, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 
 	err = unlock.Release()
@@ -497,12 +497,12 @@ func TestSnake_SafeUnlock_DoubleRelease(t *testing.T) {
 func TestSnake_SafeUnlock_StaleNonce(t *testing.T) {
 	s := newTestSnake(defaultSnakeConfig())
 
-	unlock1, err := s.Acquire(t.Context(), "")
+	unlock1, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 
 	acquired := make(chan *SafeUnlock, 1)
 	go func() {
-		u, err := s.Acquire(t.Context(), "")
+		u, err := s.Acquire(t.Context(), "", 0)
 		if err == nil {
 			acquired <- u
 		}
@@ -534,7 +534,7 @@ func TestSnake_ReleaseCallbacks_Executed(t *testing.T) {
 	}
 	s := newTestSnake(cfg)
 
-	unlock, err := s.Acquire(t.Context(), "")
+	unlock, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 
 	unlock.Release()
@@ -549,7 +549,7 @@ func TestSnake_ReleaseCallbacks_ReceiveError(t *testing.T) {
 	}
 	s := newTestSnake(cfg)
 
-	unlock, err := s.Acquire(t.Context(), "")
+	unlock, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 
 	myErr := errors.New("test error")
@@ -574,7 +574,7 @@ func TestSnake_ReleaseCallbacks_NilOnNormalRelease(t *testing.T) {
 	}
 	s := newTestSnake(cfg)
 
-	unlock, err := s.Acquire(t.Context(), "")
+	unlock, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 
 	unlock.Release()
@@ -591,7 +591,7 @@ func TestSnake_ReleaseCallbacks_PanicRecovery(t *testing.T) {
 	}
 	s := newTestSnake(cfg)
 
-	unlock, err := s.Acquire(t.Context(), "")
+	unlock, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 
 	err = unlock.Release()
@@ -607,7 +607,7 @@ func TestSnake_ReleaseCallbacks_NoDeadlock(t *testing.T) {
 	}
 	s := newTestSnake(cfg)
 
-	unlock, err := s.Acquire(t.Context(), "")
+	unlock, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 
 	done := make(chan struct{})
@@ -631,7 +631,7 @@ func TestSnake_IsIdle_IsHealthy(t *testing.T) {
 	assert.True(t, s.isIdle())
 	assert.True(t, s.IsHealthy())
 
-	unlock, err := s.Acquire(t.Context(), "")
+	unlock, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 
 	assert.False(t, s.isIdle())
@@ -646,19 +646,19 @@ func TestSnake_IsIdle_IsHealthy(t *testing.T) {
 func TestSnake_CancelInCoDelQueue(t *testing.T) {
 	s := newTestSnake(defaultSnakeConfig())
 
-	unlock1, err := s.Acquire(t.Context(), "")
+	unlock1, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 
 	ctx2, cancel2 := context.WithCancel(t.Context())
 	waiter2Done := make(chan error, 1)
 	go func() {
-		_, err := s.Acquire(ctx2, "")
+		_, err := s.Acquire(ctx2, "", 0)
 		waiter2Done <- err
 	}()
 
 	waiter3Done := make(chan struct{})
 	go func() {
-		u, err := s.Acquire(t.Context(), "")
+		u, err := s.Acquire(t.Context(), "", 0)
 		if err == nil {
 			close(waiter3Done)
 			u.Release()
@@ -690,14 +690,14 @@ func TestSnake_CancelInCoDelQueue(t *testing.T) {
 func TestSnake_CancelInValve(t *testing.T) {
 	s := newTestSnake(defaultSnakeConfig())
 
-	unlock1, err := s.Acquire(t.Context(), "id1")
+	unlock1, err := s.Acquire(t.Context(), "id1", 0)
 	require.NoError(t, err)
 
 	ctx3, cancel3 := context.WithCancel(t.Context())
 
 	waiter2Done := make(chan struct{})
 	go func() {
-		u, err := s.Acquire(t.Context(), "id1")
+		u, err := s.Acquire(t.Context(), "id1", 0)
 		if err == nil {
 			u.Release()
 		}
@@ -708,7 +708,7 @@ func TestSnake_CancelInValve(t *testing.T) {
 
 	waiter3Done := make(chan error, 1)
 	go func() {
-		_, err := s.Acquire(ctx3, "id1")
+		_, err := s.Acquire(ctx3, "id1", 0)
 		waiter3Done <- err
 	}()
 
@@ -716,7 +716,7 @@ func TestSnake_CancelInValve(t *testing.T) {
 
 	waiter4Done := make(chan struct{})
 	go func() {
-		u, err := s.Acquire(t.Context(), "id1")
+		u, err := s.Acquire(t.Context(), "id1", 0)
 		if err == nil {
 			u.Release()
 		}
@@ -759,13 +759,13 @@ func TestSnake_Undroppable_NeverDropped(t *testing.T) {
 	cfg.LoadsheddingAllowed = func() bool { return false }
 	s := newTestSnake(cfg)
 
-	unlock, err := s.Acquire(t.Context(), "")
+	unlock, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 
 	results := make(chan error, 5)
 	for range 5 {
 		go func() {
-			u, err := s.Acquire(t.Context(), "")
+			u, err := s.Acquire(t.Context(), "", 0)
 			if err == nil {
 				u.Release()
 			}
@@ -797,13 +797,13 @@ func TestSnake_AcquireError_Custom(t *testing.T) {
 	cfg.AcquireError = func() error { return myErr }
 	s := newTestSnake(cfg)
 
-	unlock, err := s.Acquire(t.Context(), "")
+	unlock, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 
 	errCh := make(chan error, 3)
 	for range 3 {
 		go func() {
-			_, err := s.Acquire(t.Context(), "")
+			_, err := s.Acquire(t.Context(), "", 0)
 			errCh <- err
 		}()
 	}
@@ -838,7 +838,7 @@ func TestSnake_SelfContention_WithExceptions(t *testing.T) {
 	var mu sync.Mutex
 	var order []int
 
-	unlock1, err := s.Acquire(t.Context(), "id1")
+	unlock1, err := s.Acquire(t.Context(), "id1", 0)
 	require.NoError(t, err)
 
 	var wg sync.WaitGroup
@@ -848,7 +848,7 @@ func TestSnake_SelfContention_WithExceptions(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			u, err := s.Acquire(t.Context(), "id1")
+			u, err := s.Acquire(t.Context(), "id1", 0)
 			if err != nil {
 				return
 			}
@@ -871,10 +871,36 @@ func TestSnake_SelfContention_WithExceptions(t *testing.T) {
 func TestNewSnake_DefaultClock(t *testing.T) {
 	s := NewSnake(defaultSnakeConfig())
 
-	unlock, err := s.Acquire(t.Context(), "")
+	unlock, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 	assert.False(t, s.isIdle())
 
 	unlock.Release()
 	assert.True(t, s.isIdle())
+}
+
+// TestSnake_Priority_HonorsCallerKey confirms Snake enqueues the caller's
+// priority unchanged when shedding is allowed. Snake is agnostic to the
+// caller's priority scheme; it only applies the LoadsheddingAllowed gate.
+func TestSnake_Priority_HonorsCallerKey(t *testing.T) {
+	s := newTestSnake(defaultSnakeConfig())
+
+	for _, priority := range []float64{0, 50, 100} {
+		assert.Equal(t, priority, s.priority(priority),
+			"caller priority must pass through untouched when shedding is allowed")
+	}
+}
+
+// TestSnake_Priority_GateOverridesToUndroppable confirms that when shedding is
+// disallowed the caller's priority is ignored and the request is made
+// undroppable, regardless of how important the caller marked it.
+func TestSnake_Priority_GateOverridesToUndroppable(t *testing.T) {
+	cfg := defaultSnakeConfig()
+	cfg.LoadsheddingAllowed = func() bool { return false }
+	s := newTestSnake(cfg)
+
+	for _, priority := range []float64{0, 50, 100} {
+		assert.Equal(t, priorityUndroppable, s.priority(priority),
+			"a closed shedding gate must override any caller priority to undroppable")
+	}
 }

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -820,7 +820,10 @@ func (qre *QueryExecutor) getConn() (*connpool.PooledConn, func(), error) {
 	if snake != nil {
 		contentionID := qre.options.GetUniqueId()
 		if contentionID != "" {
-			unlock, err := snake.Acquire(ctx, contentionID)
+			// Translate the Vitess proto priority (0 = most important) into
+			// Snake's convention (higher priority shed last).
+			snakePriority := float64(sqlparser.MaxPriorityValue - qre.tsv.getPriorityFromOptions(qre.options))
+			unlock, err := snake.Acquire(ctx, contentionID, snakePriority)
 			if err != nil {
 				return nil, nil, vterrors.Errorf(vtrpcpb.Code_RESOURCE_EXHAUSTED, "load shed: %v", err)
 			}

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -597,7 +597,15 @@ func (tsv *TabletServer) begin(
 }
 
 func (tsv *TabletServer) getPriorityFromOptions(options *querypb.ExecuteOptions) int {
-	priority := tsv.config.TxThrottlerDefaultPriority
+	return priorityFromOptions(options, tsv.config.TxThrottlerDefaultPriority)
+}
+
+// priorityFromOptions resolves the ExecuteOptions priority, falling back to
+// defaultPriority when no usable value is present. It is shared by callers that
+// cannot reach a TabletServer (e.g. TxPool), so the parse-and-default logic
+// lives in one place.
+func priorityFromOptions(options *querypb.ExecuteOptions, defaultPriority int) int {
+	priority := defaultPriority
 	if options == nil {
 		return priority
 	}

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -600,10 +600,6 @@ func (tsv *TabletServer) getPriorityFromOptions(options *querypb.ExecuteOptions)
 	return priorityFromOptions(options, tsv.config.TxThrottlerDefaultPriority)
 }
 
-// priorityFromOptions resolves the ExecuteOptions priority, falling back to
-// defaultPriority when no usable value is present. It is shared by callers that
-// cannot reach a TabletServer (e.g. TxPool), so the parse-and-default logic
-// lives in one place.
 func priorityFromOptions(options *querypb.ExecuteOptions, defaultPriority int) int {
 	priority := defaultPriority
 	if options == nil {

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -2925,3 +2925,45 @@ func addTabletServerSupportedQueries(db *fakesqldb.DB) {
 		}},
 	})
 }
+
+func TestPriorityFromOptions(t *testing.T) {
+	const defaultPriority = 100
+
+	tests := []struct {
+		name    string
+		options *querypb.ExecuteOptions
+		want    int
+	}{
+		{
+			name:    "nil options uses default",
+			options: nil,
+			want:    defaultPriority,
+		},
+		{
+			name:    "empty priority string uses default",
+			options: &querypb.ExecuteOptions{Priority: ""},
+			want:    defaultPriority,
+		},
+		{
+			name:    "valid priority is parsed",
+			options: &querypb.ExecuteOptions{Priority: "0"},
+			want:    0,
+		},
+		{
+			name:    "valid mid-range priority is parsed",
+			options: &querypb.ExecuteOptions{Priority: "30"},
+			want:    30,
+		},
+		{
+			name:    "non-numeric priority falls back to default",
+			options: &querypb.ExecuteOptions{Priority: "not-a-number"},
+			want:    defaultPriority,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, priorityFromOptions(tt.options, defaultPriority))
+		})
+	}
+}

--- a/go/vt/vttablet/tabletserver/tx_pool.go
+++ b/go/vt/vttablet/tabletserver/tx_pool.go
@@ -255,7 +255,11 @@ func (tp *TxPool) Begin(ctx context.Context, options *querypb.ExecuteOptions, re
 
 		if tp.snake != nil {
 			if contentionID := options.GetUniqueId(); contentionID != "" {
-				unlock, snakeErr := tp.snake.Acquire(ctx, contentionID)
+				// Translate the Vitess proto priority (0 = most important) into
+				// Snake's convention (higher priority shed last).
+				protoPriority := priorityFromOptions(options, tp.env.Config().TxThrottlerDefaultPriority)
+				snakePriority := float64(sqlparser.MaxPriorityValue - protoPriority)
+				unlock, snakeErr := tp.snake.Acquire(ctx, contentionID, snakePriority)
 				if snakeErr != nil {
 					tp.limiter.Release(immediateCaller, effectiveCaller)
 					return nil, "", "", vterrors.Errorf(vtrpcpb.Code_RESOURCE_EXHAUSTED, "dml load shed: %v", snakeErr)


### PR DESCRIPTION
AI disclosure: Claude Code assisted with development. Every line of code was either written by or carefully reviewed by me :)

### Background / Why?

Snake (the CoDel-based load-shedding gate for vttablet conn pools) shed every request at the same priority, so under contention it had no way to preferentially drop less-important traffic. Vitess already carries a per-query priority on `ExecuteOptions` (the `PRIORITY` directive, `0` = most important, `sqlparser.MaxPriorityValue` = least important, the same value the tx throttler uses), but Snake never saw it.

This wires that priority through to both Snake entrypoints — `QueryExecutor.getConn` and `TxPool.Begin`. The design keeps the `loadshed` package completely agnostic to Vitess's priority convention: Snake's `Acquire` takes a priority in its *own* convention (lower priority shed first, higher shed last), and each caller translates the proto priority into it with `MaxPriorityValue - protoPriority`. The callers already import `sqlparser`, so `loadshed` keeps zero vitess-internal dependencies and no mirrored constant — the translation lives at the boundary, not inside the queue.

An earlier attempt did the inversion inside `loadshed` and mirrored `sqlparser.MaxPriorityValue` as a local constant to avoid the dependency; that coupled a generic CoDel queue to Vitess's specific 0–100 scale, so we moved the translation out to the entrypoints instead.

### Summary

- `Snake.Acquire` gains a `priority float64` parameter; `s.priority` now passes the caller's value through, still applying the `LoadsheddingAllowed` gate as the one place a request can be forced undroppable.
- Extracted the proto-priority parse-and-default logic out of `TabletServer.getPriorityFromOptions` into a package-level `priorityFromOptions(options, defaultPriority)` so `TxPool` — which cannot reach a `TabletServer` — can share it. Unmarked traffic defaults to `TxThrottlerDefaultPriority` (`MaxPriorityValue`), the least-important value, so it is the most sheddable.

### Testing

Added a table test for `priorityFromOptions` (nil / empty / valid / mid-range / non-numeric) and two tests pinning Snake's priority boundary: the caller's priority passes through when shedding is allowed, and a closed `LoadsheddingAllowed` gate overrides any priority to undroppable. Snake's own "lowest priority shed first" ordering is already covered by existing `codelq` tests. Ran the full `loadshed` suite and the new `tabletserver` test locally.