### PR TITLE
Export Snake load-shedder stats as per-pool Prometheus gauges

### DIFF
--- a/go/vt/vttablet/tabletserver/loadshed/snake_stats.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_stats.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loadshed
+
+import (
+	"vitess.io/vitess/go/stats"
+)
+
+// statsExporter is the subset of servenv.Exporter that PublishStats needs.
+// Declaring it here (rather than importing the concrete Exporter) keeps the
+// loadshed package free of a servenv dependency and lets tests pass a
+// throwaway exporter.
+type statsExporter interface {
+	NewGaugeFunc(name, help string, f func() int64) *stats.GaugeFunc
+}
+
+// PublishStats registers one GaugeFunc per SnakeStats field, each name prefixed
+// with prefix (e.g. "SnakeOltpRead" or "SnakeDml"). Call this once per Snake
+// instance from engine init — never from NewSnake, which is also exercised by
+// tests and the benchmark harness where duplicate registration would panic.
+//
+// Each Snake gets its own prefixed metric names rather than a shared "pool"
+// label: both the oltp-read and dml snakes register through the same tablet
+// Exporter, whose single label dimension is already the tablet name, so a
+// shared labeled gauge would collide on that one key.
+func PublishStats(exporter statsExporter, prefix string, s *Snake) {
+	exporter.NewGaugeFunc(prefix+"QueueLen", "Snake CoDel queue length (waiters)", func() int64 {
+		return int64(s.Stats().QueueLen)
+	})
+	exporter.NewGaugeFunc(prefix+"DroppableLen", "Snake CoDel droppable queue length", func() int64 {
+		return int64(s.Stats().DroppableLen)
+	})
+	exporter.NewGaugeFunc(prefix+"HolderCount", "Snake current slot holders", func() int64 {
+		return int64(s.Stats().HolderCount)
+	})
+	exporter.NewGaugeFunc(prefix+"Dropping", "Whether Snake CoDel is in the dropping state (1) or not (0)", func() int64 {
+		if s.Stats().Dropping {
+			return 1
+		}
+		return 0
+	})
+	exporter.NewGaugeFunc(prefix+"DropCount", "Snake CoDel drop count (control law state)", func() int64 {
+		return int64(s.Stats().DropCount)
+	})
+	exporter.NewGaugeFunc(prefix+"CurrentIntervalNs", "Snake CoDel current control interval in nanoseconds", func() int64 {
+		return s.Stats().CurrentInterval
+	})
+}

--- a/go/vt/vttablet/tabletserver/loadshed/snake_stats_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_stats_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loadshed
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/stats"
+)
+
+// fakeExporter captures the GaugeFuncs registered by PublishStats so the test
+// can invoke them directly, without touching global stats registration.
+type fakeExporter struct {
+	gauges map[string]func() int64
+}
+
+func newFakeExporter() *fakeExporter {
+	return &fakeExporter{gauges: make(map[string]func() int64)}
+}
+
+func (e *fakeExporter) NewGaugeFunc(name, _ string, f func() int64) *stats.GaugeFunc {
+	e.gauges[name] = f
+	return nil
+}
+
+func TestPublishStats_ReflectsSnakeState(t *testing.T) {
+	s := newTestSnake(defaultSnakeConfig())
+	exp := newFakeExporter()
+
+	PublishStats(exp, "SnakeOltpRead", s)
+
+	// All six fields are registered under the prefix.
+	for _, field := range []string{"QueueLen", "DroppableLen", "HolderCount", "Dropping", "DropCount", "CurrentIntervalNs"} {
+		_, ok := exp.gauges["SnakeOltpRead"+field]
+		assert.True(t, ok, "expected gauge SnakeOltpRead%s to be registered", field)
+	}
+
+	// Idle: no holders.
+	assert.Equal(t, int64(0), exp.gauges["SnakeOltpReadHolderCount"]())
+
+	// Acquire a slot (capacity defaults to 1) and confirm the gauge tracks it.
+	unlock, err := s.Acquire(t.Context(), "", 0)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), exp.gauges["SnakeOltpReadHolderCount"]())
+
+	// The gauge closure reads live Stats(), so it matches after release too.
+	require.NoError(t, unlock.Release())
+	assert.Equal(t, int64(s.Stats().HolderCount), exp.gauges["SnakeOltpReadHolderCount"]())
+
+	// CurrentIntervalNs mirrors the raw ns value from Stats (not a unit-converted one).
+	assert.Equal(t, s.Stats().CurrentInterval, exp.gauges["SnakeOltpReadCurrentIntervalNs"]())
+}
+
+func TestPublishStats_PrefixIsolation(t *testing.T) {
+	// Two snakes registered under different prefixes through the same exporter
+	// must not collide — this is the two-pool case (oltp-read vs dml).
+	exp := newFakeExporter()
+	PublishStats(exp, "SnakeOltpRead", newTestSnake(defaultSnakeConfig()))
+	PublishStats(exp, "SnakeDml", newTestSnake(defaultSnakeConfig()))
+
+	assert.Contains(t, exp.gauges, "SnakeOltpReadQueueLen")
+	assert.Contains(t, exp.gauges, "SnakeDmlQueueLen")
+	assert.Len(t, exp.gauges, 12, "expected 6 gauges per snake, two snakes")
+}

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -257,6 +257,7 @@ func NewQueryEngine(env tabletenv.Env, se *schema.Engine) *QueryEngine {
 			Capacity:            func() int { return config.OltpReadPool.Size },
 			LoadsheddingAllowed: func() bool { return true },
 		})
