### PR TITLE
Rename `snake-*` flags to `loadshed-*` and expose `--loadshed-exponent`

### DIFF
--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -190,6 +190,10 @@ Flags:
       --keep_logs_by_mtime duration                                      keep logs for this long (using mtime) (zero to keep forever)
       --keyspaces_to_watch strings                                       Specifies which keyspaces this vtgate should have access to while routing queries or accessing the vschema.
       --lameduck-period duration                                         keep running at least this long after SIGTERM before stopping (default 50ms)
+      --loadshed-enabled                                                 If true, enables CoDel-based load shedding on the OLTP read and transaction pools.
+      --loadshed-exponent float                                          CoDel control law exponent for the load shedder. (default 1)
+      --loadshed-interval duration                                       CoDel observation interval for the load shedder. Recommended to be 10-20x loadshed-target. (default 400ms)
+      --loadshed-target duration                                         CoDel target delay for the load shedder. (default 20ms)
       --lock-timeout duration                                            Maximum time to wait when attempting to acquire a lock from the topo server (default 45s)
       --lock_heartbeat_time duration                                     If there is lock function used. This will keep the lock connection active by using this heartbeat (default 5s)
       --lock_tables_timeout duration                                     How long to keep the table locked before timing out (default 1m0s)
@@ -339,9 +343,6 @@ Flags:
       --serving_state_grace_period duration                              how long to pause after broadcasting health to vtgate, before enforcing a new serving state
       --shard_sync_retry_delay duration                                  delay between retries of updates to keep the tablet and its shard record in sync (default 30s)
       --shutdown_grace_period duration                                   how long to wait for queries and transactions to complete during graceful shutdown. (default 3s)
-      --snake-enabled                                                    If true, enables CoDel-based load shedding (Snake) on the OLTP read pool.
-      --snake-interval duration                                          CoDel interval for the Snake load shedder. (default 100ms)
-      --snake-target duration                                            CoDel target delay for the Snake load shedder. (default 5ms)
       --sql-max-length-errors int                                        truncate queries in error logs to the given length (default unlimited)
       --sql-max-length-ui int                                            truncate queries in debug UIs to the given length (default 512) (default 512)
       --srv_topo_cache_refresh duration                                  how frequently to refresh the topology for cached entries (default 1s)

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -216,6 +216,10 @@ Flags:
       --keep_logs duration                                               keep logs for this long (using ctime) (zero to keep forever)
       --keep_logs_by_mtime duration                                      keep logs for this long (using mtime) (zero to keep forever)
       --lameduck-period duration                                         keep running at least this long after SIGTERM before stopping (default 50ms)
+      --loadshed-enabled                                                 If true, enables CoDel-based load shedding on the OLTP read and transaction pools.
+      --loadshed-exponent float                                          CoDel control law exponent for the load shedder. (default 1)
+      --loadshed-interval duration                                       CoDel observation interval for the load shedder. Recommended to be 10-20x loadshed-target. (default 400ms)
+      --loadshed-target duration                                         CoDel target delay for the load shedder. (default 20ms)
       --lock-timeout duration                                            Maximum time to wait when attempting to acquire a lock from the topo server (default 45s)
       --lock_tables_timeout duration                                     How long to keep the table locked before timing out (default 1m0s)
       --log_backtrace_at traceLocations                                  when logging hits line file:N, emit a stack trace
@@ -339,9 +343,6 @@ Flags:
       --serving_state_grace_period duration                              how long to pause after broadcasting health to vtgate, before enforcing a new serving state
       --shard_sync_retry_delay duration                                  delay between retries of updates to keep the tablet and its shard record in sync (default 30s)
       --shutdown_grace_period duration                                   how long to wait for queries and transactions to complete during graceful shutdown. (default 3s)
-      --snake-enabled                                                    If true, enables CoDel-based load shedding (Snake) on the OLTP read pool.
-      --snake-interval duration                                          CoDel interval for the Snake load shedder. (default 100ms)
-      --snake-target duration                                            CoDel target delay for the Snake load shedder. (default 5ms)
       --sql-max-length-errors int                                        truncate queries in error logs to the given length (default unlimited)
       --sql-max-length-ui int                                            truncate queries in debug UIs to the given length (default 512) (default 512)
       --srv_topo_cache_refresh duration                                  how frequently to refresh the topology for cached entries (default 1s)

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -245,13 +245,13 @@ func NewQueryEngine(env tabletenv.Env, se *schema.Engine) *QueryEngine {
 	}
 	qe.txSerializer = txserializer.New(env)
 
