### PR TITLE
Count Snake-shed requests with a monotonic per-pool `ShedCount`

### DIFF
--- a/go/vt/vttablet/tabletserver/loadshed/snake.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"log"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -52,6 +53,11 @@ type (
 		dropTimerArmed bool
 		cfg            SnakeConfig
 		clockFunc      func() int64
+
+		// shedCount counts requests this Snake has shed (rejected by the CoDel
+		// gate). It excludes context cancellations, which are the caller giving
+		// up rather than the gate shedding. Read lock-free via ShedCount.
+		shedCount atomic.Int64
 	}
 
 	// SafeUnlock is a handle for releasing a slot. Only the goroutine that
@@ -260,10 +266,17 @@ func (s *Snake) priority(priority float64) float64 {
 }
 
 func (s *Snake) acquireError() error {
+	s.shedCount.Add(1)
 	if s.cfg.AcquireError != nil {
 		return s.cfg.AcquireError()
 	}
 	return &DroppedRequestError{}
+}
+
+// ShedCount returns the cumulative number of requests this Snake has shed.
+// Context cancellations are not counted — only gate-driven drops.
+func (s *Snake) ShedCount() int64 {
+	return s.shedCount.Load()
 }
 
 // --- timer management (must be called with s.mu held) ---

--- a/go/vt/vttablet/tabletserver/loadshed/snake_stats.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_stats.go
@@ -26,6 +26,7 @@ import (
 // throwaway exporter.
 type statsExporter interface {
 	NewGaugeFunc(name, help string, f func() int64) *stats.GaugeFunc
+	NewCounterFunc(name, help string, f func() int64) *stats.CounterFunc
 }
 
 // PublishStats registers one GaugeFunc per SnakeStats field, each name prefixed
@@ -58,5 +59,8 @@ func PublishStats(exporter statsExporter, prefix string, s *Snake) {
 	})
 	exporter.NewGaugeFunc(prefix+"CurrentIntervalNs", "Snake CoDel current control interval in nanoseconds", func() int64 {
 		return s.Stats().CurrentInterval
+	})
+	exporter.NewCounterFunc(prefix+"ShedCount", "Cumulative requests shed by the Snake load shedder", func() int64 {
+		return s.ShedCount()
 	})
 }

--- a/go/vt/vttablet/tabletserver/loadshed/snake_stats_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_stats_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package loadshed
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,18 +27,28 @@ import (
 	"vitess.io/vitess/go/stats"
 )
 
-// fakeExporter captures the GaugeFuncs registered by PublishStats so the test
-// can invoke them directly, without touching global stats registration.
+// fakeExporter captures the GaugeFuncs and CounterFuncs registered by
+// PublishStats so the test can invoke them directly, without touching global
+// stats registration.
 type fakeExporter struct {
-	gauges map[string]func() int64
+	gauges   map[string]func() int64
+	counters map[string]func() int64
 }
 
 func newFakeExporter() *fakeExporter {
-	return &fakeExporter{gauges: make(map[string]func() int64)}
+	return &fakeExporter{
+		gauges:   make(map[string]func() int64),
+		counters: make(map[string]func() int64),
+	}
 }
 
 func (e *fakeExporter) NewGaugeFunc(name, _ string, f func() int64) *stats.GaugeFunc {
 	e.gauges[name] = f
+	return nil
+}
+
+func (e *fakeExporter) NewCounterFunc(name, _ string, f func() int64) *stats.CounterFunc {
+	e.counters[name] = f
 	return nil
 }
 
