### PR TITLE
Characterize O(n) drop-scan cost as queue depth grows

### DIFF
--- a/go/vt/vttablet/tabletserver/loadshed/snake_depthscan_bench_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_depthscan_bench_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loadshed
+
+import (
+	"fmt"
+	"testing"
+)
+
+// depthScanDepths is the queue-depth axis swept by the benchmarks below. The
+// existing contention benchmark sweeps contender count at shallow depth, so it
+// never exercises lockedFindLowestPriorityDroppable (codelq.go:283) over a deep
+// queue. These depths push well past the {10, 100, 1000} of
+// BenchmarkCoDelQueue_FindLowestPriority so the O(n) shape is unambiguous.
+var depthScanDepths = []int{16, 64, 256, 1024, 4096, 16384, 65536}
+
+// BenchmarkSnake_DropScanDepth characterizes how the cost of the O(n)
+// lowest-priority drop scan grows with queue DEPTH.
+//
+// Design 1 (undroppable holders create depth). lockedFindLowestPriorityDroppable
+// walks the entire container/list (codelq.go:286 `for e := q.queue.Front()`).
+// Undroppable entries are skipped via `continue` (codelq.go:288) but are still
+// traversed by e.Next(), so they inflate the n the scan walks. This mirrors the
+// realistic "grant stall" regime exercised by
+// TestSnake_Overload_GrantStall_ShedsDuringStall: many granted (undroppable)
+// holders pin the queue while a droppable waiter must be located and shed.
+//
+// We measure two levels:
+//
+//   - ScanOnly: calls lockedFindLowestPriorityDroppable directly on a queue of
+//     D undroppable holders followed by a single droppable tail entry. Because
+//     the only droppable entry sits at the end and is not priority 0, the scan
+//     cannot early-exit (codelq.go:291) and must traverse all D+1 elements.
+//     This isolates the scan cost from timer scheduling and drop bookkeeping.
+//
+//   - DropPath: drives the full drop path (lockedRunScheduledDrop -> dropFn ->
+//     lockedFindLowestPriorityDroppable -> lockedDrop) once per op against a
+//     queue pre-populated with D undroppable holders and a fresh droppable tail.
+//     This includes the realistic per-drop work around the scan.
+//
+// We call the in-package scan/drop entry points directly rather than driving
+// the real Acquire path because the production drop is timer-driven
+// (time.AfterFunc in snake.go:277); forcing exactly one scan per timed
+// iteration synchronously through Acquire at depths up to 65536 is infeasible.
+// We are in package loadshed, so calling the locked* methods directly is the
+// honest way to put D entries in the list and trigger the scan deterministically.
+func BenchmarkSnake_DropScanDepth(b *testing.B) {
+	b.Run("ScanOnly", func(b *testing.B) {
+		for _, depth := range depthScanDepths {
+			b.Run(fmt.Sprintf("Depth%d", depth), func(b *testing.B) {
+				clock := newTestClock()
+				q, _ := newTestQueue(defaultTestConfig(), clock)
+
+				// D undroppable holders create depth without being eligible to
+				// drop. The scan still traverses every one of them.
+				for range depth {
+					q.lockedEnqueue(newRequest(priorityUndroppable))
+				}
+				// A single droppable entry at the tail with a non-zero priority,
+				// so the scan must walk the whole list to find it (no early exit).
+				q.lockedEnqueue(newRequest(1))
+
+				b.ResetTimer()
+				for range b.N {
+					if q.lockedFindLowestPriorityDroppable() == nil {
+						b.Fatal("expected a droppable entry")
+					}
+				}
+			})
+		}
+	})
+
+	b.Run("DropPath", func(b *testing.B) {
+		for _, depth := range depthScanDepths {
+			b.Run(fmt.Sprintf("Depth%d", depth), func(b *testing.B) {
+				clock := newTestClock()
+				cfg := CoDelConfig{
+					IntervalNs:     func() int64 { return 1_000_000 }, // 1ms
+					TargetNs:       func() int64 { return 1 },         // 1ns
+					MinDropDelayNs: func() int64 { return 100 },
+					Exponent:       func() float64 { return 1.0 },
+				}
+				q, _ := newTestQueue(cfg, clock)
+
+				// D undroppable holders that create depth and never leave.
+				for range depth {
+					q.lockedEnqueue(newRequest(priorityUndroppable))
+				}
+
+				// Force the dropping state so lockedRunScheduledDrop actually
+				// scans+drops rather than no-opping. dropNextNs in the past plus
+				// now advanced past it makes the drop loop fire.
+				q.dropping = true
+				q.count = 1
+
+				dropFn := func() bool {
+					elem := q.lockedFindLowestPriorityDroppable()
+					if elem == nil {
+						return false
+					}
+					q.lockedPopElem(elem, &DroppedRequestError{})
+					return true
+				}
+
+				b.ResetTimer()
+				for range b.N {
+					// Each op: add one droppable tail entry (non-zero priority so
+					// the scan can't early-exit), then run one scan+drop over the
+					// D-deep list. StopTimer fences the setup so only the
+					// scan+drop is timed.
+					b.StopTimer()
+					q.lockedEnqueue(newRequest(1))
+					q.dropping = true
+					q.count = 1
+					clock.now = 0
+					q.dropNextNs = -1 // in the past => drop loop fires immediately
+					b.StartTimer()
+
+					q.lockedRunScheduledDrop(dropFn)
+				}
+			})
+		}
+	})
+}


