### PR TITLE
Disable loadshed in the shared test tablet helper

### DIFF
--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1783,6 +1783,9 @@ func newTestTabletServer(ctx context.Context, flags executorFlags, db *fakesqldb
 	} else {
 		cfg.Consolidator = tabletenv.Disable
 	}
+	// Loadshed defaults to on, but the shared test tablet should leave Snake
+	// disabled unless a test opts in (TestGetConnWithSnake builds its own config).
+	cfg.LoadshedEnabled = false
 	dbconfigs := newDBConfigs(db)
 	cfg.DB = dbconfigs
 	srvTopoCounts := stats.NewCountersWithSingleLabel("", "Resilient srvtopo server operations", "type")


### PR DESCRIPTION
### Background / Why?

Flipping `--loadshed-enabled` to default `true` had a test-side ripple: `newTestTabletServer` builds its config from `NewDefaultConfig()` and never overrides loadshed, so every tablet it constructs now comes up with Snake enabled. `TestGetConnSnakeDisabled` asserts `tsv.qe.snake` is nil "when LoadshedEnabled=false" — but it gets a non-nil snake and fails:

```
query_executor_test.go:1728: snake should be nil when LoadshedEnabled=false
```

The fix sets `cfg.LoadshedEnabled = false` explicitly in the shared helper, restoring the behavior the many tests using it relied on before the default flip. Tests that actually want Snake on (`TestGetConnWithSnake`) already build their own config with `LoadshedEnabled = true`, so they're unaffected.

### Testing

`go test ./go/vt/vttablet/tabletserver/ -run 'TestGetConnSnakeDisabled|TestGetConnWithSnake'` — both pass.