### PR TITLE
Track live pool capacity in Snake load-shedder gates

### DIFF
--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -254,10 +254,8 @@ func NewQueryEngine(env tabletenv.Env, se *schema.Engine) *QueryEngine {
 				Exponent:       func() float64 { return config.LoadshedExponent },
 				MinDropDelayNs: func() int64 { return int64(time.Millisecond) },
 			},
-			// Track the pool's live capacity so runtime resizes (e.g. via
-			// /debug/env SetPoolSize) keep the gate in lockstep with the pool.
-			// Capacity() reports 0 until the pool is opened, so fall back to the
-			// configured size during that startup window to avoid throttling to 1.
+			// Track live pool capacity so runtime resizes keep the gate in sync.
+			// Capacity() is 0 until the pool opens; fall back to config until then.
 			Capacity: func() int {
 				if c := int(qe.conns.Capacity()); c > 0 {
 					return c

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -254,7 +254,16 @@ func NewQueryEngine(env tabletenv.Env, se *schema.Engine) *QueryEngine {
 				Exponent:       func() float64 { return config.LoadshedExponent },
 				MinDropDelayNs: func() int64 { return int64(time.Millisecond) },
 			},
-			Capacity:            func() int { return config.OltpReadPool.Size },
+			// Track the pool's live capacity so runtime resizes (e.g. via
+			// /debug/env SetPoolSize) keep the gate in lockstep with the pool.
+			// Capacity() reports 0 until the pool is opened, so fall back to the
+			// configured size during that startup window to avoid throttling to 1.
+			Capacity: func() int {
+				if c := int(qe.conns.Capacity()); c > 0 {
+					return c
+				}
+				return config.OltpReadPool.Size
+			},
 			LoadsheddingAllowed: func() bool { return true },
 		})
 		loadshed.PublishStats(env.Exporter(), "SnakeOltpRead", qe.snake)

--- a/go/vt/vttablet/tabletserver/snake_capacity_test.go
+++ b/go/vt/vttablet/tabletserver/snake_capacity_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tabletserver
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql/fakesqldb"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/loadshed"
+)
+
+// acquireN acquires count slots from the snake, failing the test if any acquire
+// is shed or blocked. The returned unlocks must be released by the caller.
+func acquireN(t *testing.T, s *loadshed.Snake, count int) []*loadshed.SafeUnlock {
+	t.Helper()
+	unlocks := make([]*loadshed.SafeUnlock, count)
+	for i := range count {
+		u, err := s.Acquire(t.Context(), "", 0)
+		require.NoErrorf(t, err, "acquire %d of %d should be granted", i+1, count)
+		unlocks[i] = u
+	}
+	return unlocks
+}
+
+// acquireBlocks reports whether a single acquire blocks (rather than being
+// granted) within a short window. A granted slot is released immediately.
+func acquireBlocks(s *loadshed.Snake) bool {
+	granted := make(chan *loadshed.SafeUnlock, 1)
+	go func() {
+		u, err := s.Acquire(context.Background(), "", 0)
+		if err == nil {
+			granted <- u
+		}
+	}()
+	select {
+	case u := <-granted:
+		u.Release()
+		return false
+	case <-time.After(50 * time.Millisecond):
+		return true
+	}
+}
+
+// TestSnakeCapacity_TracksLivePoolResize verifies that shrinking the oltp-read
+// pool at runtime (as /debug/env SetPoolSize does) also lowers the snake's
+// effective gate capacity. Before this wiring the snake read the static
+// configured size, so a live pool resize left the gate admitting at the old
+// ceiling while the smaller pool queued the overflow.
+func TestSnakeCapacity_TracksLivePoolResize(t *testing.T) {
+	db := fakesqldb.New(t)
+	defer db.Close()
+
+	qe := newTestQueryEngine(10*time.Second, true, newDBConfigs(db))
+	qe.se.Open()
+	qe.Open()
+	defer qe.Close()
+
+	require.NotNil(t, qe.snake, "loadshed should be enabled by default in tests")
+
+	// Shrink the live pool below the configured size.
+	require.NoError(t, qe.conns.SetCapacity(context.Background(), 2))
+
+	// The gate should now admit exactly the live capacity (2) and block the 3rd.
+	unlocks := acquireN(t, qe.snake, 2)
+	defer func() {
+		for _, u := range unlocks {
+			u.Release()
+		}
+	}()
+
+	assert.True(t, acquireBlocks(qe.snake),
+		"acquire beyond the resized pool capacity should block, not be granted")
+}
+
+// TestSnakeCapacity_FallsBackToConfigBeforeOpen verifies that before the pool is
+// opened — when Pool.Capacity() reports 0 — the snake falls back to the
+// configured pool size rather than collapsing to a single holder. A snake built
+// from a freshly-constructed (unopened) query engine must still admit up to the
+// configured OltpReadPool.Size.
+func TestSnakeCapacity_FallsBackToConfigBeforeOpen(t *testing.T) {
+	db := fakesqldb.New(t)
+	defer db.Close()
+
+	// Engine constructed but never Open()ed: qe.conns.Capacity() == 0.
+	qe := newTestQueryEngine(10*time.Second, true, newDBConfigs(db))
+	require.NotNil(t, qe.snake, "loadshed should be enabled by default in tests")
+
+	configured := qe.env.Config().OltpReadPool.Size
+	require.Greater(t, configured, 1, "test needs a configured size > 1 to be meaningful")
+
+	// The gate must admit up to the configured size despite the pool being
+	// unopened (Capacity() == 0). A naive live-only closure would max(0,1)=1
+	// here and block the 2nd acquire.
+	unlocks := acquireN(t, qe.snake, configured)
+	defer func() {
+		for _, u := range unlocks {
+			u.Release()
+		}
+	}()
+
+	assert.True(t, acquireBlocks(qe.snake),
+		"acquire beyond the configured size should block")
+}

