### PR TITLE
Gate vttablet conns through Snake even without a valve ID

### DIFF
--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -818,22 +818,24 @@ func (qre *QueryExecutor) getConn() (*connpool.PooledConn, func(), error) {
 
 	snake := qre.tsv.qe.snake
 	if snake != nil {
-		contentionID := qre.options.GetUniqueId()
-		if contentionID != "" {
-			// Translate the Vitess proto priority (0 = most important) into
-			// Snake's convention (higher priority shed last).
-			snakePriority := float64(sqlparser.MaxPriorityValue - qre.tsv.getPriorityFromOptions(qre.options))
-			unlock, err := snake.Acquire(ctx, contentionID, snakePriority)
-			if err != nil {
-				return nil, nil, vterrors.Errorf(vtrpcpb.Code_RESOURCE_EXHAUSTED, "load shed: %v", err)
-			}
-			conn, err := qre.tsv.qe.conns.Get(ctx, qre.setting)
-			if err != nil {
-				unlock.Release()
-				return nil, nil, err
-			}
-			return conn, func() { unlock.Release() }, nil
+		// An empty valve ID is valid: such requests bypass the per-valve
+		// fairness layer but still pass through the CoDel gate. Gating the
+		// acquire on a non-empty ID would silently exclude all unkeyed traffic
+		// from load shedding.
+		valveID := qre.options.GetUniqueId()
+		// Translate the Vitess proto priority (0 = most important) into
+		// Snake's convention (higher priority shed last).
+		snakePriority := float64(sqlparser.MaxPriorityValue - qre.tsv.getPriorityFromOptions(qre.options))
+		unlock, err := snake.Acquire(ctx, valveID, snakePriority)
+		if err != nil {
+			return nil, nil, vterrors.Errorf(vtrpcpb.Code_RESOURCE_EXHAUSTED, "load shed: %v", err)
 		}
+		conn, err := qre.tsv.qe.conns.Get(ctx, qre.setting)
+		if err != nil {
+			unlock.Release()
+			return nil, nil, err
+		}
+		return conn, func() { unlock.Release() }, nil
 	}
 
 	conn, err := qre.tsv.qe.conns.Get(ctx, qre.setting)

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1650,7 +1650,7 @@ func TestGetConnectionLogStats(t *testing.T) {
 	assert.True(t, qre.logStats.WaitingForConnection > 0)
 }
 
-func TestGetConnSnakeBypassed(t *testing.T) {
+func TestGetConnSnakeEmptyValveID(t *testing.T) {
 	db := setUpQueryExecutorTest(t)
 	defer db.Close()
 
@@ -1674,13 +1674,22 @@ func TestGetConnSnakeBypassed(t *testing.T) {
 
 	input := "select * from test_table limit 1"
 
-	// Without UniqueId set, Snake gate is bypassed entirely
+	// Without a valve ID the request still passes through the Snake gate
+	// (entering the CoDel queue directly, bypassing only the per-valve layer)
+	// and is admitted when capacity is available.
 	qre := newTestQueryExecutor(ctx, tsv, input, 0)
 	conn, release, err := qre.getConn()
 	require.NoError(t, err)
 	require.NotNil(t, conn)
+
+	// While the slot is held, the gate reports one holder — proof that Acquire
+	// ran on the empty valve ID rather than being skipped.
+	assert.Equal(t, 1, tsv.qe.snake.Stats().HolderCount, "empty valve ID should still acquire a Snake slot")
+
 	conn.Recycle()
 	release()
+
+	assert.Equal(t, 0, tsv.qe.snake.Stats().HolderCount, "slot should be released after getConn cleanup")
 }
 
 func TestGetConnWithSnake(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/tx_pool.go
+++ b/go/vt/vttablet/tabletserver/tx_pool.go
@@ -254,18 +254,21 @@ func (tp *TxPool) Begin(ctx context.Context, options *querypb.ExecuteOptions, re
 		}
 
 		if tp.snake != nil {
-			if contentionID := options.GetUniqueId(); contentionID != "" {
-				// Translate the Vitess proto priority (0 = most important) into
-				// Snake's convention (higher priority shed last).
-				protoPriority := priorityFromOptions(options, tp.env.Config().TxThrottlerDefaultPriority)
-				snakePriority := float64(sqlparser.MaxPriorityValue - protoPriority)
-				unlock, snakeErr := tp.snake.Acquire(ctx, contentionID, snakePriority)
-				if snakeErr != nil {
-					tp.limiter.Release(immediateCaller, effectiveCaller)
-					return nil, "", "", vterrors.Errorf(vtrpcpb.Code_RESOURCE_EXHAUSTED, "dml load shed: %v", snakeErr)
-				}
-				snakeRelease = func() { unlock.Release() }
+			// An empty valve ID is valid: such requests bypass the per-valve
+			// fairness layer but still pass through the CoDel gate. Gating the
+			// acquire on a non-empty ID would silently exclude all unkeyed
+			// traffic from load shedding.
+			valveID := options.GetUniqueId()
+			// Translate the Vitess proto priority (0 = most important) into
+			// Snake's convention (higher priority shed last).
+			protoPriority := priorityFromOptions(options, tp.env.Config().TxThrottlerDefaultPriority)
+			snakePriority := float64(sqlparser.MaxPriorityValue - protoPriority)
+			unlock, snakeErr := tp.snake.Acquire(ctx, valveID, snakePriority)
+			if snakeErr != nil {
+				tp.limiter.Release(immediateCaller, effectiveCaller)
+				return nil, "", "", vterrors.Errorf(vtrpcpb.Code_RESOURCE_EXHAUSTED, "dml load shed: %v", snakeErr)
 			}
+			snakeRelease = func() { unlock.Release() }
 		}
 
 		conn, err = tp.createConn(ctx, options, setting)

--- a/go/vt/vttablet/tabletserver/tx_pool_snake_test.go
+++ b/go/vt/vttablet/tabletserver/tx_pool_snake_test.go
@@ -147,30 +147,23 @@ func TestTxPoolSnake_RollbackReleasesSlot(t *testing.T) {
 	conn4.Release(tx.TxCommit)
 }
 
-func TestTxPoolSnake_EmptyUniqueIdBypassesSnake(t *testing.T) {
-	_, txPool, closer := setupWithSnake(t, 1)
+func TestTxPoolSnake_EmptyUniqueIdAcquiresSlot(t *testing.T) {
+	_, txPool, closer := setupWithSnake(t, 2)
 	defer closer()
 
 	ctx := context.Background()
 
-	// Fill the single slot with a tagged request.
-	conn, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{UniqueId: "req-1"}, false, 0, nil)
+	// A request with no UniqueId still acquires a Snake slot — it enters the
+	// CoDel queue directly, bypassing only the per-valve fairness layer.
+	conn, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
 	require.NoError(t, err)
+	assert.NotNil(t, conn.TxProperties().SnakeRelease, "empty valve ID should still acquire a Snake slot")
 	conn.Unlock()
-
-	// A request with no UniqueId should bypass the snake entirely.
-	conn2, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
-	require.NoError(t, err)
-	assert.Nil(t, conn2.TxProperties().SnakeRelease)
-	conn2.Unlock()
 
 	// Cleanup.
 	c, _ := txPool.GetAndLock(conn.ReservedID(), "")
 	_, _ = txPool.Commit(ctx, c)
 	c.Release(tx.TxCommit)
-	c2, _ := txPool.GetAndLock(conn2.ReservedID(), "")
-	_, _ = txPool.Commit(ctx, c2)
-	c2.Release(tx.TxCommit)
 }
 
 func TestTxPoolSnake_ReservedConnSkipsSnake(t *testing.T) {


### PR DESCRIPTION
Brings us into consistency with the RFC