-	if config.SnakeEnabled {
+	if config.LoadshedEnabled {
 		qe.snake = loadshed.NewSnake(loadshed.SnakeConfig{
 			Name: "oltp-read",
 			CoDel: loadshed.CoDelConfig{
-				TargetNs:       func() int64 { return config.SnakeTarget.Nanoseconds() },
-				IntervalNs:     func() int64 { return config.SnakeInterval.Nanoseconds() },
-				Exponent:       func() float64 { return 1.0 },
+				TargetNs:       func() int64 { return config.LoadshedTarget.Nanoseconds() },
+				IntervalNs:     func() int64 { return config.LoadshedInterval.Nanoseconds() },
+				Exponent:       func() float64 { return config.LoadshedExponent },
 				MinDropDelayNs: func() int64 { return int64(time.Millisecond) },
 			},
 			Capacity:            func() int { return config.OltpReadPool.Size },

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1658,9 +1658,9 @@ func TestGetConnSnakeBypassed(t *testing.T) {
 	cfg := tabletenv.NewDefaultConfig()
 	cfg.OltpReadPool.Size = 2
 	cfg.TxPool.Size = 100
-	cfg.SnakeEnabled = true
-	cfg.SnakeTarget = 5 * time.Millisecond
-	cfg.SnakeInterval = 100 * time.Millisecond
+	cfg.LoadshedEnabled = true
+	cfg.LoadshedTarget = 5 * time.Millisecond
+	cfg.LoadshedInterval = 100 * time.Millisecond
 	cfg.DB = newDBConfigs(db)
 
 	srvTopoCounts := stats.NewCountersWithSingleLabel("", "Resilient srvtopo server operations", "type")
@@ -1691,9 +1691,9 @@ func TestGetConnWithSnake(t *testing.T) {
 	cfg := tabletenv.NewDefaultConfig()
 	cfg.OltpReadPool.Size = 2
 	cfg.TxPool.Size = 100
-	cfg.SnakeEnabled = true
-	cfg.SnakeTarget = 5 * time.Millisecond
-	cfg.SnakeInterval = 100 * time.Millisecond
+	cfg.LoadshedEnabled = true
+	cfg.LoadshedTarget = 5 * time.Millisecond
+	cfg.LoadshedInterval = 100 * time.Millisecond
 	cfg.DB = newDBConfigs(db)
 
 	srvTopoCounts := stats.NewCountersWithSingleLabel("", "Resilient srvtopo server operations", "type")
@@ -1703,7 +1703,7 @@ func TestGetConnWithSnake(t *testing.T) {
 	require.NoError(t, err)
 	defer tsv.StopService()
 
-	require.NotNil(t, tsv.qe.snake, "snake should be initialized when SnakeEnabled=true")
+	require.NotNil(t, tsv.qe.snake, "snake should be initialized when LoadshedEnabled=true")
 
 	input := "select * from test_table limit 1"
 
@@ -1725,7 +1725,7 @@ func TestGetConnSnakeDisabled(t *testing.T) {
 	tsv := newTestTabletServer(ctx, noFlags, db)
 	defer tsv.StopService()
 
-	assert.Nil(t, tsv.qe.snake, "snake should be nil when SnakeEnabled=false")
+	assert.Nil(t, tsv.qe.snake, "snake should be nil when LoadshedEnabled=false")
 
 	input := "select * from test_table limit 1"
 	qre := newTestQueryExecutor(ctx, tsv, input, 0)

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -80,7 +80,7 @@ var (
 	unhealthyThreshold           time.Duration
 	transitionGracePeriod        time.Duration
 	enableReplicationReporter    bool
-	enableSnake                  bool
+	enableLoadshed               bool
 )
 
 func init() {
@@ -225,9 +225,10 @@ func registerTabletEnvFlags(fs *pflag.FlagSet) {
 
 	fs.BoolVar(&currentConfig.Unmanaged, "unmanaged", false, "Indicates an unmanaged tablet, i.e. using an external mysql-compatible database")
 
-	fs.BoolVar(&enableSnake, "snake-enabled", false, "If true, enables CoDel-based load shedding (Snake) on the OLTP read pool.")
-	fs.DurationVar(&currentConfig.SnakeTarget, "snake-target", defaultConfig.SnakeTarget, "CoDel target delay for the Snake load shedder.")
-	fs.DurationVar(&currentConfig.SnakeInterval, "snake-interval", defaultConfig.SnakeInterval, "CoDel interval for the Snake load shedder.")
+	fs.BoolVar(&enableLoadshed, "loadshed-enabled", false, "If true, enables CoDel-based load shedding on the OLTP read and transaction pools.")
+	fs.DurationVar(&currentConfig.LoadshedTarget, "loadshed-target", defaultConfig.LoadshedTarget, "CoDel target delay for the load shedder.")
+	fs.DurationVar(&currentConfig.LoadshedInterval, "loadshed-interval", defaultConfig.LoadshedInterval, "CoDel observation interval for the load shedder. Recommended to be 10-20x loadshed-target.")
+	fs.Float64Var(&currentConfig.LoadshedExponent, "loadshed-exponent", defaultConfig.LoadshedExponent, "CoDel control law exponent for the load shedder.")
 }
 
 var (
@@ -300,7 +301,7 @@ func Init() {
 	currentConfig.GracePeriods.Transition = transitionGracePeriod
 	currentConfig.SemiSyncMonitor.Interval = semiSyncMonitorInterval
 
-	currentConfig.SnakeEnabled = enableSnake
+	currentConfig.LoadshedEnabled = enableLoadshed
 	logFormat := streamlog.GetQueryLogConfig().Format
 	switch logFormat {
 	case streamlog.QueryLogFormatText:
@@ -394,9 +395,10 @@ type TabletConfig struct {
 
 	EnablePerWorkloadTableMetrics bool `json:"-"`
 
-	SnakeEnabled  bool          `json:"-"`
-	SnakeTarget   time.Duration `json:"-"`
-	SnakeInterval time.Duration `json:"-"`
+	LoadshedEnabled  bool          `json:"-"`
+	LoadshedTarget   time.Duration `json:"-"`
+	LoadshedInterval time.Duration `json:"-"`
+	LoadshedExponent float64       `json:"-"`
 }
 
 func (cfg *TabletConfig) MarshalJSON() ([]byte, error) {
@@ -1149,8 +1151,9 @@ var defaultConfig = TabletConfig{
 
 	TwoPCAbandonAge: 15 * time.Minute,
 
-	SnakeTarget:   5 * time.Millisecond,
-	SnakeInterval: 100 * time.Millisecond,
+	LoadshedTarget:   20 * time.Millisecond,
+	LoadshedInterval: 400 * time.Millisecond,
+	LoadshedExponent: 1.0,
 }
 
 // defaultTxThrottlerConfig returns the default TxThrottlerConfigFlag object based on

--- a/go/vt/vttablet/tabletserver/tx_engine.go
+++ b/go/vt/vttablet/tabletserver/tx_engine.go
@@ -115,13 +115,13 @@ func NewTxEngine(env tabletenv.Env, dxNotifier func()) *TxEngine {
 	}
 	limiter := txlimiter.New(env)
 	te.txPool = NewTxPool(env, limiter)
-	if config.SnakeEnabled {
+	if config.LoadshedEnabled {
 		te.txPool.snake = loadshed.NewSnake(loadshed.SnakeConfig{
 			Name: "dml",
 			CoDel: loadshed.CoDelConfig{
-				TargetNs:       func() int64 { return config.SnakeTarget.Nanoseconds() },
-				IntervalNs:     func() int64 { return config.SnakeInterval.Nanoseconds() },
-				Exponent:       func() float64 { return 1.0 },
+				TargetNs:       func() int64 { return config.LoadshedTarget.Nanoseconds() },
+				IntervalNs:     func() int64 { return config.LoadshedInterval.Nanoseconds() },
+				Exponent:       func() float64 { return config.LoadshedExponent },
 				MinDropDelayNs: func() int64 { return int64(time.Millisecond) },
 			},
 			Capacity:            func() int { return config.TxPool.Size },


### PR DESCRIPTION
### Background / Why?

The [Query Admission Control RFC](https://salesforce.enterprise.slack.com/docs/T024BE7LD/F0B9GQVKLM7) defines the configuration surface for the load shedder (internally "Snake") as four flags, all under a `--loadshed-` prefix: `--loadshed-enabled`, `--loadshed-target`, `--loadshed-interval`, and `--loadshed-exponent`. The flags that actually shipped on the branch were named `--snake-*`, exposed only target and interval, and hardcoded the CoDel control law exponent to `1.0`. This brings the flag surface in line with the RFC so the names we test against in staging are the names we propose upstream, and so the exponent — which the RFC explicitly documents as a tunable for experimentation — is reachable without a recompile.

The `--loadshed-target`/`--loadshed-interval` flags are kept as Go `Duration` flags (e.g. `--loadshed-target=20ms`) rather than the RFC's literal `-ms` integer suffix, matching the idiom used by every other time-valued vttablet flag.

### Summary

- Rename the three `--snake-*` flags to `--loadshed-*`, along with their `TabletConfig` fields (`Snake*` → `Loadshed*`) and the `enableSnake` local.
- **Add `--loadshed-exponent`** (float, default `1.0`) and wire it into both the OLTP read pool (`query_engine.go`) and tx pool (`tx_engine.go`) CoDel configs, replacing the hardcoded `1.0`.
- Set defaults to the RFC's recommended values: target `20ms`, interval `400ms`, exponent `1.0`.
- Regenerate the `vttablet.txt` / `vtcombo.txt` golden flag files.
- No easing flags: the RFC explicitly specifies the easing behavior as non-configurable.

### Testing

`go build ./go/vt/vttablet/tabletserver/...` and the `loadshed`/snake-related tabletserver tests. Updated and ran the `TestHelpOutput/vttablet` and `TestHelpOutput/vtcombo` golden-flag tests to confirm the help output matches the regenerated `.txt` files.

AI disclosure: Claude Code assisted with development. Every line of code was either written by or carefully reviewed by me :)