--- a/go/vt/vttablet/tabletserver/tx_engine.go
+++ b/go/vt/vttablet/tabletserver/tx_engine.go
@@ -124,10 +124,8 @@ func NewTxEngine(env tabletenv.Env, dxNotifier func()) *TxEngine {
 				Exponent:       func() float64 { return config.LoadshedExponent },
 				MinDropDelayNs: func() int64 { return int64(time.Millisecond) },
 			},
-			// Track the pool's live capacity so runtime resizes (e.g. via
-			// /debug/env SetTxPoolSize) keep the gate in lockstep with the pool.
-			// Capacity() reports 0 until the pool is opened, so fall back to the
-			// configured size during that startup window to avoid throttling to 1.
+			// Track live pool capacity so runtime resizes keep the gate in sync.
+			// Capacity() is 0 until the pool opens; fall back to config until then.
 			Capacity: func() int {
 				if c := te.txPool.scp.Capacity(); c > 0 {
 					return c

--- a/go/vt/vttablet/tabletserver/tx_engine.go
+++ b/go/vt/vttablet/tabletserver/tx_engine.go
@@ -124,7 +124,16 @@ func NewTxEngine(env tabletenv.Env, dxNotifier func()) *TxEngine {
 				Exponent:       func() float64 { return config.LoadshedExponent },
 				MinDropDelayNs: func() int64 { return int64(time.Millisecond) },
 			},
-			Capacity:            func() int { return config.TxPool.Size },
+			// Track the pool's live capacity so runtime resizes (e.g. via
+			// /debug/env SetTxPoolSize) keep the gate in lockstep with the pool.
+			// Capacity() reports 0 until the pool is opened, so fall back to the
+			// configured size during that startup window to avoid throttling to 1.
+			Capacity: func() int {
+				if c := te.txPool.scp.Capacity(); c > 0 {
+					return c
+				}
+				return config.TxPool.Size
+			},
 			LoadsheddingAllowed: func() bool { return true },
 		})
 		loadshed.PublishStats(env.Exporter(), "SnakeDml", te.txPool.snake)


### PR DESCRIPTION
### Background / Why?

The Snake load-shedder gates (oltp-read and dml) derive their concurrency ceiling from a `Capacity` closure. Until now those closures read the static config fields — `config.OltpReadPool.Size` and `config.TxPool.Size` — which are populated once at startup from the `--queryserver-config-pool-size` / `--queryserver-config-transaction-cap` flags.

That created a silent desync with the actual connection pool. The pool size can be changed at runtime — most notably by an operator shrinking `ReadPoolSize` via the `/debug/env` page — and that path calls `Pool.SetCapacity()` only; it never writes back to the config struct. So after a live resize the gate kept admitting at the *old* ceiling (e.g. 250) while the pool itself was smaller (e.g. 50). The overflow piled up in the pool's plain FIFO waiter queue instead of being CoDel-shed at the gate, which is exactly the queueing layer the Snake exists to replace. I hit this directly while load-testing on staging: after setting the pool to 50 via `/debug/env`, the tablet showed `ConnPoolCapacity: 50` and `ConnPoolWaitCount` climbing into the hundreds of thousands, yet `SnakeOltpReadHolderCount: 152` and `SnakeOltpReadShedCount: 0` — the gate never engaged.

This points each capacity closure at the pool's live `Capacity()` so runtime resizes keep the gate in lockstep with the pool. There's one wrinkle worth calling out: `smartconnpool` seeds its `capacity` field only in `open()`, so `Pool.Capacity()` returns 0 between construction and `Open()`. A naive live-only closure would then compute `max(0, 1) = 1` and throttle the gate to a single holder during startup. The closures fall back to the configured size while `Capacity()` reports 0 to avoid that.

### Testing

Added `snake_capacity_test.go` with two tests that pin the closure to exactly one behavior — live capacity once the pool is open, configured size before it is:

- `TestSnakeCapacity_TracksLivePoolResize` opens the engine, shrinks the live pool to 2 via `SetCapacity`, and asserts the gate grants 2 and blocks the 3rd acquire. This fails against the previous static-config closure (the gate kept admitting past the resized pool) and passes with the fix.
- `TestSnakeCapacity_FallsBackToConfigBeforeOpen` constructs the engine without opening it (so `Capacity()` is 0) and asserts the gate still admits up to the configured size, guarding against a regression to a live-only closure that would throttle to 1.

Verified the red/green transition by temporarily reverting the `query_engine.go` closure: `TracksLivePoolResize` fails on the old code with the exact production symptom, then passes once restored. Ran the full `loadshed` package and `tabletserver` Snake suites locally.

**Monitoring:** once deployed, a `/debug/env` `ReadPoolSize` change should be reflected in `SnakeOltpReadHolderCount` topping out at the new value and `SnakeOltpReadShedCount` moving off zero under overload.
