### PR TITLE
Sync `defaultConfig.LoadshedEnabled` with the flag default

### DIFF
--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -1151,6 +1151,7 @@ var defaultConfig = TabletConfig{
 
 	TwoPCAbandonAge: 15 * time.Minute,
 
+	LoadshedEnabled:  true,
 	LoadshedTarget:   20 * time.Millisecond,
 	LoadshedInterval: 400 * time.Millisecond,
 	LoadshedExponent: 1.0,


### PR DESCRIPTION
### Background / Why?

The earlier change that flipped `--loadshed-enabled` to default `true` updated the flag golden files (`vttablet.txt`, `vtcombo.txt`) but left `defaultConfig.LoadshedEnabled` implicitly `false`. `TestFlags` builds its expectation from `NewDefaultConfig()` and compares it against the flag-populated `currentConfig`, so the two now disagree and the test fails:

```
- LoadshedEnabled: (bool) false,
+ LoadshedEnabled: (bool) true,
```

This sets `LoadshedEnabled: true` explicitly in `defaultConfig` so `NewDefaultConfig()` matches the flag default and the struct-level config invariant holds.

### Testing

`go test ./go/vt/vttablet/tabletserver/tabletenv/ -run TestFlags` passes with the fix (fails without it).