+		loadshed.PublishStats(env.Exporter(), "SnakeOltpRead", qe.snake)
 	}
 
 	qe.strictTableACL = config.StrictTableACL

--- a/go/vt/vttablet/tabletserver/tx_engine.go
+++ b/go/vt/vttablet/tabletserver/tx_engine.go
@@ -127,6 +127,7 @@ func NewTxEngine(env tabletenv.Env, dxNotifier func()) *TxEngine {
 			Capacity:            func() int { return config.TxPool.Size },
 			LoadsheddingAllowed: func() bool { return true },
 		})
+		loadshed.PublishStats(env.Exporter(), "SnakeDml", te.txPool.snake)
 	}
 	// We initially allow twoPC (handles vttablet restarts).
 	// We will disallow them for a few reasons -


### PR DESCRIPTION
### Background / Why?

We're load-testing the Snake load-shedder against QA Vitess via vtload, and right now Snake's internal CoDel state is invisible during those runs. The only place we can see queue depth, drop count, the dropping flag, and the current control interval is the in-repo benchmark harness, which runs Snake in-process and plots them from TSVs. In a real vttablet those numbers exist (`Snake.Stats()`) but are never published anywhere, so there's nothing for Grafana to graph.

This wires `Snake.Stats()` into the tablet's existing stats Exporter so the six CoDel-internal fields become ordinary Vitess metrics. Because they go through the standard Exporter, they ride the vttablet Prometheus scrape we already have — no new scrape config or monitoring-team involvement needed — and we can build a Grafana panel for queue depth / drop count / interval alongside the existing vttablet host view.

One wrinkle worth calling out: there are two Snake instances (the OLTP read pool and the DML/tx pool), and both register through the same tablet Exporter, whose single label dimension is already the tablet name. A shared `pool`-labeled gauge would collide on that key, so each instance gets its own prefixed metric names (`SnakeOltpRead*` / `SnakeDml*`) instead.

### Summary

- New `PublishStats` helper in the `loadshed` package registers one `GaugeFunc` per `SnakeStats` field through a minimal local exporter interface. Deliberately *not* inside `NewSnake`, which is also called by tests and the benchmark module where global registration would panic.
- Called once per Snake from the query-engine and tx-engine init blocks (both already gated on `LoadshedEnabled`).
- A follow-up will add a monotonic shed counter; this PR is the gauges only.

### Testing

New unit test (`snake_stats_test.go`) using a fake exporter that captures the registered `GaugeFunc`s: asserts each gauge reflects live `Snake.Stats()` (idle, after an acquire, after release), that `CurrentIntervalNs` passes the raw ns value through unconverted, and that two snakes under different prefixes register 12 distinct gauges without collision. Full `loadshed` package suite and `go vet` pass locally.