### PR TITLE
Replace Snake point-in-time gauges with distributions and time-in-state

### DIFF
--- a/go/vt/vttablet/tabletserver/loadshed/snake.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake.go
@@ -57,7 +57,16 @@ type (
 		clockFunc      func() int64
 
 		shedCount atomic.Int64
-		sojourn *stats.Histogram
+
+		sojourn      *stats.Histogram
+		queueLen     *stats.Histogram
+		droppableLen *stats.Histogram
+		holderCount  *stats.Histogram
+		interval     *stats.Histogram
+		dropCount    *stats.Histogram
+
+		droppingNanos   int64
+		droppingSinceNs int64
 	}
 
 	// SafeUnlock is a handle for releasing a slot. Only the goroutine that
@@ -83,9 +92,20 @@ func NewSnake(cfg SnakeConfig) *Snake {
 		clockFunc:    defaultClock,
 		holders:      make(map[*Request]struct{}),
 		maxAgeTimers: make(map[*Request]*time.Timer),
+		sojourn:      stats.NewHistogram("", "", loadshedBucketCutoffs),
+		queueLen:     stats.NewHistogram("", "", lengthBucketCutoffs),
+		droppableLen: stats.NewHistogram("", "", lengthBucketCutoffs),
+		holderCount:  stats.NewHistogram("", "", lengthBucketCutoffs),
+		interval:     stats.NewHistogram("", "", intervalBucketCutoffs),
+		dropCount:    stats.NewHistogram("", "", lengthBucketCutoffs),
 	}
 	s.q = newValvedCoDelQueue(cfg.CoDel, defaultClock, s.lockedScheduleDropTimer, s.lockedStopDropTimer)
 	return s
