### PR TITLE
Record Snake sojourn as a time-to-grant histogram

### DIFF
--- a/go/vt/vttablet/tabletserver/loadshed/snake.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake.go
@@ -56,15 +56,7 @@ type (
 		cfg            SnakeConfig
 		clockFunc      func() int64
 
-		// shedCount counts requests this Snake has shed (rejected by the CoDel
-		// gate). It excludes context cancellations, which are the caller giving
-		// up rather than the gate shedding. Read lock-free via ShedCount.
 		shedCount atomic.Int64
-
-		// sojourn records the time-to-grant distribution (queue wait before a
-		// slot is granted). Nil until PublishStats wires it, so NewSnake — used
-		// by tests and the benchmark harness — registers nothing globally.
-		// Written under s.mu in lockedGrant; Histogram.Add is itself atomic.
 		sojourn *stats.Histogram
 	}
 

--- a/go/vt/vttablet/tabletserver/loadshed/snake.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake.go
@@ -22,6 +22,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"vitess.io/vitess/go/stats"
 )
 
 type (
@@ -58,6 +60,12 @@ type (
 		// gate). It excludes context cancellations, which are the caller giving
 		// up rather than the gate shedding. Read lock-free via ShedCount.
 		shedCount atomic.Int64
+
+		// sojourn records the time-to-grant distribution (queue wait before a
+		// slot is granted). Nil until PublishStats wires it, so NewSnake — used
+		// by tests and the benchmark harness — registers nothing globally.
+		// Written under s.mu in lockedGrant; Histogram.Add is itself atomic.
+		sojourn *stats.Histogram
 	}
 
 	// SafeUnlock is a handle for releasing a slot. Only the goroutine that
@@ -235,6 +243,9 @@ func (s *Snake) releaseOnCancel(req *Request) {
 func (s *Snake) lockedGrant(req *Request) {
 	s.holders[req] = struct{}{}
 	s.q.lockedOnGrant(req)
+	if s.sojourn != nil {
+		s.sojourn.Add(s.clockFunc() - req.codelqEnqueuedAtNs)
+	}
 	s.lockedStartMaxAgeTimer(req)
 	req.signal(grantSentinel)
 }

--- a/go/vt/vttablet/tabletserver/loadshed/snake_stats.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_stats.go
@@ -17,6 +17,8 @@ limitations under the License.
 package loadshed
 
 import (
+	"time"
+
 	"vitess.io/vitess/go/stats"
 )
 
@@ -30,12 +32,26 @@ type statsExporter interface {
 	NewHistogram(name, help string, cutoffs []int64) *stats.Histogram
 }
 
-// loadshedBucketCutoffs are the sojourn (time-to-grant) histogram bucket
-// boundaries, in nanoseconds. Unlike the shared query-latency cutoffs in
-// go/stats (which start at 500µs), sojourn is sub-millisecond when healthy, so
-// these resolve the 500ns–200µs region where grants cluster while still landing
-// exactly on the target (5ms) and default trigger (100ms) thresholds.
-var loadshedBucketCutoffs = []int64{5e2, 1e3, 1e4, 5e4, 2e5, 1e6, 5e6, 2e7, 1e8, 5e8}
+var loadshedBucketCutoffs = durationNanos(
+	500*time.Nanosecond,
+	time.Microsecond,
+	10*time.Microsecond,
+	50*time.Microsecond,
+	200*time.Microsecond,
+	time.Millisecond,
+	5*time.Millisecond,
+	20*time.Millisecond,
+	100*time.Millisecond,
+	500*time.Millisecond,
+)
+
+func durationNanos(ds ...time.Duration) []int64 {
+	out := make([]int64, len(ds))
+	for i, d := range ds {
+		out[i] = d.Nanoseconds()
+	}
+	return out
+}
 
 // PublishStats registers one GaugeFunc per SnakeStats field, each name prefixed
 // with prefix (e.g. "SnakeOltpRead" or "SnakeDml"). Call this once per Snake
@@ -71,8 +87,5 @@ func PublishStats(exporter statsExporter, prefix string, s *Snake) {
 	exporter.NewCounterFunc(prefix+"ShedCount", "Cumulative requests shed by the Snake load shedder", func() int64 {
 		return s.ShedCount()
 	})
-	// Attach here rather than in NewSnake so nothing is registered globally
-	// until an engine explicitly publishes: NewSnake is also exercised by tests
-	// and the benchmark harness, where duplicate registration would panic.
 	s.sojourn = exporter.NewHistogram(prefix+"SojournNs", "Distribution of Snake sojourn (time-to-grant: queue wait before slot grant), in nanoseconds", loadshedBucketCutoffs)
 }

--- a/go/vt/vttablet/tabletserver/loadshed/snake_stats.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_stats.go
@@ -27,7 +27,15 @@ import (
 type statsExporter interface {
 	NewGaugeFunc(name, help string, f func() int64) *stats.GaugeFunc
 	NewCounterFunc(name, help string, f func() int64) *stats.CounterFunc
+	NewHistogram(name, help string, cutoffs []int64) *stats.Histogram
 }
+
+// loadshedBucketCutoffs are the sojourn (time-to-grant) histogram bucket
+// boundaries, in nanoseconds. Unlike the shared query-latency cutoffs in
+// go/stats (which start at 500µs), sojourn is sub-millisecond when healthy, so
+// these resolve the 500ns–200µs region where grants cluster while still landing
+// exactly on the target (5ms) and default trigger (100ms) thresholds.
+var loadshedBucketCutoffs = []int64{5e2, 1e3, 1e4, 5e4, 2e5, 1e6, 5e6, 2e7, 1e8, 5e8}
 
 // PublishStats registers one GaugeFunc per SnakeStats field, each name prefixed
 // with prefix (e.g. "SnakeOltpRead" or "SnakeDml"). Call this once per Snake
@@ -63,4 +71,8 @@ func PublishStats(exporter statsExporter, prefix string, s *Snake) {
 	exporter.NewCounterFunc(prefix+"ShedCount", "Cumulative requests shed by the Snake load shedder", func() int64 {
 		return s.ShedCount()
 	})
+	// Attach here rather than in NewSnake so nothing is registered globally
+	// until an engine explicitly publishes: NewSnake is also exercised by tests
+	// and the benchmark harness, where duplicate registration would panic.
+	s.sojourn = exporter.NewHistogram(prefix+"SojournNs", "Distribution of Snake sojourn (time-to-grant: queue wait before slot grant), in nanoseconds", loadshedBucketCutoffs)
 }

--- a/go/vt/vttablet/tabletserver/loadshed/snake_stats_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_stats_test.go
@@ -27,18 +27,20 @@ import (
 	"vitess.io/vitess/go/stats"
 )
 
-// fakeExporter captures the GaugeFuncs and CounterFuncs registered by
-// PublishStats so the test can invoke them directly, without touching global
+// fakeExporter captures the GaugeFuncs, CounterFuncs, and Histograms registered
+// by PublishStats so the test can invoke them directly, without touching global
 // stats registration.
 type fakeExporter struct {
-	gauges   map[string]func() int64
-	counters map[string]func() int64
+	gauges     map[string]func() int64
+	counters   map[string]func() int64
+	histograms map[string]*stats.Histogram
 }
 
 func newFakeExporter() *fakeExporter {
 	return &fakeExporter{
-		gauges:   make(map[string]func() int64),
-		counters: make(map[string]func() int64),
+		gauges:     make(map[string]func() int64),
+		counters:   make(map[string]func() int64),
+		histograms: make(map[string]*stats.Histogram),
 	}
 }
 
@@ -50,6 +52,15 @@ func (e *fakeExporter) NewGaugeFunc(name, _ string, f func() int64) *stats.Gauge
 func (e *fakeExporter) NewCounterFunc(name, _ string, f func() int64) *stats.CounterFunc {
 	e.counters[name] = f
 	return nil
+}
+
+// NewHistogram builds the histogram with an empty name so it is never published
+// to the global stats registry — the map keyed on the requested name is enough
+// for tests to look it up, and empty-named histograms skip publish().
+func (e *fakeExporter) NewHistogram(name, help string, cutoffs []int64) *stats.Histogram {
+	h := stats.NewHistogram("", help, cutoffs)
+	e.histograms[name] = h
+	return h
 }
 
 func TestPublishStats_ReflectsSnakeState(t *testing.T) {
@@ -159,4 +170,53 @@ func TestPublishStats_ShedCountIgnoresContextCancellation(t *testing.T) {
 	require.Error(t, err)
 
 	assert.Equal(t, int64(0), shedGauge(), "context cancellation must not count as a shed")
+}
+
+func TestPublishStats_SojournRecordsGrant(t *testing.T) {
+	s := newTestSnake(defaultSnakeConfig())
+	exp := newFakeExporter()
+
+	PublishStats(exp, "SnakeOltpRead", s)
+
+	hist := exp.histograms["SnakeOltpReadSojournNs"]
+	require.NotNil(t, hist, "expected histogram SnakeOltpReadSojournNs to be registered")
+	assert.Equal(t, int64(0), hist.Count(), "no grants before any acquire")
+
+	// A granted request records exactly one sojourn observation.
+	unlock, err := s.Acquire(t.Context(), "", 0)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), hist.Count(), "one grant should record one sojourn observation")
+	assert.GreaterOrEqual(t, hist.Total(), int64(0), "sojourn total should be a non-negative duration")
+
+	require.NoError(t, unlock.Release())
+}
+
+func TestPublishStats_SojournBucketing(t *testing.T) {
+	s := newTestSnake(defaultSnakeConfig())
+	exp := newFakeExporter()
+	PublishStats(exp, "SnakeOltpRead", s)
+	hist := exp.histograms["SnakeOltpReadSojournNs"]
+	require.NotNil(t, hist)
+
+	// A fast, uncontended grant lands in one of the low buckets: well under the
+	// 1ms cutoff. Assert nothing landed at or above the 5ms (5e6) cutoff.
+	unlock, err := s.Acquire(t.Context(), "", 0)
+	require.NoError(t, err)
+	require.NoError(t, unlock.Release())
+
+	counts := hist.Counts()
+	slow := counts["5000000"] + counts["20000000"] + counts["100000000"] + counts["500000000"] + counts["inf"]
+	assert.Equal(t, int64(0), slow, "an uncontended grant must not land in the >=5ms buckets")
+	assert.Equal(t, int64(1), hist.Count(), "exactly one observation recorded")
+}
+
+func TestNewSnake_SojournNilUntilPublished(t *testing.T) {
+	// A Snake built without PublishStats (the benchmark/test path) must grant
+	// without panicking; the sojourn histogram stays nil.
+	s := newTestSnake(defaultSnakeConfig())
+	assert.Nil(t, s.sojourn, "sojourn must be nil until PublishStats wires it")
+
+	unlock, err := s.Acquire(t.Context(), "", 0)
+	require.NoError(t, err)
+	require.NoError(t, unlock.Release())
 }

--- a/go/vt/vttablet/tabletserver/loadshed/snake_stats_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_stats_test.go
@@ -54,9 +54,6 @@ func (e *fakeExporter) NewCounterFunc(name, _ string, f func() int64) *stats.Cou
 	return nil
 }
 
-// NewHistogram builds the histogram with an empty name so it is never published
-// to the global stats registry — the map keyed on the requested name is enough
-// for tests to look it up, and empty-named histograms skip publish().
 func (e *fakeExporter) NewHistogram(name, help string, cutoffs []int64) *stats.Histogram {
 	h := stats.NewHistogram("", help, cutoffs)
 	e.histograms[name] = h


### PR DESCRIPTION
### Background / Why?

Snake, the CoDel-based load shedder for vttablet, already publishes six point-in-time gauges (`QueueLen`, `DroppableLen`, `HolderCount`, `Dropping`, `DropCount`, `CurrentIntervalNs`) and a cumulative `ShedCount` counter. What it never surfaced is the one quantity the CoDel control law is actually built around: **sojourn** — the time a request spends waiting in the queue before it's granted a slot. Sojourn is compared internally against the target and trigger thresholds on every grant, but until now it only appeared in code comments, never as an emitted metric.

A gauge would be the wrong tool here — the system is far too dynamic for a single instantaneous value to mean much. A histogram with fixed buckets aggregates cleanly across tablets and lets percentiles be computed at query time with `histogram_quantile`, which is the correct pattern (pre-computed percentiles can't be averaged across instances). This gives us fleet-wide p50/p99 time-to-grant to plot against target and trigger.

### Summary

- Record time-to-grant (`grant time − enqueue time`) for **granted requests only** — shed/dropped/cancelled requests are already covered by `ShedCount`.
- The observation happens in `lockedGrant`, the single choke point every granted request passes through under `s.mu`, using the same clock that stamped the enqueue timestamp so the delta is consistent in production and tests.
- The histogram is attached only in `PublishStats`, never in `NewSnake`, so unit tests and the benchmark harness (which build Snakes directly) register nothing globally. The hot path guards on a nil check.
- **Buckets are sojourn-tuned**, not the shared query-latency set: the standard `go/stats` cutoffs start at 500µs, which would collapse nearly every healthy grant into the floor bucket. These span 500ns–500ms, resolving the sub-millisecond region where healthy grants cluster, and land exactly on the target (5ms) and default trigger (100ms) thresholds.
- Final Prometheus names: `SnakeOltpReadSojournNs` and `SnakeDmlSojournNs`.

### Testing

Added unit tests in `snake_stats_test.go`: one granted request records exactly one observation with a non-negative total; an uncontended grant lands in the low buckets (nothing at/above the 5ms cutoff); and `sojourn` stays nil for a Snake built without `PublishStats`. Exercised locally with `go test -race ./go/vt/vttablet/tabletserver/loadshed/...`; the widened `statsExporter` interface is covered by the existing `PublishStats` call sites in `query_engine.go` and `tx_engine.go`, which pass the real `servenv.Exporter`.

AI disclosure: Claude Code assisted with development. Every line of code was either written by or carefully reviewed by me :)