@@ -78,4 +90,73 @@ func TestPublishStats_PrefixIsolation(t *testing.T) {
 	assert.Contains(t, exp.gauges, "SnakeOltpReadQueueLen")
 	assert.Contains(t, exp.gauges, "SnakeDmlQueueLen")
 	assert.Len(t, exp.gauges, 12, "expected 6 gauges per snake, two snakes")
+
+	assert.Contains(t, exp.counters, "SnakeOltpReadShedCount")
+	assert.Contains(t, exp.counters, "SnakeDmlShedCount")
+	assert.Len(t, exp.counters, 2, "expected 1 shed counter per snake, two snakes")
+}
+
+func TestPublishStats_ShedCountTracksDrops(t *testing.T) {
+	cfg := defaultSnakeConfig()
+	cfg.CoDel.IntervalNs = func() int64 { return 1_000 }
+	cfg.CoDel.TargetNs = func() int64 { return 1 }
+	cfg.CoDel.MinDropDelayNs = func() int64 { return 1 }
+	s := newTestSnake(cfg)
+
+	exp := newFakeExporter()
+	PublishStats(exp, "SnakeOltpRead", s)
+	shedGauge := exp.counters["SnakeOltpReadShedCount"]
+	require.NotNil(t, shedGauge)
+
+	assert.Equal(t, int64(0), shedGauge(), "no sheds before any contention")
+
+	// Hold the single slot, then pile on contending acquires so CoDel drops some.
+	unlock, err := s.Acquire(t.Context(), "", 0)
+	require.NoError(t, err)
+
+	errCh := make(chan error, 5)
+	for range 5 {
+		go func() {
+			_, err := s.Acquire(t.Context(), "", 0)
+			errCh <- err
+		}()
+	}
+	time.Sleep(200 * time.Millisecond)
+	unlock.Release()
+
+	dropped := 0
+	for range 5 {
+		select {
+		case err := <-errCh:
+			if err != nil {
+				dropped++
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("goroutine did not return")
+		}
+	}
+	require.Greater(t, dropped, 0, "CoDel should have dropped some requests")
+	assert.Equal(t, int64(dropped), shedGauge(), "shed counter should equal the number of dropped requests")
+}
+
+func TestPublishStats_ShedCountIgnoresContextCancellation(t *testing.T) {
+	s := newTestSnake(defaultSnakeConfig()) // capacity 1
+
+	exp := newFakeExporter()
+	PublishStats(exp, "SnakeOltpRead", s)
+	shedGauge := exp.counters["SnakeOltpReadShedCount"]
+
+	// Occupy the only slot so the next acquire must wait.
+	unlock, err := s.Acquire(t.Context(), "", 0)
+	require.NoError(t, err)
+	defer unlock.Release()
+
+	// A second acquire whose context is cancelled returns ctx.Err(), which is
+	// the caller giving up — not a gate shed — so it must not be counted.
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err = s.Acquire(ctx, "", 0)
+	require.Error(t, err)
+
+	assert.Equal(t, int64(0), shedGauge(), "context cancellation must not count as a shed")
 }


### PR DESCRIPTION
### Background / Why?

When Snake sheds a request, nothing counts it server-side — the only shed signal today lives in the in-repo benchmark harness. For a load test, the rate of shed requests is the headline number: it's what tells us Snake is doing its job under spike load.

This adds a monotonic shed counter that Snake increments itself, in `acquireError()` — the single funnel for gate-driven drops. Crucially, context cancellations return `ctx.Err()` without passing through that funnel, so they're correctly excluded: a cancellation is the caller giving up, not the gate shedding. `PublishStats` exports it as a per-pool `CounterFunc` (`SnakeOltpReadShedCount` / `SnakeDmlShedCount`), riding the same vttablet Prometheus scrape as the gauges.

**Why a separate counter when CoDel already has a drop count?** They measure different things. The CoDel `DropCount` gauge is non-monotonic control-law *state* — it rises while the queue is dropping and decays during easing — so it can't answer "how many requests were rejected." `ShedCount` is the monotonic, client-facing tally of rejected requests, which is what a shed-rate panel (`rate(ShedCount)`) needs.

Keeping the counter inside Snake leaves `tabletenv.Stats` and the query/tx callers untouched.

### Testing

New tests in `snake_stats_test.go`: one drives CoDel into dropping and asserts the exported counter equals the number of dropped requests; another confirms a context-cancelled acquire does **not** increment the counter. Full `loadshed` package suite, `go vet`, and `gofmt` all clean locally.