+}
+
+func (s *Snake) lockedObserveLengths() {
+	s.queueLen.Add(int64(s.q.lockedLen()))
+	s.droppableLen.Add(int64(s.q.lockedDroppableLen()))
 }
 
 func (s *Snake) capacity() int {
@@ -118,10 +138,13 @@ func (s *Snake) Acquire(ctx context.Context, valveID string, priority float64) (
 
 	if s.hasCapacity() && req.codelqElem != nil {
 		s.lockedGrant(req)
+		s.lockedObserveLengths()
 		s.mu.Unlock()
 		return &SafeUnlock{s: s, req: req}, nil
 	}
 
+	s.lockedObserveLengths()
+	s.lockedObserveDropping()
 	s.mu.Unlock()
 
 	select {
@@ -153,6 +176,8 @@ func (s *Snake) Acquire(ctx context.Context, valveID string, priority float64) (
 				s.releaseOnCancel(req)
 			} else {
 				s.q.lockedCancel(req)
+				s.lockedObserveLengths()
+				s.lockedObserveDropping()
 				s.mu.Unlock()
 			}
 		}
@@ -215,8 +240,11 @@ func (s *Snake) release(req *Request, excValue error) error {
 	}
 	s.lockedStopMaxAgeTimer(req)
 	delete(s.holders, req)
+	s.lockedObserveHolderCount()
 	s.q.lockedComplete(req)
 	s.lockedTryGrantOne()
+	s.lockedObserveLengths()
+	s.lockedObserveDropping()
 	s.mu.Unlock()
 
 	s.runReleaseCBs(excValue)
@@ -227,19 +255,46 @@ func (s *Snake) releaseOnCancel(req *Request) {
 	s.mu.Lock()
 	s.lockedStopMaxAgeTimer(req)
 	delete(s.holders, req)
+	s.lockedObserveHolderCount()
 	s.q.lockedComplete(req)
 	s.lockedTryGrantOne()
+	s.lockedObserveLengths()
+	s.lockedObserveDropping()
 	s.mu.Unlock()
 }
 
 func (s *Snake) lockedGrant(req *Request) {
 	s.holders[req] = struct{}{}
+	s.lockedObserveHolderCount()
 	s.q.lockedOnGrant(req)
-	if s.sojourn != nil {
-		s.sojourn.Add(s.clockFunc() - req.codelqEnqueuedAtNs)
-	}
+	now := s.clockFunc()
+	s.lockedAccrueDropping(now)
+	s.sojourn.Add(now - req.codelqEnqueuedAtNs)
 	s.lockedStartMaxAgeTimer(req)
 	req.signal(grantSentinel)
+}
+
+func (s *Snake) lockedObserveHolderCount() {
+	s.holderCount.Add(int64(len(s.holders)))
+}
+
+func (s *Snake) lockedObserveDropping() {
+	dropping := !s.q.lockedIsHealthy()
+	if dropping == (s.droppingSinceNs != 0) {
+		return
+	}
+	s.lockedAccrueDropping(s.clockFunc())
+}
+
+func (s *Snake) lockedAccrueDropping(now int64) {
+	dropping := !s.q.lockedIsHealthy()
+	switch {
+	case dropping && s.droppingSinceNs == 0:
+		s.droppingSinceNs = now
+	case !dropping && s.droppingSinceNs != 0:
+		s.droppingNanos += now - s.droppingSinceNs
+		s.droppingSinceNs = 0
+	}
 }
 
 func (s *Snake) lockedTryGrantOne() {
@@ -287,6 +342,16 @@ func (s *Snake) ShedCount() int64 {
 	return s.shedCount.Load()
 }
 
+func (s *Snake) DroppingNanos() int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	total := s.droppingNanos
+	if s.droppingSinceNs != 0 {
+		total += s.clockFunc() - s.droppingSinceNs
+	}
+	return total
+}
+
 // --- timer management (must be called with s.mu held) ---
 
 func (s *Snake) lockedScheduleDropTimer(delayNs int64) {
@@ -314,6 +379,10 @@ func (s *Snake) runDropTimer() {
 	}
 	s.dropTimerArmed = false
 	s.q.lockedRunTimer()
+	s.interval.Add(s.q.lockedCurrentInterval())
+	s.dropCount.Add(int64(s.q.lockedCount()))
+	s.lockedObserveLengths()
+	s.lockedObserveDropping()
 	s.mu.Unlock()
 }
 

--- a/go/vt/vttablet/tabletserver/loadshed/snake_stats.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_stats.go
@@ -27,7 +27,6 @@ import (
 // loadshed package free of a servenv dependency and lets tests pass a
 // throwaway exporter.
 type statsExporter interface {
-	NewGaugeFunc(name, help string, f func() int64) *stats.GaugeFunc
 	NewCounterFunc(name, help string, f func() int64) *stats.CounterFunc
 	NewHistogram(name, help string, cutoffs []int64) *stats.Histogram
 }
@@ -45,6 +44,10 @@ var loadshedBucketCutoffs = durationNanos(
 	500*time.Millisecond,
 )
 
+var intervalBucketCutoffs = loadshedBucketCutoffs
+
+var lengthBucketCutoffs = []int64{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096}
+
 func durationNanos(ds ...time.Duration) []int64 {
 	out := make([]int64, len(ds))
 	for i, d := range ds {
@@ -53,39 +56,27 @@ func durationNanos(ds ...time.Duration) []int64 {
 	return out
 }
 
-// PublishStats registers one GaugeFunc per SnakeStats field, each name prefixed
-// with prefix (e.g. "SnakeOltpRead" or "SnakeDml"). Call this once per Snake
-// instance from engine init — never from NewSnake, which is also exercised by
-// tests and the benchmark harness where duplicate registration would panic.
+// PublishStats registers Snake's counters and distribution histograms, each
+// name prefixed with prefix (e.g. "SnakeOltpRead" or "SnakeDml"). Call this once
+// per Snake instance from engine init — never from NewSnake, which is also
+// exercised by tests and the benchmark harness where duplicate registration
+// would panic.
 //
 // Each Snake gets its own prefixed metric names rather than a shared "pool"
 // label: both the oltp-read and dml snakes register through the same tablet
 // Exporter, whose single label dimension is already the tablet name, so a
-// shared labeled gauge would collide on that one key.
+// shared labeled metric would collide on that one key.
 func PublishStats(exporter statsExporter, prefix string, s *Snake) {
-	exporter.NewGaugeFunc(prefix+"QueueLen", "Snake CoDel queue length (waiters)", func() int64 {
-		return int64(s.Stats().QueueLen)
-	})
-	exporter.NewGaugeFunc(prefix+"DroppableLen", "Snake CoDel droppable queue length", func() int64 {
-		return int64(s.Stats().DroppableLen)
-	})
-	exporter.NewGaugeFunc(prefix+"HolderCount", "Snake current slot holders", func() int64 {
-		return int64(s.Stats().HolderCount)
-	})
-	exporter.NewGaugeFunc(prefix+"Dropping", "Whether Snake CoDel is in the dropping state (1) or not (0)", func() int64 {
-		if s.Stats().Dropping {
-			return 1
-		}
-		return 0
-	})
-	exporter.NewGaugeFunc(prefix+"DropCount", "Snake CoDel drop count (control law state)", func() int64 {
-		return int64(s.Stats().DropCount)
-	})
-	exporter.NewGaugeFunc(prefix+"CurrentIntervalNs", "Snake CoDel current control interval in nanoseconds", func() int64 {
-		return s.Stats().CurrentInterval
-	})
 	exporter.NewCounterFunc(prefix+"ShedCount", "Cumulative requests shed by the Snake load shedder", func() int64 {
 		return s.ShedCount()
 	})
+	exporter.NewCounterFunc(prefix+"DroppingNanosTotal", "Cumulative nanoseconds Snake CoDel spent in the dropping state; rate() yields the fraction of time shedding", func() int64 {
+		return s.DroppingNanos()
+	})
 	s.sojourn = exporter.NewHistogram(prefix+"SojournNs", "Distribution of Snake sojourn (time-to-grant: queue wait before slot grant), in nanoseconds", loadshedBucketCutoffs)
+	s.queueLen = exporter.NewHistogram(prefix+"QueueLenObserved", "Distribution of Snake CoDel queue length, sampled at each change", lengthBucketCutoffs)
+	s.droppableLen = exporter.NewHistogram(prefix+"DroppableLenObserved", "Distribution of Snake CoDel droppable queue length, sampled at each change", lengthBucketCutoffs)
+	s.holderCount = exporter.NewHistogram(prefix+"HolderCountObserved", "Distribution of Snake slot holders, sampled at each change", lengthBucketCutoffs)
+	s.interval = exporter.NewHistogram(prefix+"IntervalObservedNs", "Distribution of Snake CoDel control interval in nanoseconds, sampled at each timer fire", intervalBucketCutoffs)
+	s.dropCount = exporter.NewHistogram(prefix+"DropCountObserved", "Distribution of Snake CoDel drop count (control-law state), sampled at each timer fire", lengthBucketCutoffs)
 }

--- a/go/vt/vttablet/tabletserver/loadshed/snake_stats_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_stats_test.go
@@ -27,26 +27,19 @@ import (
 	"vitess.io/vitess/go/stats"
 )
 
-// fakeExporter captures the GaugeFuncs, CounterFuncs, and Histograms registered
-// by PublishStats so the test can invoke them directly, without touching global
+// fakeExporter captures the CounterFuncs and Histograms registered by
+// PublishStats so the test can invoke them directly, without touching global
 // stats registration.
 type fakeExporter struct {
-	gauges     map[string]func() int64
 	counters   map[string]func() int64
 	histograms map[string]*stats.Histogram
 }
 
 func newFakeExporter() *fakeExporter {
 	return &fakeExporter{
-		gauges:     make(map[string]func() int64),
 		counters:   make(map[string]func() int64),
 		histograms: make(map[string]*stats.Histogram),
 	}
-}
-
-func (e *fakeExporter) NewGaugeFunc(name, _ string, f func() int64) *stats.GaugeFunc {
-	e.gauges[name] = f
-	return nil
 }
 
 func (e *fakeExporter) NewCounterFunc(name, _ string, f func() int64) *stats.CounterFunc {
@@ -60,32 +53,18 @@ func (e *fakeExporter) NewHistogram(name, help string, cutoffs []int64) *stats.H
 	return h
 }
 
-func TestPublishStats_ReflectsSnakeState(t *testing.T) {
+func TestPublishStats_RegistersCountersAndHistograms(t *testing.T) {
 	s := newTestSnake(defaultSnakeConfig())
 	exp := newFakeExporter()
 
 	PublishStats(exp, "SnakeOltpRead", s)
 
-	// All six fields are registered under the prefix.
-	for _, field := range []string{"QueueLen", "DroppableLen", "HolderCount", "Dropping", "DropCount", "CurrentIntervalNs"} {
-		_, ok := exp.gauges["SnakeOltpRead"+field]
-		assert.True(t, ok, "expected gauge SnakeOltpRead%s to be registered", field)
+	for _, name := range []string{"ShedCount", "DroppingNanosTotal"} {
+		assert.Contains(t, exp.counters, "SnakeOltpRead"+name)
 	}
-
-	// Idle: no holders.
-	assert.Equal(t, int64(0), exp.gauges["SnakeOltpReadHolderCount"]())
-
-	// Acquire a slot (capacity defaults to 1) and confirm the gauge tracks it.
-	unlock, err := s.Acquire(t.Context(), "", 0)
-	require.NoError(t, err)
-	assert.Equal(t, int64(1), exp.gauges["SnakeOltpReadHolderCount"]())
-
-	// The gauge closure reads live Stats(), so it matches after release too.
-	require.NoError(t, unlock.Release())
-	assert.Equal(t, int64(s.Stats().HolderCount), exp.gauges["SnakeOltpReadHolderCount"]())
-
-	// CurrentIntervalNs mirrors the raw ns value from Stats (not a unit-converted one).
-	assert.Equal(t, s.Stats().CurrentInterval, exp.gauges["SnakeOltpReadCurrentIntervalNs"]())
+	for _, name := range []string{"SojournNs", "QueueLenObserved", "DroppableLenObserved", "HolderCountObserved", "IntervalObservedNs", "DropCountObserved"} {
+		assert.Contains(t, exp.histograms, "SnakeOltpRead"+name)
+	}
 }
 
 func TestPublishStats_PrefixIsolation(t *testing.T) {
@@ -95,13 +74,16 @@ func TestPublishStats_PrefixIsolation(t *testing.T) {
 	PublishStats(exp, "SnakeOltpRead", newTestSnake(defaultSnakeConfig()))
 	PublishStats(exp, "SnakeDml", newTestSnake(defaultSnakeConfig()))
 
-	assert.Contains(t, exp.gauges, "SnakeOltpReadQueueLen")
-	assert.Contains(t, exp.gauges, "SnakeDmlQueueLen")
-	assert.Len(t, exp.gauges, 12, "expected 6 gauges per snake, two snakes")
-
 	assert.Contains(t, exp.counters, "SnakeOltpReadShedCount")
 	assert.Contains(t, exp.counters, "SnakeDmlShedCount")
-	assert.Len(t, exp.counters, 2, "expected 1 shed counter per snake, two snakes")
+	assert.Contains(t, exp.counters, "SnakeOltpReadDroppingNanosTotal")
+	assert.Contains(t, exp.counters, "SnakeDmlDroppingNanosTotal")
+	assert.Len(t, exp.counters, 4, "expected shed + dropping counters per snake, two snakes")
+
+	assert.Contains(t, exp.histograms, "SnakeOltpReadQueueLenObserved")
+	assert.Contains(t, exp.histograms, "SnakeDmlQueueLenObserved")
+	// sojourn + queueLen + droppableLen + holderCount + interval + dropCount, per snake.
+	assert.Len(t, exp.histograms, 12, "expected 6 histograms per snake, two snakes")
 }
 
 func TestPublishStats_ShedCountTracksDrops(t *testing.T) {
@@ -207,13 +189,180 @@ func TestPublishStats_SojournBucketing(t *testing.T) {
 	assert.Equal(t, int64(1), hist.Count(), "exactly one observation recorded")
 }
 
-func TestNewSnake_SojournNilUntilPublished(t *testing.T) {
-	// A Snake built without PublishStats (the benchmark/test path) must grant
-	// without panicking; the sojourn histogram stays nil.
+func TestNewSnake_DistributionMetricsInitializedBeforePublish(t *testing.T) {
+	// NewSnake initializes every distribution histogram to a detached (unnamed,
+	// unregistered) instance, so the observation paths never nil-check. A Snake
+	// built without PublishStats records into these throwaway histograms and
+	// registers nothing globally.
 	s := newTestSnake(defaultSnakeConfig())
-	assert.Nil(t, s.sojourn, "sojourn must be nil until PublishStats wires it")
+	require.NotNil(t, s.sojourn)
+	require.NotNil(t, s.queueLen)
+	require.NotNil(t, s.droppableLen)
+	require.NotNil(t, s.holderCount)
+	require.NotNil(t, s.interval)
+	require.NotNil(t, s.dropCount)
 
 	unlock, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
+	// The detached histograms accumulate even before PublishStats swaps in the
+	// exporter-registered instances.
+	assert.Positive(t, s.queueLen.Count())
+	assert.Positive(t, s.holderCount.Count())
+	assert.Positive(t, s.sojourn.Count())
 	require.NoError(t, unlock.Release())
+}
+
+func TestPublishStats_QueueAndHolderHistogramsRecord(t *testing.T) {
+	s := newTestSnake(defaultSnakeConfig()) // capacity 1
+	exp := newFakeExporter()
+	PublishStats(exp, "SnakeOltpRead", s)
+
+	queueLen := exp.histograms["SnakeOltpReadQueueLenObserved"]
+	holderCount := exp.histograms["SnakeOltpReadHolderCountObserved"]
+	require.NotNil(t, queueLen)
+	require.NotNil(t, holderCount)
+	assert.Equal(t, int64(0), queueLen.Count(), "no observations before any acquire")
+	assert.Equal(t, int64(0), holderCount.Count())
+
+	// A grant observes both: the enqueue records queue length, the holder insert
+	// records holder count.
+	unlock, err := s.Acquire(t.Context(), "", 0)
+	require.NoError(t, err)
+	assert.Positive(t, queueLen.Count(), "enqueue should record a queue-length observation")
+	assert.Positive(t, holderCount.Count(), "grant should record a holder-count observation")
+
+	// Release records again (queue length drops as the granted entry leaves; the
+	// holder delete is observed too).
+	beforeQueue := queueLen.Count()
+	beforeHolder := holderCount.Count()
+	require.NoError(t, unlock.Release())
+	assert.Greater(t, queueLen.Count(), beforeQueue, "release should record another queue-length observation")
+	assert.Greater(t, holderCount.Count(), beforeHolder, "release should record another holder-count observation")
+}
+
+func TestPublishStats_DroppableAndIntervalHistogramsRecordUnderLoad(t *testing.T) {
+	cfg := defaultSnakeConfig()
+	cfg.CoDel.IntervalNs = func() int64 { return 1_000 }
+	cfg.CoDel.TargetNs = func() int64 { return 1 }
+	cfg.CoDel.MinDropDelayNs = func() int64 { return 1 }
+	s := newTestSnake(cfg)
+
+	exp := newFakeExporter()
+	PublishStats(exp, "SnakeOltpRead", s)
+	droppable := exp.histograms["SnakeOltpReadDroppableLenObserved"]
+	interval := exp.histograms["SnakeOltpReadIntervalObservedNs"]
+	dropCount := exp.histograms["SnakeOltpReadDropCountObserved"]
+	require.NotNil(t, droppable)
+	require.NotNil(t, interval)
+	require.NotNil(t, dropCount)
+
+	// Occupy the slot, then contend so droppable entries queue and the drop timer
+	// fires (recording interval and drop-count observations).
+	unlock, err := s.Acquire(t.Context(), "", 0)
+	require.NoError(t, err)
+
+	errCh := make(chan error, 5)
+	for range 5 {
+		go func() {
+			_, err := s.Acquire(t.Context(), "", 0)
+			errCh <- err
+		}()
+	}
+	time.Sleep(200 * time.Millisecond)
+	unlock.Release()
+	for range 5 {
+		select {
+		case <-errCh:
+		case <-time.After(2 * time.Second):
+			t.Fatal("goroutine did not return")
+		}
+	}
+
+	assert.Positive(t, droppable.Count(), "contending droppable enqueues should record droppable-length observations")
+	assert.Positive(t, interval.Count(), "drop-timer fires should record interval observations")
+	assert.Positive(t, dropCount.Count(), "drop-timer fires should record drop-count observations")
+}
+
+func TestPublishStats_DroppingNanosAdvancesDuringEpisode(t *testing.T) {
+	cfg := defaultSnakeConfig()
+	cfg.CoDel.IntervalNs = func() int64 { return 1_000 }
+	cfg.CoDel.TargetNs = func() int64 { return 1 }
+	cfg.CoDel.MinDropDelayNs = func() int64 { return 1 }
+	s := newTestSnake(cfg)
+
+	exp := newFakeExporter()
+	PublishStats(exp, "SnakeOltpRead", s)
+	droppingNanos := exp.counters["SnakeOltpReadDroppingNanosTotal"]
+	require.NotNil(t, droppingNanos)
+	assert.Equal(t, int64(0), droppingNanos(), "no dropping time before contention")
+
+	// Drive a dropping episode: hold the slot and pile on contenders.
+	unlock, err := s.Acquire(t.Context(), "", 0)
+	require.NoError(t, err)
+
+	errCh := make(chan error, 5)
+	for range 5 {
+		go func() {
+			_, err := s.Acquire(t.Context(), "", 0)
+			errCh <- err
+		}()
+	}
+	time.Sleep(200 * time.Millisecond)
+	unlock.Release()
+	for range 5 {
+		select {
+		case <-errCh:
+		case <-time.After(2 * time.Second):
+			t.Fatal("goroutine did not return")
+		}
+	}
+
+	assert.Positive(t, droppingNanos(), "an induced dropping episode should accumulate dropping nanoseconds")
+}
+
+func TestDroppingNanos_IntegratesExactlyOverEpisode(t *testing.T) {
+	// Hermetic test of the accumulator math with an injected clock: no timing
+	// dependence. Drive dropping true→false transitions directly through the
+	// observer and assert the accumulated nanoseconds match the clock deltas.
+	s := newTestSnake(defaultSnakeConfig())
+	var now int64
+	s.clockFunc = func() int64 { return now }
+
+	// Not dropping yet: nothing accrues, and the open-segment flush is a no-op.
+	assert.Equal(t, int64(0), s.DroppingNanos())
+
+	// Open an episode at t=100 by forcing the queue into the dropping state.
+	now = 100
+	s.mu.Lock()
+	s.q.codelq.dropping = true
+	s.lockedObserveDropping()
+	s.mu.Unlock()
+
+	// Mid-episode at t=250: the open segment (250-100) is visible before it ends.
+	now = 250
+	assert.Equal(t, int64(150), s.DroppingNanos(), "open segment must be included before the episode ends")
+
+	// Close the episode at t=400: 300ns total accrued (400-100).
+	now = 400
+	s.mu.Lock()
+	s.q.codelq.dropping = false
+	s.lockedObserveDropping()
+	s.mu.Unlock()
+	assert.Equal(t, int64(300), s.DroppingNanos())
+
+	// Idle stretch adds nothing.
+	now = 1000
+	assert.Equal(t, int64(300), s.DroppingNanos())
+
+	// A second episode from t=1000 to t=1100 adds 100ns for 400ns total.
+	s.mu.Lock()
+	s.q.codelq.dropping = true
+	s.lockedObserveDropping()
+	s.mu.Unlock()
+	now = 1100
+	s.mu.Lock()
+	s.q.codelq.dropping = false
+	s.lockedObserveDropping()
+	s.mu.Unlock()
+	assert.Equal(t, int64(400), s.DroppingNanos())
 }

--- a/go/vt/vttablet/tabletserver/loadshed/valved_codelq.go
+++ b/go/vt/vttablet/tabletserver/loadshed/valved_codelq.go
@@ -120,6 +120,18 @@ func (q *ValvedCoDelQueue) onPeekCleanup(req *Request) {
 	q.decrementOutstanding(req.valveID)
 }
 
+func (q *ValvedCoDelQueue) lockedCurrentInterval() int64 {
+	return q.codelq.lockedCurrentInterval()
+}
+
+func (q *ValvedCoDelQueue) lockedDroppableLen() int {
+	return q.codelq.droppableLen
+}
+
+func (q *ValvedCoDelQueue) lockedCount() int {
+	return q.codelq.count
+}
+
 // lockedLen returns the number of requests in the CoDel queue.
 func (q *ValvedCoDelQueue) lockedLen() int {
 	return q.codelq.lockedLen()


### PR DESCRIPTION
### Background / Why?

Snake's [Load Testing dashboard](https://grafana-dev.tinyspeck.com/d/dfq8s8ous9t6oa/snake-load-testing) reads six `GaugeFunc`s that are scraped roughly every 30 seconds: queue length, droppable length, holder count, dropping (0/1), drop count, and current interval. Every one of these is a *point-in-time* read, so a 30s scrape samples the instantaneous value and loses everything that happened between scrapes. For a load shedder — whose entire job is transient overload — that's the wrong lens: a queue that spiked to 400 for two seconds and drained is invisible if the scrape lands in a quiet moment.

This records each fast-moving quantity using a Prometheus-native aggregate type that survives a slow scrape, observed *where the value changes* rather than sampled on a timer. It's the same pattern as the sojourn histogram in #896 — the cumulative histogram/counter is scrape-rate independent. The six existing gauges stay: they're near-free and remain the only way to see the instantaneous "right now" value.

A note on the shapes chosen, since the metric type is the interesting decision here. The three length metrics (queue, droppable, holder) become **histograms** so we can pull percentiles with `histogram_quantile` — observations are event-weighted (one per change), which biases toward the busy/overloaded regime, the behavior we actually care about for a shedder. Interval also becomes a **histogram** (it stays a human-readable ns duration rather than forcing anyone to derive it from `count`). Dropping becomes a monotonic **nanosecond counter** rather than a histogram — a percentile of a boolean is meaningless; the only sensible aggregate is "fraction of wall-clock time shedding," which is exactly `rate(...DroppingNanosTotal[5m])`.

### Summary

- **Observer seam on `CoDelQueue`** (`onQueueLen` / `onDroppableLen`): fired at each queue/droppable mutation site, and *only* where its own quantity moves, so each histogram sees exactly the sequence of values that quantity took — including every drop inside a multi-drop timer burst. The seam passes plain funcs, keeping the `stats` dependency out of the algorithm layer (`codelq.go`, `valved_codelq.go`).
- **Holder count** observed at the three `holders` mutation sites; **interval** observed once per timer fire (the only place `count` changes).
- **`DroppingNanosTotal`** integrated at each Snake-operation boundary — the dropping state is constant between operations, so boundary sampling is exact. `DroppingNanos()` flushes the current open episode under the lock, so an in-progress episode is visible before it ends. Implemented as a `CounterFunc` over an accumulator, so no `statsExporter` interface change was needed.
- All histograms and the counter are attached **only** in `PublishStats` and nil-guarded on the hot path, so `NewSnake` (tests, benchmark harness) registers nothing globally.

Length histograms use count-domain cutoffs (powers of two, 1–4096); the interval histogram reuses the sub-ms–500ms sojourn cutoffs.

Follow-up (not in this change): swap the dashboard's point-in-time panels for `histogram_quantile(...)` and `rate(...DroppingNanosTotal[5m])`.

### Testing

New unit tests in `snake_stats_test.go`:
- Length and holder histograms record on acquire/release; droppable and interval histograms record under induced contention.
- `DroppingNanosTotal` advances across a load-driven dropping episode, plus a hermetic clock-injected test asserting the integral is exact (150ns mid-episode, 300ns after close, 400ns across two episodes).
- Nil-safety: a `NewSnake` built without `PublishStats` observes lengths and runs the drop timer without panicking.

Ran the package benchmarks with `-benchmem`: the hot grant path holds at **288 B/op, 5 allocs/op**, unchanged from baseline — the nil-guarded observer closures add no per-op allocations.

AI disclosure: Claude Code assisted with development. Every line of code was either written by or carefully reviewed by me :)