### PR DESCRIPTION
### Background / Why?

The existing contention benchmark in `snake_bench_test.go` sweeps contender count while the CoDel queue stays shallow, so it never exercises the cost dimension that actually matters for the lock-hold concern raised in RFC review: queue *depth*. When the queue is deep, every scheduled drop calls `lockedFindLowestPriorityDroppable` (codelq.go:283), which walks the entire `container/list` from front to back under the global Snake mutex. Granted (undroppable) holders are skipped with a `continue` (codelq.go:288) but are still traversed by `e.Next()`, so they count toward the n the scan walks. That is precisely the "grant stall" regime that `TestSnake_Overload_GrantStall_ShedsDuringStall` describes: many in-flight holders pin the queue while CoDel still has to locate and shed a droppable waiter on every drop. The existing `BenchmarkCoDelQueue_FindLowestPriority` only goes to depth 1000, which is too shallow to make the asymptotic behavior obvious.

This benchmark sweeps queue depth from 16 to 65536 so we can see whether per-drop cost grows linearly with depth, which is the regime relevant to an accumulation/pileup concern and which motivates the existing O(log n) TODO at codelq.go:281-282.

### Testing

Benchmark-only; no production code changes. Uses **Design 1** (depth created by undroppable holders, since the scan traverses the whole list including undroppable entries). Two levels are measured per depth in `depthScanDepths` = {16, 64, 256, 1024, 4096, 16384, 65536}:

- `ScanOnly` calls `lockedFindLowestPriorityDroppable` directly on a queue of D undroppable holders plus one droppable tail entry (non-zero priority, so the scan cannot early-exit at codelq.go:291 and must walk all D+1 elements).
- `DropPath` drives the full `lockedRunScheduledDrop` -> `dropFn` -> scan -> `lockedPopElem` path once per op against the same D-deep queue, forcing the dropping state so the drop loop fires.

The scan/drop entry points are called directly in-package rather than through `Acquire` because the production drop is timer-driven (`time.AfterFunc`), so forcing exactly one scan per timed iteration at depths up to 65536 is infeasible; calling the `locked*` methods is the deterministic way to put D entries in the list and trigger the scan.

Ran with `-benchtime 2000x` (fixed iteration count so deep cases finish and depths are directly comparable):

```
BenchmarkSnake_DropScanDepth/ScanOnly/Depth16-16        27.40 ns/op
BenchmarkSnake_DropScanDepth/ScanOnly/Depth64-16       135.3 ns/op
BenchmarkSnake_DropScanDepth/ScanOnly/Depth256-16      480.7 ns/op
BenchmarkSnake_DropScanDepth/ScanOnly/Depth1024-16    1828 ns/op
BenchmarkSnake_DropScanDepth/ScanOnly/Depth4096-16   12870 ns/op
BenchmarkSnake_DropScanDepth/ScanOnly/Depth16384-16  33267 ns/op
BenchmarkSnake_DropScanDepth/ScanOnly/Depth65536-16 136046 ns/op
BenchmarkSnake_DropScanDepth/DropPath/Depth16-16       206.4 ns/op
BenchmarkSnake_DropScanDepth/DropPath/Depth65536-16 140097 ns/op
```

ns/op per element stays roughly flat at ~2 ns/element across more than three orders of magnitude of depth, so the per-drop scan is **linear in queue depth** with no knee. `DropPath` tracks `ScanOnly` once D dominates the constant per-drop bookkeeping. This confirms the O(n) concern and motivates the O(log n) TODO at codelq.go:281-282.

AI disclosure: Claude Code assisted with development. Every line of code was either written by or carefully reviewed by me :)