### PR TITLE
Disable loadshed in the endtoend test tablet harness

### DIFF
--- a/go/vt/vttablet/endtoend/connecttcp/main_test.go
+++ b/go/vt/vttablet/endtoend/connecttcp/main_test.go
@@ -88,6 +88,7 @@ func TestMain(m *testing.M) {
 
 		config := tabletenv.NewDefaultConfig()
 		config.TwoPCAbandonAge = 1 * time.Second
+		config.LoadshedEnabled = false
 
 		if err := framework.StartCustomServer(ctx, connParams, connAppDebugParams, cluster.DbName(), config); err != nil {
 			fmt.Fprintf(os.Stderr, "%v", err)

--- a/go/vt/vttablet/endtoend/connkilling/main_test.go
+++ b/go/vt/vttablet/endtoend/connkilling/main_test.go
@@ -83,6 +83,7 @@ func TestMain(m *testing.M) {
 		connAppDebugParams = cluster.MySQLAppDebugConnParams()
 		config := tabletenv.NewDefaultConfig()
 		config.Oltp.TxTimeout = 3 * time.Second
+		config.LoadshedEnabled = false
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		err := framework.StartCustomServer(ctx, connParams, connAppDebugParams, cluster.DbName(), config)

--- a/go/vt/vttablet/endtoend/framework/server.go
+++ b/go/vt/vttablet/endtoend/framework/server.go
@@ -119,6 +119,7 @@ func StartServer(ctx context.Context, connParams, connAppDebugParams mysql.ConnP
 	config.EnableViews = true
 	config.QueryCacheDoorkeeper = false
 	config.SchemaReloadInterval = 5 * time.Second
+	config.LoadshedEnabled = false
 	gotBytes, _ := yaml2.Marshal(config)
 	log.Infof("Config:\n%s", gotBytes)
 	return StartCustomServer(ctx, connParams, connAppDebugParams, dbName, config)

--- a/go/vt/vttablet/endtoend/twopc/main_test.go
+++ b/go/vt/vttablet/endtoend/twopc/main_test.go
@@ -85,6 +85,7 @@ func TestMain(m *testing.M) {
 
 		config := tabletenv.NewDefaultConfig()
 		config.TwoPCAbandonAge = 1 * time.Second
+		config.LoadshedEnabled = false
 		err := framework.StartCustomServer(ctx, connParams, connAppDebugParams, cluster.DbName(), config)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%v", err)


### PR DESCRIPTION
### Background / Why?

The `--loadshed-enabled` flag recently flipped to default `true`. The endtoend test harness builds its tablet config from `tabletenv.NewDefaultConfig()` (in `framework.StartServer`), so e2e tablets started coming up with the Snake CoDel gate live. That's fine at normal speed, but the `e2e_race` job runs everything under the race detector, which inflates per-operation latency well past CoDel's 20ms sojourn target. The dml Snake then sheds legitimate test traffic, and 27 transaction tests in `go/vt/vttablet/endtoend` failed with:

```
Code: RESOURCE_EXHAUSTED
dml load shed: request dropped by CoDel queue (CallerID: dev)
```

This is the e2e analogue of the earlier unit-test fix that disabled loadshed in the shared unit-test tablet helper — the e2e framework is a separate config path that didn't get the same treatment. The load-shedder has no business gating a test harness; CoDel is meant to protect a real overloaded MySQL, not arbitrate against the race detector's overhead.

This disables loadshed in `framework.StartServer` (the path the failing package uses) and in the three `StartCustomServer` callers (`connkilling`, `connecttcp`, `twopc`). Those three pass today only because they don't run the transaction-heavy workload that trips CoDel under `-race`; disabling there too keeps any future e2e package from flaking on the gate.

### Testing

These e2e packages require a real MySQL and built Vitess binaries that only exist in the CI runner, so a full local run isn't possible. Verified locally that all four test binaries compile (`go vet` + `go build` over `./go/vt/vttablet/endtoend/...`); the actual transaction suites are left to the `e2e` and `e2e_race` CI jobs.
