### PR TITLE
backport: chunked builtin backup engine (#20167)

### DIFF
--- a/go/flags/endtoend/vtbackup.txt
+++ b/go/flags/endtoend/vtbackup.txt
@@ -62,6 +62,8 @@ Flags:
       --backup_storage_implementation string                        Which backup storage implementation to use for creating and restoring backups.
       --backup_storage_number_blocks int                            if backup_storage_compress is true, backup_storage_number_blocks sets the number of blocks that can be processed, in parallel, before the writer blocks, during compression (default is 2). It should be equal to the number of CPUs available for compression. (default 2)
       --bind-address string                                         Bind address for the server. If empty, the server will listen on all available unicast and anycast IP addresses of the local system.
+      --builtinbackup-file-chunk-size uint                          Size of each chunk (in bytes) when splitting large files for parallel backup/restore. (default 1073741824)
+      --builtinbackup-file-chunk-threshold uint                     Files larger than this size (in bytes) are split into chunks for parallel backup/restore. 0 disables chunking.
       --builtinbackup-file-read-buffer-size uint                    read files using an IO buffer of this many bytes. Golang defaults are used when set to 0.
       --builtinbackup-file-write-buffer-size uint                   write files using an IO buffer of this many bytes. Golang defaults are used when set to 0. (default 2097152)
       --builtinbackup-incremental-restore-path string               the directory where incremental restore files, namely binlog files, are extracted to. In k8s environments, this should be set to a directory that is shared between the vttablet and mysqld pods. The path should exist. When empty, the default OS temp dir is assumed.

--- a/go/flags/endtoend/vtbench.txt
+++ b/go/flags/endtoend/vtbench.txt
@@ -62,6 +62,7 @@ Flags:
       --db-credentials-vault-tokenfile string                       Path to file containing Vault auth token; token can also be passed using VAULT_TOKEN environment variable
       --db-credentials-vault-ttl duration                           How long to cache DB credentials from the Vault server (default 30m0s)
       --deadline duration                                           Maximum duration for the test run (default 5 minutes) (default 5m0s)
+      --grpc-dial-concurrency-limit int                             Maximum concurrency of grpc dial operations. This should be less than the golang max thread limit of 10000. (default 1024)
       --grpc_auth_static_client_creds string                        When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.
       --grpc_compression string                                     Which protocol to use for compressing gRPC. Default: nothing. Supported: snappy
       --grpc_enable_tracing                                         Enable gRPC tracing.
@@ -69,6 +70,8 @@ Flags:
       --grpc_initial_window_size int                                gRPC initial window size
       --grpc_keepalive_time duration                                After a duration of this time, if the client doesn't see any activity, it pings the server to see if the transport is still alive. (default 10s)
       --grpc_keepalive_timeout duration                             After having pinged for keepalive check, the client waits for a duration of Timeout and if no activity is seen even after that the connection is closed. (default 10s)
+      --grpc_max_message_recv_size int                              Maximum allowed RPC message size when receiving. If 0, defaults to grpc_max_message_size.
+      --grpc_max_message_send_size int                              Maximum allowed RPC message size when sending. If 0, defaults to grpc_max_message_size.
       --grpc_max_message_size int                                   Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
       --grpc_prometheus                                             Enable gRPC monitoring with Prometheus.
   -h, --help                                                        help for vtbench

--- a/go/flags/endtoend/vtclient.txt
+++ b/go/flags/endtoend/vtclient.txt
@@ -21,10 +21,22 @@ Flags:
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --count int                                                   DMLs only: Number of times each thread executes the query. Useful for simple, sustained load testing. (default 1)
+      --datadog-agent-host string                                   host to send spans to. if empty, no tracing will be done
+      --datadog-agent-port string                                   port to send spans to. if empty, no tracing will be done
+      --grpc-dial-concurrency-limit int                             Maximum concurrency of grpc dial operations. This should be less than the golang max thread limit of 10000. (default 1024)
+      --grpc_auth_static_client_creds string                        When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.
+      --grpc_compression string                                     Which protocol to use for compressing gRPC. Default: nothing. Supported: snappy
       --grpc_enable_tracing                                         Enable gRPC tracing.
+      --grpc_initial_conn_window_size int                           gRPC initial connection window size
+      --grpc_initial_window_size int                                gRPC initial window size
+      --grpc_keepalive_time duration                                After a duration of this time, if the client doesn't see any activity, it pings the server to see if the transport is still alive. (default 10s)
+      --grpc_keepalive_timeout duration                             After having pinged for keepalive check, the client waits for a duration of Timeout and if no activity is seen even after that the connection is closed. (default 10s)
+      --grpc_max_message_recv_size int                              Maximum allowed RPC message size when receiving. If 0, defaults to grpc_max_message_size.
+      --grpc_max_message_send_size int                              Maximum allowed RPC message size when sending. If 0, defaults to grpc_max_message_size.
       --grpc_max_message_size int                                   Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
       --grpc_prometheus                                             Enable gRPC monitoring with Prometheus.
   -h, --help                                                        help for vtclient
+      --jaeger-agent-host string                                    host and port to send spans to. if empty, no tracing will be done
       --json                                                        Output JSON instead of human-readable table
       --keep_logs duration                                          keep logs for this long (using ctime) (zero to keep forever)
       --keep_logs_by_mtime duration                                 keep logs for this long (using mtime) (zero to keep forever)
@@ -47,7 +59,18 @@ Flags:
       --streaming                                                   use a streaming query
       --target string                                               keyspace:shard@tablet_type
       --timeout duration                                            timeout for queries (default 30s)
+      --tracer string                                               tracing service to use (default "noop")
+      --tracing-enable-logging                                      whether to enable logging in the tracing service
+      --tracing-sampling-rate float                                 sampling rate for the probabilistic jaeger sampler (default 0.1)
+      --tracing-sampling-type string                                sampling strategy to use for jaeger. possible values are 'const', 'probabilistic', 'rateLimiting', or 'remote' (default "const")
       --use_random_sequence                                         use random sequence for generating [min_sequence_id, max_sequence_id)
       --v Level                                                     log level for V logs
   -v, --version                                                     print binary version
       --vmodule vModuleFlag                                         comma-separated list of pattern=N settings for file-filtered logging
+      --vtgate_grpc_ca string                                       the server ca to use to validate servers when connecting
+      --vtgate_grpc_cert string                                     the cert to use to connect
+      --vtgate_grpc_crl string                                      the server crl to use to validate server certificates when connecting
+      --vtgate_grpc_fail_fast                                       whether to enable grpc fail fast when communicating with vtgate
+      --vtgate_grpc_key string                                      the key to use to connect
+      --vtgate_grpc_server_name string                              the server name to use to validate server certificate
+      --vtgate_protocol string                                      how to talk to vtgate (default "grpc")

--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -29,6 +29,8 @@ Flags:
       --buffer_min_time_between_failovers duration                       Minimum time between the end of a failover and the start of the next one (tracked per shard). Faster consecutive failovers will not trigger buffering. (default 1m0s)
       --buffer_size int                                                  Maximum number of buffered requests in flight (across all ongoing failovers). (default 1000)
       --buffer_window duration                                           Duration for how long a request should be buffered at most. (default 10s)
+      --builtinbackup-file-chunk-size uint                               Size of each chunk (in bytes) when splitting large files for parallel backup/restore. (default 1073741824)
+      --builtinbackup-file-chunk-threshold uint                          Files larger than this size (in bytes) are split into chunks for parallel backup/restore. 0 disables chunking.
       --builtinbackup-file-read-buffer-size uint                         read files using an IO buffer of this many bytes. Golang defaults are used when set to 0.
       --builtinbackup-file-write-buffer-size uint                        write files using an IO buffer of this many bytes. Golang defaults are used when set to 0. (default 2097152)
       --builtinbackup-incremental-restore-path string                    the directory where incremental restore files, namely binlog files, are extracted to. In k8s environments, this should be set to a directory that is shared between the vttablet and mysqld pods. The path should exist. When empty, the default OS temp dir is assumed.

--- a/go/flags/endtoend/vtctld.txt
+++ b/go/flags/endtoend/vtctld.txt
@@ -35,6 +35,8 @@ Flags:
       --backup_storage_implementation string                             Which backup storage implementation to use for creating and restoring backups.
       --backup_storage_number_blocks int                                 if backup_storage_compress is true, backup_storage_number_blocks sets the number of blocks that can be processed, in parallel, before the writer blocks, during compression (default is 2). It should be equal to the number of CPUs available for compression. (default 2)
       --bind-address string                                              Bind address for the server. If empty, the server will listen on all available unicast and anycast IP addresses of the local system.
+      --builtinbackup-file-chunk-size uint                               Size of each chunk (in bytes) when splitting large files for parallel backup/restore. (default 1073741824)
+      --builtinbackup-file-chunk-threshold uint                          Files larger than this size (in bytes) are split into chunks for parallel backup/restore. 0 disables chunking.
       --builtinbackup-file-read-buffer-size uint                         read files using an IO buffer of this many bytes. Golang defaults are used when set to 0.
       --builtinbackup-file-write-buffer-size uint                        write files using an IO buffer of this many bytes. Golang defaults are used when set to 0. (default 2097152)
       --builtinbackup-incremental-restore-path string                    the directory where incremental restore files, namely binlog files, are extracted to. In k8s environments, this should be set to a directory that is shared between the vttablet and mysqld pods. The path should exist. When empty, the default OS temp dir is assumed.

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -63,6 +63,8 @@ Flags:
       --binlog_player_grpc_key string                                    the key to use to connect
       --binlog_player_grpc_server_name string                            the server name to use to validate server certificate
       --binlog_player_protocol string                                    the protocol to download binlogs from a vttablet (default "grpc")
+      --builtinbackup-file-chunk-size uint                               Size of each chunk (in bytes) when splitting large files for parallel backup/restore. (default 1073741824)
+      --builtinbackup-file-chunk-threshold uint                          Files larger than this size (in bytes) are split into chunks for parallel backup/restore. 0 disables chunking.
       --builtinbackup-file-read-buffer-size uint                         read files using an IO buffer of this many bytes. Golang defaults are used when set to 0.
       --builtinbackup-file-write-buffer-size uint                        write files using an IO buffer of this many bytes. Golang defaults are used when set to 0. (default 2097152)
       --builtinbackup-incremental-restore-path string                    the directory where incremental restore files, namely binlog files, are extracted to. In k8s environments, this should be set to a directory that is shared between the vttablet and mysqld pods. The path should exist. When empty, the default OS temp dir is assumed.

--- a/go/flags/endtoend/vttestserver.txt
+++ b/go/flags/endtoend/vttestserver.txt
@@ -11,6 +11,8 @@ Flags:
       --backup_storage_block_size int                                    if backup_storage_compress is true, backup_storage_block_size sets the byte size for each block while compressing (default is 250000). (default 250000)
       --backup_storage_compress                                          if set, the backup files will be compressed. (default true)
       --backup_storage_number_blocks int                                 if backup_storage_compress is true, backup_storage_number_blocks sets the number of blocks that can be processed, in parallel, before the writer blocks, during compression (default is 2). It should be equal to the number of CPUs available for compression. (default 2)
+      --builtinbackup-file-chunk-size uint                               Size of each chunk (in bytes) when splitting large files for parallel backup/restore. (default 1073741824)
+      --builtinbackup-file-chunk-threshold uint                          Files larger than this size (in bytes) are split into chunks for parallel backup/restore. 0 disables chunking.
       --builtinbackup-file-read-buffer-size uint                         read files using an IO buffer of this many bytes. Golang defaults are used when set to 0.
       --builtinbackup-file-write-buffer-size uint                        write files using an IO buffer of this many bytes. Golang defaults are used when set to 0. (default 2097152)
       --builtinbackup-incremental-restore-path string                    the directory where incremental restore files, namely binlog files, are extracted to. In k8s environments, this should be set to a directory that is shared between the vttablet and mysqld pods. The path should exist. When empty, the default OS temp dir is assumed.

--- a/go/test/endtoend/backup/s3/s3_builtin_test.go
+++ b/go/test/endtoend/backup/s3/s3_builtin_test.go
@@ -40,6 +40,7 @@ import (
 	"vitess.io/vitess/go/vt/mysqlctl/backupstats"
 	"vitess.io/vitess/go/vt/mysqlctl/blackbox"
 	"vitess.io/vitess/go/vt/mysqlctl/s3backupstorage"
+	"vitess.io/vitess/go/vt/servenv"
 )
 
 /*
@@ -171,7 +172,7 @@ func runBackupTest(t *testing.T, cfg backupTestConfig) {
 	})
 
 	ctx := context.Background()
-	backupRoot, keyspace, shard, ts := blackbox.SetupCluster(ctx, t, 2, 2)
+	backupRoot, keyspace, shard, ts := blackbox.SetupCluster(ctx, t, 2, 2, 13)
 
 	be := &mysqlctl.BuiltinBackupEngine{}
 
@@ -255,6 +256,28 @@ func TestExecuteBackupS3FailEachFileOnce(t *testing.T) {
 	})
 }
 
+func TestExecuteBackupS3FatalError(t *testing.T) {
+	runBackupTest(t, backupTestConfig{
+		concurrency: 1,
+
+		addFileReturnFn:   s3backupstorage.FailWithFatalError,
+		checkCleanupError: false,
+		expectedResult:    mysqlctl.BackupUnusable,
+
+		// FAILED_PRECONDITION must abort immediately without retrying.
+		// With 4 files and concurrency=1, only the first file is attempted.
+		// AddFile fails before any Destination stats are recorded.
+		expectedStats: blackbox.StatSummary{
+			DestinationCloseStats: 0,
+			DestinationOpenStats:  0,
+			DestinationWriteStats: 0,
+			SourceCloseStats:      1,
+			SourceOpenStats:       1,
+			SourceReadStats:       0,
+		},
+	})
+}
+
 func TestExecuteBackupS3FailEachFileTwice(t *testing.T) {
 	runBackupTest(t, backupTestConfig{
 		concurrency: 1,
@@ -285,9 +308,10 @@ func TestExecuteBackupS3FailEachFileTwice(t *testing.T) {
 }
 
 type restoreTestConfig struct {
-	readFileReturnFn func(s3 *s3backupstorage.S3BackupHandle, ctx context.Context, filename string, firstRead bool) (io.ReadCloser, error)
-	expectSuccess    bool
-	expectedStats    blackbox.StatSummary
+	readFileReturnFn         func(s3 *s3backupstorage.S3BackupHandle, ctx context.Context, filename string, firstRead bool) (io.ReadCloser, error)
+	expectSuccess            bool
+	expectedStats            blackbox.StatSummary
+	expectedReadFileAttempts int // if > 0, assert total ReadFile attempts on the restore handle
 }
 
 func runRestoreTest(t *testing.T, cfg restoreTestConfig) {
@@ -300,7 +324,7 @@ func runRestoreTest(t *testing.T, cfg restoreTestConfig) {
 	})
 
 	ctx := context.Background()
-	backupRoot, keyspace, shard, ts := blackbox.SetupCluster(ctx, t, 2, 2)
+	backupRoot, keyspace, shard, ts := blackbox.SetupCluster(ctx, t, 2, 2, 13)
 
 	fakeStats := backupstats.NewFakeStats()
 	logger := logutil.NewMemoryLogger()
@@ -397,6 +421,10 @@ func runRestoreTest(t *testing.T, cfg restoreTestConfig) {
 	require.Equal(t, cfg.expectedStats.SourceCloseStats, ss.SourceCloseStats)
 	require.Equal(t, cfg.expectedStats.SourceOpenStats, ss.SourceOpenStats)
 	require.Equal(t, cfg.expectedStats.SourceReadStats, ss.SourceReadStats)
+
+	if cfg.expectedReadFileAttempts > 0 {
+		require.Equal(t, cfg.expectedReadFileAttempts, restoreBh.ReadFileAttempts())
+	}
 }
 
 func TestExecuteRestoreS3FailEachFileOnce(t *testing.T) {
@@ -431,4 +459,164 @@ func TestExecuteRestoreS3FailEachFileTwice(t *testing.T) {
 			SourceReadStats:       5,
 		},
 	})
+}
+
+func TestExecuteRestoreS3FatalError(t *testing.T) {
+	runRestoreTest(t, restoreTestConfig{
+		readFileReturnFn: s3backupstorage.FailWithFatalReadError,
+		expectSuccess:    false,
+
+		// FAILED_PRECONDITION must abort immediately without retrying.
+		// ReadFile fails before any stats are recorded.
+		expectedStats: blackbox.StatSummary{
+			DestinationCloseStats: 0,
+			DestinationOpenStats:  0,
+			DestinationWriteStats: 0,
+			SourceCloseStats:      0,
+			SourceOpenStats:       0,
+			SourceReadStats:       0,
+		},
+
+		// MANIFEST is read once (allowed), plus one data file attempt = 2 total.
+		// With retry (broken behavior), ReadFileCount would be 3+.
+		expectedReadFileAttempts: 2,
+	})
+}
+
+func TestExecuteBackupRestoreS3WithChunking(t *testing.T) {
+	checkEnvForS3(t)
+
+	const (
+		dirs        = 1
+		filesPerDir = 1
+		fileSize    = 5 * 1024 * 1024 // 5MiB — just over the minimum chunk size to produce 2 chunks
+		chunkSize   = 4 * 1024 * 1024 // 4MiB
+	)
+
+	// GetFlagSetFor re-registers all flags (including S3 ones) with their
+	// defaults, so it must be called before InitFlag to avoid overwriting
+	// the bucket/region/endpoint values.
+	fs := servenv.GetFlagSetFor("vtbackup")
+	oldThreshold := fs.Lookup("builtinbackup-file-chunk-threshold").Value.String()
+	oldSize := fs.Lookup("builtinbackup-file-chunk-size").Value.String()
+	require.NoError(t, fs.Set("builtinbackup-file-chunk-threshold", strconv.Itoa(chunkSize)))
+	require.NoError(t, fs.Set("builtinbackup-file-chunk-size", strconv.Itoa(chunkSize)))
+	t.Cleanup(func() {
+		fs.Set("builtinbackup-file-chunk-threshold", oldThreshold)
+		fs.Set("builtinbackup-file-chunk-size", oldSize)
+	})
+
+	s3backupstorage.InitFlag(s3backupstorage.FakeConfig{
+		Region:    os.Getenv("AWS_REGION"),
+		Endpoint:  os.Getenv("AWS_ENDPOINT"),
+		Bucket:    os.Getenv("AWS_BUCKET"),
+		ForcePath: true,
+	})
+
+	ctx := context.Background()
+	backupRoot, keyspace, shard, ts := blackbox.SetupCluster(ctx, t, dirs, filesPerDir, fileSize)
+
+	be := &mysqlctl.BuiltinBackupEngine{}
+
+	oldDeadline := blackbox.SetBuiltinBackupMysqldDeadline(time.Second)
+	defer blackbox.SetBuiltinBackupMysqldDeadline(oldDeadline)
+
+	fakeStats := backupstats.NewFakeStats()
+	logger := logutil.NewMemoryLogger()
+
+	dirName := time.Now().Format(mysqlctl.BackupTimestampFormat)
+	name := t.Name() + "-" + strconv.Itoa(int(time.Now().Unix()))
+	bh, err := s3backupstorage.NewFakeS3BackupHandle(ctx, name, dirName, logger, fakeStats)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, bh.AbortBackup(ctx))
+	})
+
+	fakedb := fakesqldb.New(t)
+	defer fakedb.Close()
+	mysqld := mysqlctl.NewFakeMysqlDaemon(fakedb)
+	defer mysqld.Close()
+	mysqld.ExpectedExecuteSuperQueryList = []string{"STOP REPLICA", "START REPLICA"}
+
+	backupResult, err := be.ExecuteBackup(ctx, mysqlctl.BackupParams{
+		Logger: logger,
+		Mysqld: mysqld,
+		Cnf: &mysqlctl.Mycnf{
+			InnodbDataHomeDir:     path.Join(backupRoot, "innodb"),
+			InnodbLogGroupHomeDir: path.Join(backupRoot, "log"),
+			DataDir:               path.Join(backupRoot, "datadir"),
+		},
+		Concurrency:          4,
+		HookExtraEnv:         map[string]string{},
+		TopoServer:           ts,
+		Keyspace:             keyspace,
+		Shard:                shard,
+		Stats:                fakeStats,
+		MysqlShutdownTimeout: blackbox.MysqlShutdownTimeout,
+	}, bh)
+
+	require.NoError(t, err)
+	require.Equal(t, mysqlctl.BackupUsable, backupResult)
+
+	ss := blackbox.GetStats(fakeStats)
+	totalFiles := dirs * filesPerDir
+	chunksPerFile := (fileSize + chunkSize - 1) / chunkSize
+	totalChunks := totalFiles * chunksPerFile
+	t.Logf("Backup stats: %d files, %d chunks total (%d chunks per file)", totalFiles, ss.DestinationCloseStats, chunksPerFile)
+	assert.Equal(t, totalChunks, ss.DestinationCloseStats)
+	assert.Equal(t, totalChunks, ss.DestinationOpenStats)
+	assert.Equal(t, totalChunks, ss.DestinationWriteStats)
+	assert.Equal(t, totalChunks, ss.SourceCloseStats)
+	assert.Equal(t, totalChunks, ss.SourceOpenStats)
+	assert.Equal(t, totalChunks, ss.SourceReadStats)
+
+	// Restore the chunked backup
+	restoreStats := backupstats.NewFakeStats()
+	restoreBh, err := s3backupstorage.NewFakeS3RestoreHandle(ctx, name, logger, restoreStats)
+	require.NoError(t, err)
+
+	fakedb = fakesqldb.New(t)
+	defer fakedb.Close()
+	mysqld = mysqlctl.NewFakeMysqlDaemon(fakedb)
+	defer mysqld.Close()
+	mysqld.ExpectedExecuteSuperQueryList = []string{"STOP REPLICA", "START REPLICA"}
+
+	restoreParams := mysqlctl.RestoreParams{
+		Cnf: &mysqlctl.Mycnf{
+			InnodbDataHomeDir:     path.Join(backupRoot, "innodb"),
+			InnodbLogGroupHomeDir: path.Join(backupRoot, "log"),
+			DataDir:               path.Join(backupRoot, "datadir"),
+			BinLogPath:            path.Join(backupRoot, "binlog"),
+			RelayLogPath:          path.Join(backupRoot, "relaylog"),
+			RelayLogIndexPath:     path.Join(backupRoot, "relaylogindex"),
+			RelayLogInfoPath:      path.Join(backupRoot, "relayloginfo"),
+		},
+		Logger:               logger,
+		Mysqld:               mysqld,
+		Concurrency:          4,
+		HookExtraEnv:         map[string]string{},
+		DeleteBeforeRestore:  false,
+		DbName:               "test",
+		Keyspace:             "test",
+		Shard:                "-",
+		StartTime:            time.Now(),
+		RestoreToPos:         replication.Position{},
+		RestoreToTimestamp:   time.Time{},
+		DryRun:               false,
+		Stats:                restoreStats,
+		MysqlShutdownTimeout: blackbox.MysqlShutdownTimeout,
+	}
+
+	bm, err := be.ExecuteRestore(ctx, restoreParams, restoreBh)
+	require.NoError(t, err)
+	assert.NotNil(t, bm)
+
+	restoreSS := blackbox.GetStats(restoreStats)
+	assert.Equal(t, totalChunks, restoreSS.DestinationOpenStats)
+	assert.Equal(t, totalChunks, restoreSS.DestinationCloseStats)
+	assert.Equal(t, totalChunks, restoreSS.DestinationWriteStats)
+	assert.Equal(t, totalFiles*fileSize, restoreSS.DestinationWriteBytes)
+	assert.Equal(t, totalChunks, restoreSS.SourceCloseStats)
+	assert.Equal(t, totalChunks, restoreSS.SourceOpenStats)
+	assert.Equal(t, totalChunks, restoreSS.SourceReadStats)
 }

--- a/go/test/endtoend/backup/vtbackup/backup_only_test.go
+++ b/go/test/endtoend/backup/vtbackup/backup_only_test.go
@@ -34,6 +34,7 @@ import (
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/stats/opentsdb"
 	"vitess.io/vitess/go/test/endtoend/cluster"
+	"vitess.io/vitess/go/test/endtoend/utils"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/mysqlctl"
 )
@@ -136,10 +137,12 @@ func prepareCluster(t *testing.T) {
 	// Vitess expects that the user has set the database into ReadWrite mode before calling
 	// TabletExternallyReparented
 	err = localCluster.VtctldClientProcess.ExecuteCommand(
-		"SetWritable", primary.Alias, "true")
+		"SetWritable", primary.Alias, "true",
+	)
 	require.NoError(t, err)
 	err = localCluster.VtctldClientProcess.ExecuteCommand(
-		"TabletExternallyReparented", primary.Alias)
+		"TabletExternallyReparented", primary.Alias,
+	)
 	require.NoError(t, err)
 	restore(t, replica1, "replica", "SERVING")
 }
@@ -227,7 +230,7 @@ func firstBackupTest(t *testing.T, removeBackup bool) {
 	}
 }
 
-func startVtBackup(t *testing.T, initialBackup bool, restartBeforeBackup, disableRedoLog bool) (*os.File, error) {
+func startVtBackup(t *testing.T, initialBackup bool, restartBeforeBackup, disableRedoLog bool, additionalArgs ...string) (*os.File, error) {
 	mysqlSocket, err := os.CreateTemp("", "vtbackup_test_mysql.sock")
 	require.NoError(t, err)
 	defer os.Remove(mysqlSocket.Name())
@@ -252,6 +255,7 @@ func startVtBackup(t *testing.T, initialBackup bool, restartBeforeBackup, disabl
 	if disableRedoLog {
 		extraArgs = append(extraArgs, "--disable-redo-log")
 	}
+	extraArgs = append(extraArgs, additionalArgs...)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -472,6 +476,78 @@ func verifyDisableEnableRedoLogs(ctx context.Context, t *testing.T, mysqlSocket 
 			return
 		}
 	}
+}
+
+// TestVtBackupWithChunking verifies that the vtbackup binary accepts chunking
+// flags and produces a chunked backup. It then restores the chunked backup on
+// replica2 and verifies the data is intact.
+func TestVtBackupWithChunking(t *testing.T) {
+	// Chunked backups are a v25 feature; older vttablets can't restore them.
+	utils.SkipIfBinaryIsBelowVersion(t, 25, "vttablet")
+	prepareCluster(t)
+
+	_, err := primary.VttabletProcess.QueryTablet(vtInsertTest, keyspaceName, true)
+	require.NoError(t, err)
+	_, err = primary.VttabletProcess.QueryTablet("insert into vt_insert_test (msg) values ('test1')", keyspaceName, true)
+	require.NoError(t, err)
+
+	cluster.VerifyRowsInTablet(t, replica1, keyspaceName, 1)
+
+	_, err = startVtBackup(
+		t, false, true, false,
+		"--builtinbackup-file-chunk-threshold", "4194304",
+		"--builtinbackup-file-chunk-size", "4194304",
+	)
+	require.NoError(t, err)
+
+	backups, err := listBackups(shardKsName)
+	require.NoError(t, err)
+	require.NotEmpty(t, backups)
+
+	backupLocation := path.Join(localCluster.VtbackupProcess.FileBackupStorageRoot, keyspaceName, shardName, backups[len(backups)-1])
+	manifestData, err := os.ReadFile(path.Join(backupLocation, "MANIFEST"))
+	require.NoError(t, err)
+
+	var manifest struct {
+		FileEntries []mysqlctl.FileEntry
+	}
+	require.NoError(t, json.Unmarshal(manifestData, &manifest))
+
+	chunkedFiles := 0
+	for _, fe := range manifest.FileEntries {
+		if len(fe.Chunks) > 0 {
+			chunkedFiles++
+			t.Logf("File %s: %d chunks", fe.Name, len(fe.Chunks))
+		}
+	}
+	assert.Positive(t, chunkedFiles, "expected at least one file with chunks in MANIFEST")
+
+	err = localCluster.InitTablet(replica2, keyspaceName, shardName)
+	require.NoError(t, err)
+	restore(t, replica2, "replica", "SERVING")
+	waitForRestoreComplete(t, replica2.VttabletProcess, 180*time.Second)
+	waitForReplicationToCatchup([]cluster.Vttablet{*replica2})
+	cluster.VerifyRowsInTablet(t, replica2, keyspaceName, 1)
+
+	removeBackups(t)
+	tearDown(t, true)
+}
+
+func waitForRestoreComplete(t *testing.T, vttablet *cluster.VttabletProcess, timeout time.Duration) {
+	t.Helper()
+	sawRestore := false
+	assert.Eventually(t, func() bool {
+		tabletType := vttablet.GetTabletType()
+		if tabletType == "restore" {
+			sawRestore = true
+		}
+		return sawRestore && tabletType == "replica"
+	}, timeout, 300*time.Millisecond)
+	if sawRestore {
+		require.Equal(t, "replica", vttablet.GetTabletType(), "timed out waiting for tablet restore to complete")
+	}
+	// If we never observed "restore" type, the restore likely completed
+	// before we started polling. Nothing to wait for.
 }
 
 // This helper function wait for all replicas to catch-up the replication.

--- a/go/test/endtoend/backup/vtctlbackup/backup_test.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_test.go
@@ -17,7 +17,10 @@ limitations under the License.
 package vtctlbackup
 
 import (
+	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/vt/mysqlctl"
 )
@@ -65,6 +68,47 @@ func TestBuiltinBackupWithExternalZstdCompressionAndManifestedDecompressor(t *te
 	}
 
 	TestBackup(t, BuiltinBackup, "xbstream", 0, cDetails, []string{"TestReplicaBackup", "TestPrimaryBackup"})
+}
+
+// TestBuiltinBackupChunked uses a low chunk threshold and chunk size (4MiB each) to force
+// InnoDB files (ibdata1, undo tablespaces) to be split into multiple chunks during backup.
+// This verifies that MySQL can start successfully and read back rows after a chunked restore.
+func TestBuiltinBackupChunked(t *testing.T) {
+	defer setDefaultCommonArgs()
+	const chunkSizeBytes = 4194304 // 4MiB
+	commonTabletArg = append(
+		getDefaultCommonArgs(),
+		"--builtinbackup-file-chunk-threshold", strconv.Itoa(chunkSizeBytes),
+		"--builtinbackup-file-chunk-size", strconv.Itoa(chunkSizeBytes),
+	)
+
+	code, err := LaunchCluster(BuiltinBackup, "xbstream", 0, nil)
+	require.NoErrorf(t, err, "setup failed with status code %d", code)
+	defer TearDownCluster()
+
+	t.Run("TestChunkedBackup", chunkedBackup)
+}
+
+// TestBuiltinBackupNonChunked verifies that with the default threshold of 0, no chunking
+// occurs and the MANIFEST remains compatible with older Vitess versions.
+func TestBuiltinBackupNonChunked(t *testing.T) {
+	defer setDefaultCommonArgs()
+	code, err := LaunchCluster(BuiltinBackup, "xbstream", 0, nil)
+	require.NoErrorf(t, err, "setup failed with status code %d", code)
+	defer TearDownCluster()
+
+	t.Run("TestNonChunkedBackup", nonChunkedBackup)
+}
+
+// TestBuiltinBackupChunkedRestoreNonChunked verifies that a tablet configured with
+// chunking can restore a non-chunked backup (forward compatibility).
+func TestBuiltinBackupChunkedRestoreNonChunked(t *testing.T) {
+	defer setDefaultCommonArgs()
+	code, err := LaunchCluster(BuiltinBackup, "xbstream", 0, nil)
+	require.NoErrorf(t, err, "setup failed with status code %d", code)
+	defer TearDownCluster()
+
+	t.Run("TestChunkedRestoreNonChunked", chunkedRestoreNonChunkedBackup)
 }
 
 func setDefaultCompressionFlag() {

--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -69,7 +69,6 @@ var (
 	newInitDBFile    string
 	currentSetupType int
 	cell             = cluster.DefaultCell
-
 	hostname         = "localhost"
 	keyspaceName     = "ks"
 	dbPassword       = "VtDbaPass"
@@ -192,8 +191,10 @@ func LaunchCluster(setupType int, streamMode string, stripes int, cDetails *Comp
 		// since we spin different mysqld processes, we need to pass exactly the socket of the this particular
 		// one when running mysql shell dump/loads
 		if setupType == MySQLShell {
-			commonTabletArg = append(commonTabletArg,
-				"--mysql-shell-flags", fmt.Sprintf("--js -u vt_dba -p%s -S %s", dbPassword,
+			commonTabletArg = append(
+				commonTabletArg,
+				"--mysql-shell-flags", fmt.Sprintf(
+					"--js -u vt_dba -p%s -S %s", dbPassword,
 					path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("/vt_%010d", tablet.TabletUID), "mysql.sock"),
 				),
 			)
@@ -969,6 +970,158 @@ func vtctlBackup(t *testing.T, tabletType string) {
 	require.NoError(t, err)
 }
 
+func chunkedBackup(t *testing.T) {
+	verifyBackupChunking(t, true, 4194304)
+}
+
+func nonChunkedBackup(t *testing.T) {
+	verifyBackupChunking(t, false, 0)
+}
+
+func chunkedRestoreNonChunkedBackup(t *testing.T) {
+	verifyInitialReplication(t)
+
+	// Launch replica2 with chunking flags enabled but waiting for a backup.
+	// The backup itself will be non-chunked (taken by replica1 without chunking).
+	replica2.Type = "replica"
+	replica2.ValidateTabletRestart(t)
+	replicaTabletArgs := append(
+		commonTabletArg,
+		"--wait_for_backup_interval", "1s",
+		"--init_tablet_type", "replica",
+		"--builtinbackup-file-chunk-threshold", "4194304",
+		"--builtinbackup-file-chunk-size", "4194304",
+	)
+	replica2.VttabletProcess.ExtraArgs = replicaTabletArgs
+	replica2.VttabletProcess.ServingStatus = ""
+	err := replica2.VttabletProcess.Setup()
+	require.NoError(t, err)
+
+	// Take a non-chunked backup on replica1.
+	err = localCluster.VtctldClientProcess.ExecuteCommand("Backup", replica1.Alias)
+	require.NoError(t, err)
+
+	backups := localCluster.VerifyBackupCount(t, shardKsName, 1)
+
+	// Verify the MANIFEST has no chunks (non-chunked backup).
+	backupLocation := path.Join(localCluster.CurrentVTDATAROOT, "backups", keyspaceName, shardName, backups[0])
+	manifestData, err := os.ReadFile(path.Join(backupLocation, "MANIFEST"))
+	require.NoError(t, err)
+	var manifest struct {
+		FileEntries []struct {
+			Chunks []struct{}
+		}
+	}
+	require.NoError(t, json.Unmarshal(manifestData, &manifest))
+	for _, fe := range manifest.FileEntries {
+		require.Empty(t, fe.Chunks, "expected non-chunked backup but found chunks in MANIFEST")
+	}
+
+	// Verify replica2 restores successfully from the non-chunked backup.
+	err = replica2.VttabletProcess.WaitForTabletStatusesForTimeout([]string{"SERVING"}, 25*time.Second)
+	require.NoError(t, err)
+	cluster.VerifyRowsInTablet(t, replica2, keyspaceName, 1)
+
+	verifyAfterRemovingBackupNoBackupShouldBePresent(t, backups)
+	err = replica2.VttabletProcess.TearDown()
+	require.NoError(t, err)
+	err = localCluster.VtctldClientProcess.ExecuteCommand("DeleteTablets", replica2.Alias)
+	require.NoError(t, err)
+	_, err = primary.VttabletProcess.QueryTablet("DROP TABLE vt_insert_test", keyspaceName, true)
+	require.NoError(t, err)
+}
+
+func verifyBackupChunking(t *testing.T, expectChunked bool, chunkSizeBytes int64) {
+	verifyInitialReplication(t)
+
+	cluster.VerifyRowsInTablet(t, replica1, keyspaceName, 1)
+
+	restoreWaitForBackup(t, "replica", nil, true)
+
+	err := localCluster.VtctldClientProcess.ExecuteCommand("Backup", replica1.Alias)
+	require.NoError(t, err)
+
+	backups := localCluster.VerifyBackupCount(t, shardKsName, 1)
+	backupLocation := path.Join(localCluster.CurrentVTDATAROOT, "backups", keyspaceName, shardName, backups[0])
+
+	manifestData, err := os.ReadFile(path.Join(backupLocation, "MANIFEST"))
+	require.NoError(t, err)
+
+	var manifest struct {
+		FileEntries []struct {
+			Name   string
+			Chunks []struct {
+				StorageName string
+				Offset      int64
+				Size        int64
+				Hash        string
+			}
+		}
+	}
+	require.NoError(t, json.Unmarshal(manifestData, &manifest))
+
+	totalChunks := 0
+	chunkedFileCount := 0
+	nonChunkedFileCount := 0
+	for _, fe := range manifest.FileEntries {
+		if len(fe.Chunks) > 0 {
+			chunkedFileCount++
+			totalChunks += len(fe.Chunks)
+
+			// We want to make sure the chunk count matches what we are expecting in terms of the file size.
+			lastChunk := fe.Chunks[len(fe.Chunks)-1]
+			fileSize := lastChunk.Offset + lastChunk.Size
+			expectedChunks := int(fileSize / chunkSizeBytes)
+			if fileSize%chunkSizeBytes != 0 {
+				expectedChunks++
+			}
+			assert.Len(t, fe.Chunks, expectedChunks, "file %s: expected %d chunks for size %d with chunk size %d", fe.Name, expectedChunks, fileSize, chunkSizeBytes)
+			t.Logf("File %s: size=%d, chunks=%d (expected %d)", fe.Name, fileSize, len(fe.Chunks), expectedChunks)
+
+			for _, chunk := range fe.Chunks {
+				assert.NotEmpty(t, chunk.StorageName, "chunk StorageName must not be empty for file %s", fe.Name)
+				assert.NotEmpty(t, chunk.Hash, "chunk Hash must not be empty for file %s", fe.Name)
+				assert.Contains(t, chunk.StorageName, "-", "chunk StorageName must follow fileIndex-chunkIndex format, got %s", chunk.StorageName)
+				assert.Positive(t, chunk.Size, "chunk Size must be positive for file %s chunk %s", fe.Name, chunk.StorageName)
+			}
+		} else {
+			nonChunkedFileCount++
+		}
+	}
+	t.Logf("Total chunks: %d, chunked files: %d, non-chunked files: %d", totalChunks, chunkedFileCount, nonChunkedFileCount)
+
+	if expectChunked {
+		assert.Positive(t, chunkedFileCount, "expected at least one file to be chunked")
+		assert.Positive(t, nonChunkedFileCount, "expected at least one file to NOT be chunked (mixed scenario)")
+
+		// Verify that our small test table (well under chunk threshold) was NOT chunked.
+		foundSmallFile := false
+		for _, fe := range manifest.FileEntries {
+			if strings.Contains(fe.Name, "vt_insert_test") {
+				foundSmallFile = true
+				t.Logf("File %s: not chunked", fe.Name)
+				assert.Empty(t, fe.Chunks, "small file %s should not be chunked", fe.Name)
+			}
+		}
+		assert.True(t, foundSmallFile, "expected vt_insert_test table file in manifest")
+	} else {
+		assert.Equal(t, 0, chunkedFileCount, "expected no chunked files with threshold=0")
+		assert.Equal(t, 0, totalChunks, "expected no chunking with threshold=0")
+	}
+
+	err = replica2.VttabletProcess.WaitForTabletStatusesForTimeout([]string{"SERVING"}, 25*time.Second)
+	require.NoError(t, err)
+	cluster.VerifyRowsInTablet(t, replica2, keyspaceName, 1)
+
+	verifyAfterRemovingBackupNoBackupShouldBePresent(t, backups)
+	err = replica2.VttabletProcess.TearDown()
+	require.NoError(t, err)
+	err = localCluster.VtctldClientProcess.ExecuteCommand("DeleteTablets", replica2.Alias)
+	require.NoError(t, err)
+	_, err = primary.VttabletProcess.QueryTablet("DROP TABLE vt_insert_test", keyspaceName, true)
+	require.NoError(t, err)
+}
+
 func InitTestTable(t *testing.T) {
 	_, err := primary.VttabletProcess.QueryTablet("DROP TABLE IF EXISTS vt_insert_test", keyspaceName, true)
 	require.NoError(t, err)
@@ -1608,7 +1761,8 @@ func TestRestoreAllowedBackupEngines(t *testing.T) {
 		// check the new replica has the data
 		cluster.VerifyRowsInTablet(t, replica2, keyspaceName, 2)
 		result, err := replica2.VttabletProcess.QueryTablet(
-			fmt.Sprintf("select msg from vt_insert_test where msg='%s'", backupMsg), replica2.VttabletProcess.Keyspace, true)
+			fmt.Sprintf("select msg from vt_insert_test where msg='%s'", backupMsg), replica2.VttabletProcess.Keyspace, true,
+		)
 		require.NoError(t, err)
 		require.Equal(t, backupMsg, result.Named().Row().AsString("msg", ""))
 	})
@@ -1636,7 +1790,8 @@ func TestRestoreAllowedBackupEngines(t *testing.T) {
 		cluster.VerifyRowsInTablet(t, replica2, keyspaceName, 2)
 
 		result, err := replica2.VttabletProcess.QueryTablet(
-			fmt.Sprintf("select msg from vt_insert_test where msg='%s'", backupMsg), replica2.VttabletProcess.Keyspace, true)
+			fmt.Sprintf("select msg from vt_insert_test where msg='%s'", backupMsg), replica2.VttabletProcess.Keyspace, true,
+		)
 		require.NoError(t, err)
 		require.Equal(t, backupMsg, result.Named().Row().AsString("msg", ""))
 	})

--- a/go/vt/mysqlctl/azblobbackupstorage/azblob.go
+++ b/go/vt/mysqlctl/azblobbackupstorage/azblob.go
@@ -256,12 +256,17 @@ func (bh *AZBlobBackupHandle) AddFile(ctx context.Context, filename string, file
 	return writer, nil
 }
 
+// Wait implements BackupHandle.
+func (bh *AZBlobBackupHandle) Wait() {
+	bh.waitGroup.Wait()
+}
+
 // EndBackup implements BackupHandle.
 func (bh *AZBlobBackupHandle) EndBackup(ctx context.Context) error {
 	if bh.readOnly {
 		return fmt.Errorf("EndBackup cannot be called on read-only backup")
 	}
-	bh.waitGroup.Wait()
+	bh.Wait()
 	return bh.Error()
 }
 

--- a/go/vt/mysqlctl/backupstorage/interface.go
+++ b/go/vt/mysqlctl/backupstorage/interface.go
@@ -74,6 +74,19 @@ type BackupHandle interface {
 	// the file size is unknown.
 	AddFile(ctx context.Context, filename string, filesize int64) (io.WriteCloser, error)
 
+	// Wait blocks until all pending asynchronous AddFile operations complete.
+	// It does not finalize the backup; AddFile may still be called after Wait.
+	// Errors from async operations are available via Error()/GetFailedFiles().
+	// Idempotent and safe to call multiple times.
+	//
+	// The backup engine calls Wait() to drain in-flight uploads and inspect
+	// errors before deciding whether to proceed or abort. The top-level caller
+	// (not the engine) is responsible for calling EndBackup() to finalize, or
+	// AbortBackup() to discard. Storage implementations should not place
+	// upload-completion logic in EndBackup(); all async work must resolve by
+	// the time Wait() returns.
+	Wait()
+
 	// EndBackup stops and closes a backup. The contents should be kept.
 	// Only works for read-write backups (created by StartBackup).
 	EndBackup(ctx context.Context) error

--- a/go/vt/mysqlctl/blackbox/backup_race_test.go
+++ b/go/vt/mysqlctl/blackbox/backup_race_test.go
@@ -71,8 +71,8 @@ func TestExecuteBackupWithFailureOnLastFile(t *testing.T) {
 	// backupFiles() method (https://github.com/vitessio/vitess/blob/main/go/vt/mysqlctl/builtinbackupengine.go#L483).
 	require.NoError(t, createBackupDir(dataDir, "test1"))
 	require.NoError(t, createBackupDir(dataDir, "test2"))
-	require.NoError(t, createBackupFiles(path.Join(dataDir, "test1"), 2, "ibd"))
-	require.NoError(t, createBackupFiles(path.Join(dataDir, "test2"), 2, "ibd"))
+	require.NoError(t, createBackupFiles(path.Join(dataDir, "test1"), 2, "ibd", 13))
+	require.NoError(t, createBackupFiles(path.Join(dataDir, "test2"), 2, "ibd", 13))
 	defer os.RemoveAll(backupRoot)
 
 	needIt, err := NeedInnoDBRedoLogSubdir()

--- a/go/vt/mysqlctl/blackbox/backup_test.go
+++ b/go/vt/mysqlctl/blackbox/backup_test.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -47,6 +48,7 @@ import (
 	"vitess.io/vitess/go/vt/mysqlctl/filebackupstorage"
 	"vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/proto/vttime"
+	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
 )
@@ -62,8 +64,8 @@ func TestExecuteBackup(t *testing.T) {
 	// Add some files under data directory to force backup to actually backup files.
 	require.NoError(t, createBackupDir(dataDir, "test1"))
 	require.NoError(t, createBackupDir(dataDir, "test2"))
-	require.NoError(t, createBackupFiles(path.Join(dataDir, "test1"), 2, "ibd"))
-	require.NoError(t, createBackupFiles(path.Join(dataDir, "test2"), 2, "ibd"))
+	require.NoError(t, createBackupFiles(path.Join(dataDir, "test1"), 2, "ibd", 13))
+	require.NoError(t, createBackupFiles(path.Join(dataDir, "test2"), 2, "ibd", 13))
 	defer os.RemoveAll(backupRoot)
 
 	needIt, err := NeedInnoDBRedoLogSubdir()
@@ -208,8 +210,8 @@ func TestExecuteBackupWithSafeUpgrade(t *testing.T) {
 	// Add some files under data directory to force backup to actually backup files.
 	require.NoError(t, createBackupDir(dataDir, "test1"))
 	require.NoError(t, createBackupDir(dataDir, "test2"))
-	require.NoError(t, createBackupFiles(path.Join(dataDir, "test1"), 2, "ibd"))
-	require.NoError(t, createBackupFiles(path.Join(dataDir, "test2"), 2, "ibd"))
+	require.NoError(t, createBackupFiles(path.Join(dataDir, "test1"), 2, "ibd", 13))
+	require.NoError(t, createBackupFiles(path.Join(dataDir, "test2"), 2, "ibd", 13))
 	defer os.RemoveAll(backupRoot)
 
 	needIt, err := NeedInnoDBRedoLogSubdir()
@@ -301,8 +303,8 @@ func TestExecuteBackupWithCanceledContext(t *testing.T) {
 	// backupFiles() method (https://github.com/vitessio/vitess/blob/main/go/vt/mysqlctl/builtinbackupengine.go#L483).
 	require.NoError(t, createBackupDir(dataDir, "test1"))
 	require.NoError(t, createBackupDir(dataDir, "test2"))
-	require.NoError(t, createBackupFiles(path.Join(dataDir, "test1"), 2, "ibd"))
-	require.NoError(t, createBackupFiles(path.Join(dataDir, "test2"), 2, "ibd"))
+	require.NoError(t, createBackupFiles(path.Join(dataDir, "test1"), 2, "ibd", 13))
+	require.NoError(t, createBackupFiles(path.Join(dataDir, "test2"), 2, "ibd", 13))
 	defer os.RemoveAll(backupRoot)
 
 	needIt, err := NeedInnoDBRedoLogSubdir()
@@ -370,8 +372,9 @@ func TestExecuteBackupWithCanceledContext(t *testing.T) {
 	}, bh)
 
 	require.Error(t, err)
-	// all four files will fail
-	require.ErrorContains(t, err, "context canceled; context canceled; context canceled; context canceled")
+	// No work is scheduled when the context is already cancelled; we expect a
+	// single context error rather than one per file.
+	require.ErrorContains(t, err, "context canceled")
 	assert.Equal(t, mysqlctl.BackupUnusable, backupResult)
 }
 
@@ -390,8 +393,8 @@ func TestExecuteRestoreWithTimedOutContext(t *testing.T) {
 	// backupFiles() method (https://github.com/vitessio/vitess/blob/main/go/vt/mysqlctl/builtinbackupengine.go#L483).
 	require.NoError(t, createBackupDir(dataDir, "test1"))
 	require.NoError(t, createBackupDir(dataDir, "test2"))
-	require.NoError(t, createBackupFiles(path.Join(dataDir, "test1"), 2, "ibd"))
-	require.NoError(t, createBackupFiles(path.Join(dataDir, "test2"), 2, "ibd"))
+	require.NoError(t, createBackupFiles(path.Join(dataDir, "test1"), 2, "ibd", 13))
+	require.NoError(t, createBackupFiles(path.Join(dataDir, "test2"), 2, "ibd", 13))
 	defer os.RemoveAll(backupRoot)
 
 	needIt, err := NeedInnoDBRedoLogSubdir()
@@ -590,7 +593,7 @@ func newWriteCloseFailFirstWrite(firstWriteDone bool) *rwCloseFailFirstCall {
 
 func TestExecuteBackupFailToWriteEachFileOnlyOnce(t *testing.T) {
 	ctx := utils.LeakCheckContext(t)
-	backupRoot, keyspace, shard, ts := SetupCluster(ctx, t, 2, 2)
+	backupRoot, keyspace, shard, ts := SetupCluster(ctx, t, 2, 2, 13)
 
 	bufferPerFiles := make(map[string]*rwCloseFailFirstCall)
 	be := &mysqlctl.BuiltinBackupEngine{}
@@ -661,7 +664,7 @@ func TestExecuteBackupFailToWriteEachFileOnlyOnce(t *testing.T) {
 
 func TestExecuteBackupFailToWriteFileTwice(t *testing.T) {
 	ctx := utils.LeakCheckContext(t)
-	backupRoot, keyspace, shard, ts := SetupCluster(ctx, t, 1, 1)
+	backupRoot, keyspace, shard, ts := SetupCluster(ctx, t, 1, 1, 13)
 
 	bufferPerFiles := make(map[string]*rwCloseFailFirstCall)
 	be := &mysqlctl.BuiltinBackupEngine{}
@@ -726,7 +729,7 @@ func TestExecuteBackupFailToWriteFileTwice(t *testing.T) {
 
 func TestExecuteRestoreFailToReadEachFileOnlyOnce(t *testing.T) {
 	ctx := utils.LeakCheckContext(t)
-	backupRoot, keyspace, shard, ts := SetupCluster(ctx, t, 2, 2)
+	backupRoot, keyspace, shard, ts := SetupCluster(ctx, t, 2, 2, 13)
 
 	be := &mysqlctl.BuiltinBackupEngine{}
 	bufferPerFiles := make(map[string]*rwCloseFailFirstCall)
@@ -828,7 +831,7 @@ func TestExecuteRestoreFailToReadEachFileOnlyOnce(t *testing.T) {
 
 func TestExecuteRestoreFailToReadEachFileTwice(t *testing.T) {
 	ctx := utils.LeakCheckContext(t)
-	backupRoot, keyspace, shard, ts := SetupCluster(ctx, t, 2, 2)
+	backupRoot, keyspace, shard, ts := SetupCluster(ctx, t, 2, 2, 13)
 
 	be := &mysqlctl.BuiltinBackupEngine{}
 	bufferPerFiles := make(map[string]*rwCloseFailFirstCall)
@@ -930,7 +933,7 @@ func TestExecuteRestoreFailToReadEachFileTwice(t *testing.T) {
 
 func TestBackupRetryPropagatesHashToManifest(t *testing.T) {
 	ctx := utils.LeakCheckContext(t)
-	backupRoot, keyspace, shard, ts := SetupCluster(ctx, t, 2, 2)
+	backupRoot, keyspace, shard, ts := SetupCluster(ctx, t, 2, 2, 13)
 
 	bufferPerFiles := make(map[string]*rwCloseFailFirstCall)
 	be := &mysqlctl.BuiltinBackupEngine{}
@@ -983,4 +986,149 @@ func TestBackupRetryPropagatesHashToManifest(t *testing.T) {
 	for _, fe := range manifest.FileEntries {
 		assert.NotEmptyf(t, fe.Hash, "file %s should have a non-empty hash in the manifest", fe.Name)
 	}
+}
+
+func TestRestoreChunkedCorruptedBackup(t *testing.T) {
+	ctx := utils.LeakCheckContext(t)
+
+	const chunkSize = 4 * 1024 * 1024 // 4MiB (minimum allowed)
+	const fileSize = 12 * 1024 * 1024 // 12MiB → 3 chunks per file
+
+	fs := servenv.GetFlagSetFor("vtbackup")
+	oldThreshold := fs.Lookup("builtinbackup-file-chunk-threshold").Value.String()
+	oldSize := fs.Lookup("builtinbackup-file-chunk-size").Value.String()
+	require.NoError(t, fs.Set("builtinbackup-file-chunk-threshold", strconv.Itoa(chunkSize)))
+	require.NoError(t, fs.Set("builtinbackup-file-chunk-size", strconv.Itoa(chunkSize)))
+	t.Cleanup(func() {
+		fs.Set("builtinbackup-file-chunk-threshold", oldThreshold)
+		fs.Set("builtinbackup-file-chunk-size", oldSize)
+	})
+
+	backupRoot, keyspace, shard, ts := SetupCluster(ctx, t, 1, 1, fileSize)
+
+	be := &mysqlctl.BuiltinBackupEngine{}
+
+	oldDeadline := SetBuiltinBackupMysqldDeadline(time.Second)
+	defer SetBuiltinBackupMysqldDeadline(oldDeadline)
+
+	bh := filebackupstorage.NewBackupHandle(nil, "", "", false)
+
+	fakedb := fakesqldb.New(t)
+	defer fakedb.Close()
+	mysqld := mysqlctl.NewFakeMysqlDaemon(fakedb)
+	defer mysqld.Close()
+	mysqld.ExpectedExecuteSuperQueryList = []string{"STOP REPLICA", "START REPLICA"}
+
+	backupResult, err := be.ExecuteBackup(ctx, mysqlctl.BackupParams{
+		Logger: logutil.NewConsoleLogger(),
+		Mysqld: mysqld,
+		Cnf: &mysqlctl.Mycnf{
+			InnodbDataHomeDir:     path.Join(backupRoot, "innodb"),
+			InnodbLogGroupHomeDir: path.Join(backupRoot, "log"),
+			DataDir:               path.Join(backupRoot, "datadir"),
+		},
+		Stats:                backupstats.NewFakeStats(),
+		Concurrency:          1,
+		HookExtraEnv:         map[string]string{},
+		TopoServer:           ts,
+		Keyspace:             keyspace,
+		Shard:                shard,
+		MysqlShutdownTimeout: MysqlShutdownTimeout,
+	}, bh)
+
+	require.NoError(t, err)
+	require.Equal(t, mysqlctl.BackupUsable, backupResult)
+
+	// Find a chunk file to tamper with.
+	tamperedChunkPath := path.Join(filebackupstorage.FileBackupStorageRoot, "0-1")
+	originalData, err := os.ReadFile(tamperedChunkPath)
+	require.NoError(t, err)
+	require.NotEmpty(t, originalData)
+
+	restoreParams := mysqlctl.RestoreParams{
+		Cnf: &mysqlctl.Mycnf{
+			InnodbDataHomeDir:     path.Join(backupRoot, "innodb"),
+			InnodbLogGroupHomeDir: path.Join(backupRoot, "log"),
+			DataDir:               path.Join(backupRoot, "datadir"),
+			BinLogPath:            path.Join(backupRoot, "binlog"),
+			RelayLogPath:          path.Join(backupRoot, "relaylog"),
+			RelayLogIndexPath:     path.Join(backupRoot, "relaylogindex"),
+			RelayLogInfoPath:      path.Join(backupRoot, "relayloginfo"),
+		},
+		Logger:               logutil.NewConsoleLogger(),
+		Concurrency:          1,
+		HookExtraEnv:         map[string]string{},
+		DeleteBeforeRestore:  false,
+		DbName:               "test",
+		Keyspace:             "test",
+		Shard:                "-",
+		StartTime:            time.Now(),
+		RestoreToPos:         replication.Position{},
+		RestoreToTimestamp:   time.Time{},
+		DryRun:               false,
+		Stats:                backupstats.NewFakeStats(),
+		MysqlShutdownTimeout: MysqlShutdownTimeout,
+	}
+
+	t.Run("TruncatedChunk", func(t *testing.T) {
+		// Truncate chunk to half its size — decompression encounters unexpected EOF.
+		truncated := originalData[:len(originalData)/2]
+		require.NoError(t, os.WriteFile(tamperedChunkPath, truncated, 0o644))
+		defer os.WriteFile(tamperedChunkPath, originalData, 0o644)
+
+		fakedb := fakesqldb.New(t)
+		defer fakedb.Close()
+		mysqld := mysqlctl.NewFakeMysqlDaemon(fakedb)
+		defer mysqld.Close()
+		mysqld.ExpectedExecuteSuperQueryList = []string{"STOP REPLICA", "START REPLICA"}
+
+		restoreParams.Mysqld = mysqld
+		restoreParams.Stats = backupstats.NewFakeStats()
+
+		bh := filebackupstorage.NewBackupHandle(nil, "", "", true)
+		_, err := be.ExecuteRestore(ctx, restoreParams, bh)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to copy chunk 0-1: unexpected EOF")
+	})
+
+	t.Run("CorruptedData", func(t *testing.T) {
+		// Overwrite chunk with garbage at the original size — decompression fails.
+		garbage := bytes.Repeat([]byte("X"), len(originalData))
+		require.NoError(t, os.WriteFile(tamperedChunkPath, garbage, 0o644))
+		defer os.WriteFile(tamperedChunkPath, originalData, 0o644)
+
+		fakedb := fakesqldb.New(t)
+		defer fakedb.Close()
+		mysqld := mysqlctl.NewFakeMysqlDaemon(fakedb)
+		defer mysqld.Close()
+		mysqld.ExpectedExecuteSuperQueryList = []string{"STOP REPLICA", "START REPLICA"}
+
+		restoreParams.Mysqld = mysqld
+		restoreParams.Stats = backupstats.NewFakeStats()
+
+		bh := filebackupstorage.NewBackupHandle(nil, "", "", true)
+		_, err := be.ExecuteRestore(ctx, restoreParams, bh)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "can't create decompressor: gzip: invalid header")
+	})
+
+	t.Run("MissingChunk", func(t *testing.T) {
+		// Delete the chunk file entirely.
+		require.NoError(t, os.Remove(tamperedChunkPath))
+		defer os.WriteFile(tamperedChunkPath, originalData, 0o644)
+
+		fakedb := fakesqldb.New(t)
+		defer fakedb.Close()
+		mysqld := mysqlctl.NewFakeMysqlDaemon(fakedb)
+		defer mysqld.Close()
+		mysqld.ExpectedExecuteSuperQueryList = []string{"STOP REPLICA", "START REPLICA"}
+
+		restoreParams.Mysqld = mysqld
+		restoreParams.Stats = backupstats.NewFakeStats()
+
+		bh := filebackupstorage.NewBackupHandle(nil, "", "", true)
+		_, err := be.ExecuteRestore(ctx, restoreParams, bh)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "can't open source chunk 0-1 for reading")
+	})
 }

--- a/go/vt/mysqlctl/blackbox/utils.go
+++ b/go/vt/mysqlctl/blackbox/utils.go
@@ -18,7 +18,9 @@ package blackbox
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"slices"
@@ -46,6 +48,7 @@ type StatSummary struct {
 	DestinationCloseStats int
 	DestinationOpenStats  int
 	DestinationWriteStats int
+	DestinationWriteBytes int
 	SourceCloseStats      int
 	SourceOpenStats       int
 	SourceReadStats       int
@@ -63,6 +66,9 @@ func GetStats(stats *backupstats.FakeStats) StatSummary {
 		case "Destination:Write":
 			if len(sr.TimedIncrementBytesCalls) > 0 {
 				ss.DestinationWriteStats++
+				for _, call := range sr.TimedIncrementBytesCalls {
+					ss.DestinationWriteBytes += call.Bytes
+				}
 			}
 		case "Source:Close":
 			ss.SourceCloseStats += len(sr.TimedIncrementCalls)
@@ -85,7 +91,7 @@ func AssertLogs(t *testing.T, expectedLogs []string, logger *logutil.MemoryLogge
 	}
 }
 
-func SetupCluster(ctx context.Context, t *testing.T, dirs, filesPerDir int) (backupRoot string, keyspace string, shard string, ts *topo.Server) {
+func SetupCluster(ctx context.Context, t *testing.T, dirs, filesPerDir, fileSize int) (backupRoot string, keyspace string, shard string, ts *topo.Server) {
 	// Set up local backup directory
 	id := fmt.Sprintf("%d", time.Now().UnixNano())
 	backupRoot = fmt.Sprintf("testdata/builtinbackup_test_%s", id)
@@ -94,10 +100,12 @@ func SetupCluster(ctx context.Context, t *testing.T, dirs, filesPerDir int) (bac
 	dataDir := path.Join(backupRoot, "datadir")
 	// Add some files under data directory to force backup to execute semaphore acquire inside
 	// backupFiles() method (https://github.com/vitessio/vitess/blob/main/go/vt/mysqlctl/builtinbackupengine.go#L483).
+	totalFiles := dirs * filesPerDir
+	t.Logf("SetupCluster: creating %d files of %d bytes each (%d bytes total)", totalFiles, fileSize, totalFiles*fileSize)
 	for dirI := range dirs {
 		dirName := "test" + strconv.Itoa(dirI+1)
 		require.NoError(t, createBackupDir(dataDir, dirName))
-		require.NoError(t, createBackupFiles(path.Join(dataDir, dirName), filesPerDir, "ibd"))
+		require.NoError(t, createBackupFiles(path.Join(dataDir, dirName), filesPerDir, "ibd", fileSize))
 	}
 	t.Cleanup(func() {
 		require.NoError(t, os.RemoveAll(backupRoot))
@@ -181,16 +189,18 @@ func createBackupDir(root string, dirs ...string) error {
 	return nil
 }
 
-func createBackupFiles(root string, fileCount int, ext string) error {
-	for i := 0; i < fileCount; i++ {
+// createBackupFiles creates fileCount files of the given size (in bytes) filled with random data.
+func createBackupFiles(root string, fileCount int, ext string, size int) error {
+	for i := range fileCount {
 		f, err := os2.Create(path.Join(root, fmt.Sprintf("%d.%s", i, ext)))
 		if err != nil {
 			return err
 		}
-		if _, err := f.Write([]byte("hello, world!")); err != nil {
+		if _, err := io.CopyN(f, rand.Reader, int64(size)); err != nil {
+			f.Close()
 			return err
 		}
-		defer f.Close()
+		f.Close()
 	}
 
 	return nil

--- a/go/vt/mysqlctl/builtinbackupengine.go
+++ b/go/vt/mysqlctl/builtinbackupengine.go
@@ -26,10 +26,13 @@ import (
 	"hash"
 	"hash/crc32"
 	"io"
+	"math"
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -66,11 +69,16 @@ const (
 	// How many times we will retry file operations. Note that a file operation that
 	// returns a vtrpc.Code_FAILED_PRECONDITION error is considered fatal and we will
 	// not retry.
-	maxRetriesPerFile   = 1
-	maxFileCloseRetries = 20 // At this point we should consider it permanent
+	maxRetriesPerFile = 1
 )
 
 var (
+	// How many times we will retry file close operations. Note that a file operation that
+	// returns a vtrpc.Code_FAILED_PRECONDITION error is considered fatal and we will
+	// not retry.
+	maxFileCloseRetries = 20
+	openFile            = os.OpenFile
+
 	// BuiltinBackupMysqldTimeout is how long ExecuteBackup should wait for response from mysqld.Shutdown.
 	// It can later be extended for other calls to mysqld during backup functions.
 	// Exported for testing.
@@ -94,7 +102,36 @@ var (
 	// The path should exist.
 	// When empty, the default OS temp dir is assumed.
 	builtinIncrementalRestorePath = ""
+
+	backupFileChunkThreshold uint64                          // 0 means chunking is disabled
+	backupFileChunkSize      uint64 = 1 * 1024 * 1024 * 1024 // 1 GiB
+	minBackupFileChunkSize   uint64 = 4 * 1024 * 1024        // 4 MiB minimum to prevent the accidental allocation of a huge amount of files
+
+	errRestoreFatal = errors.New("fatal restore error")
 )
+
+func hasErrorCode(err error, code vtrpcpb.Code) bool {
+	if vterrors.Code(err) == code {
+		return true
+	}
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		for _, e := range joined.Unwrap() {
+			if hasErrorCode(e, code) {
+				return true
+			}
+		}
+	}
+	if single, ok := err.(interface{ Unwrap() error }); ok {
+		if hasErrorCode(single.Unwrap(), code) {
+			return true
+		}
+	} else if causer, ok := err.(interface{ Cause() error }); ok {
+		if hasErrorCode(causer.Cause(), code) {
+			return true
+		}
+	}
+	return false
+}
 
 // BuiltinBackupEngine encapsulates the logic of the builtin engine
 // it implements the BackupEngine interface and contains all the logic
@@ -158,12 +195,55 @@ type FileEntry struct {
 	// for writing files in a temporary directory
 	ParentPath string
 
+	// Chunks, when non-empty, indicates this file was split into chunks for
+	// parallel backup/restore. Each chunk is independently compressed and hashed.
+	Chunks []FileChunk `json:",omitempty"`
+
 	// RetryCount specifies how many times we retried restoring/backing up this FileEntry.
 	// If we fail to restore/backup this FileEntry, we will retry up to maxRetriesPerFile times.
 	// Every time the builtin backup engine retries this file, we increment this field by 1.
 	// We don't care about adding this information to the MANIFEST and also to not cause any compatibility issue
 	// we are adding the - json tag to let Go know it can ignore the field.
 	RetryCount int `json:"-"`
+}
+
+// FileChunk describes one chunk of a large file that has been split for parallel backup/restore.
+type FileChunk struct {
+	// StorageName is the name used to store this chunk in the backup storage.
+	// Format is "fileIndex-chunkIndex" (e.g. "5-0", "5-1").
+	StorageName string
+
+	// Offset is the byte offset within the original file where this chunk starts.
+	Offset int64
+
+	// Size is the number of bytes in this chunk.
+	Size int64
+
+	// Hash is the CRC32 hash of the stored data (after compression, if any).
+	Hash string
+}
+
+// computeFileChunks splits a file of the given size into chunks of chunkSize bytes.
+// The fileIndex is used to generate storage names in "fileIndex-chunkIndex" format.
+func computeFileChunks(fileIndex int, fileSize, chunkSize int64) []FileChunk {
+	numChunks := fileSize / chunkSize
+	if fileSize%chunkSize != 0 {
+		numChunks++
+	}
+	chunks := make([]FileChunk, numChunks)
+	for j := range numChunks {
+		offset := j * chunkSize
+		size := chunkSize
+		if offset+size > fileSize {
+			size = fileSize - offset
+		}
+		chunks[j] = FileChunk{
+			StorageName: fmt.Sprintf("%d-%d", fileIndex, j),
+			Offset:      offset,
+			Size:        size,
+		}
+	}
+	return chunks
 }
 
 func init() {
@@ -178,6 +258,8 @@ func registerBuiltinBackupEngineFlags(fs *pflag.FlagSet) {
 	fs.UintVar(&builtinBackupFileReadBufferSize, "builtinbackup-file-read-buffer-size", builtinBackupFileReadBufferSize, "read files using an IO buffer of this many bytes. Golang defaults are used when set to 0.")
 	fs.UintVar(&builtinBackupFileWriteBufferSize, "builtinbackup-file-write-buffer-size", builtinBackupFileWriteBufferSize, "write files using an IO buffer of this many bytes. Golang defaults are used when set to 0.")
 	fs.StringVar(&builtinIncrementalRestorePath, "builtinbackup-incremental-restore-path", builtinIncrementalRestorePath, "the directory where incremental restore files, namely binlog files, are extracted to. In k8s environments, this should be set to a directory that is shared between the vttablet and mysqld pods. The path should exist. When empty, the default OS temp dir is assumed.")
+	fs.Uint64Var(&backupFileChunkThreshold, "builtinbackup-file-chunk-threshold", backupFileChunkThreshold, "Files larger than this size (in bytes) are split into chunks for parallel backup/restore. 0 disables chunking.")
+	fs.Uint64Var(&backupFileChunkSize, "builtinbackup-file-chunk-size", backupFileChunkSize, "Size of each chunk (in bytes) when splitting large files for parallel backup/restore.")
 }
 
 // fullPath returns the full path of the entry, based on its type.
@@ -230,6 +312,16 @@ func (fe *FileEntry) open(cnf *Mycnf, readOnly bool) (*os.File, error) {
 func (be *BuiltinBackupEngine) ExecuteBackup(ctx context.Context, params BackupParams, bh backupstorage.BackupHandle) (BackupResult, error) {
 	params.Logger.Infof("Executing Backup at %v for keyspace/shard %v/%v on tablet %v, concurrency: %v, compress: %v, incrementalFromPos: %v",
 		params.BackupTime, params.Keyspace, params.Shard, params.TabletAlias, params.Concurrency, backupStorageCompress, params.IncrementalFromPos)
+
+	if backupFileChunkThreshold > 0 && backupFileChunkSize < minBackupFileChunkSize {
+		return BackupUnusable, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "builtinbackup-file-chunk-size must be >= %d", minBackupFileChunkSize)
+	}
+	if backupFileChunkThreshold > 0 && backupFileChunkSize > math.MaxInt64 {
+		return BackupUnusable, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "builtinbackup-file-chunk-size exceeds maximum allowed value of %d", int64(math.MaxInt64))
+	}
+	if backupFileChunkThreshold > 0 && backupFileChunkThreshold < backupFileChunkSize {
+		return BackupUnusable, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "builtinbackup-file-chunk-threshold (%d) must be >= builtinbackup-file-chunk-size (%d)", backupFileChunkThreshold, backupFileChunkSize)
+	}
 
 	if isIncrementalBackup(params) {
 		return be.executeIncrementalBackup(ctx, params, bh)
@@ -621,8 +713,43 @@ func (be *BuiltinBackupEngine) backupFiles(
 	}
 	params.Logger.Infof("found %v files to backup", len(fes))
 
-	// The error here can be ignored safely. Failed FileEntry's are handled in the next 'if' statement.
-	_ = be.backupFileEntries(ctx, fes, bh, params)
+	// Build a flat work list. For large files that exceed the chunk threshold,
+	// we split them into chunks that participate as individual work items in the
+	// shared concurrency pool.
+	var workItems []backupWorkItem
+	for i := range fes {
+		fe := &fes[i]
+
+		// Only fetch file size and calculate chunks if the threshold is enabled.
+		if backupFileChunkThreshold > 0 {
+			fullPath, pathErr := fe.fullPath(params.Cnf)
+			if pathErr != nil {
+				return vterrors.Wrapf(pathErr, "cannot get full path for %v", fe.Name)
+			}
+			fi, statErr := os.Stat(fullPath)
+			if statErr != nil {
+				return vterrors.Wrapf(statErr, "cannot stat file %v", fullPath)
+			}
+			fileSize := fi.Size()
+
+			// Files larger than the threshold are split into chunks for parallel backup/restore.
+			if uint64(fileSize) > backupFileChunkThreshold {
+				fe.Chunks = computeFileChunks(i, fileSize, int64(backupFileChunkSize))
+				for j, chunk := range fe.Chunks {
+					workItems = append(workItems, backupWorkItem{feIndex: i, chunkIndex: j, name: chunk.StorageName})
+				}
+				continue
+			}
+		}
+
+		workItems = append(workItems, backupWorkItem{feIndex: i, chunkIndex: -1, name: strconv.Itoa(i)})
+	}
+
+	// Backup all work items concurrently.
+	backupErr := be.backupWorkItems(ctx, workItems, fes, bh, params)
+	if hasErrorCode(backupErr, vtrpcpb.Code_FAILED_PRECONDITION) {
+		return backupErr
+	}
 
 	// BackupHandle supports the BackupErrorRecorder interface for tracking errors
 	// across any goroutines that fan out to take the backup. This means that we
@@ -633,44 +760,34 @@ func (be *BuiltinBackupEngine) backupFiles(
 	// error were encountered
 	// [here](https://github.com/vitessio/vitess/blob/d26b6c7975b12a87364e471e2e2dfa4e253c2a5b/go/vt/mysqlctl/s3backupstorage/s3.go#L139-L142).
 	//
-	// All the errors are grouped per file, if one or more files failed, we back them up
-	// once more concurrently, if any of the retry fail, we fail-fast by canceling the context
-	// and return an error. There is no reason to continue processing the other retries, if
-	// one of them failed.
+	// All the errors are grouped per file (or chunk), if one or more failed, we retry
+	// them once more concurrently. If any of the retries fail, we fail-fast by canceling
+	// the context and return an error.
 	if files := bh.GetFailedFiles(); len(files) > 0 {
-		newFEs := make([]FileEntry, len(fes))
+		var retryItems []backupWorkItem
 		for _, file := range files {
-			fileNb, err := strconv.Atoi(file)
+			feIdx, chunkIdx, err := parseBackupName(file)
 			if err != nil {
-				return vterrors.Wrapf(err, "failed to retry file '%s'", file)
+				return err
 			}
-			oldFes := fes[fileNb]
-			newFEs[fileNb] = FileEntry{
-				Base:       oldFes.Base,
-				Name:       oldFes.Name,
-				ParentPath: oldFes.ParentPath,
-				RetryCount: 1,
-			}
+			fes[feIdx].RetryCount = 1
 			bh.ResetErrorForFile(file)
+			retryItems = append(retryItems, backupWorkItem{feIndex: feIdx, chunkIndex: chunkIdx, name: file})
 		}
-		err = be.backupFileEntries(ctx, newFEs, bh, params)
-		if err != nil {
+		if err := be.backupWorkItems(ctx, retryItems, fes, bh, params); err != nil {
 			return err
 		}
-		// Propagate retry results back to the original entries so the
-		// manifest records correct hashes and metadata.
-		for i, fe := range newFEs {
-			if fe.Name != "" {
-				fes[i] = fe
-			}
-		}
+	} else if backupErr != nil {
+		// Wait surfaced an error not represented in per-file failures.
+		// Bail before MANIFEST upload to avoid reporting a successful backup.
+		return backupErr
 	}
 
 	// Backup the MANIFEST file and apply retry logic.
 	var manifestErr error
 	for currentRetry := 0; currentRetry <= maxRetriesPerFile; currentRetry++ {
 		manifestErr = be.backupManifest(ctx, params, bh, backupPosition, purgedPosition, fromPosition, fromBackupName, serverUUID, mysqlVersion, incrDetails, fes, currentRetry)
-		if manifestErr == nil || vterrors.Code(manifestErr) == vtrpcpb.Code_FAILED_PRECONDITION {
+		if manifestErr == nil || hasErrorCode(manifestErr, vtrpcpb.Code_FAILED_PRECONDITION) {
 			break
 		}
 		bh.ResetErrorForFile(backupManifestFileName)
@@ -681,15 +798,42 @@ func (be *BuiltinBackupEngine) backupFiles(
 	return nil
 }
 
-// backupFileEntries iterates over a slice of FileEntry, backing them up concurrently up to the defined concurrency limit.
-// This function will ignore empty FileEntry, allowing the retry mechanism to send a partially empty slice, to not
-// mess up the index of retriable FileEntry.
-// This function does not leave any background operation behind itself, all calls to bh.AddFile will be finished or canceled.
-func (be *BuiltinBackupEngine) backupFileEntries(ctx context.Context, fes []FileEntry, bh backupstorage.BackupHandle, params BackupParams) error {
+// parseBackupName parses a storage name back into a file index and chunk index.
+// Names are either "5" (whole file) or "5-2" (file 5, chunk 2).
+// Returns (fileIndex, chunkIndex) where chunkIndex is -1 for whole files.
+func parseBackupName(name string) (int, int, error) {
+	if strings.Contains(name, "-") {
+		parts := strings.SplitN(name, "-", 2)
+		feIdx, err := strconv.Atoi(parts[0])
+		if err != nil {
+			return 0, 0, vterrors.Wrapf(err, "failed to parse backup name '%s'", name)
+		}
+		chunkIdx, err := strconv.Atoi(parts[1])
+		if err != nil {
+			return 0, 0, vterrors.Wrapf(err, "failed to parse backup name '%s'", name)
+		}
+		return feIdx, chunkIdx, nil
+	}
+	feIdx, err := strconv.Atoi(name)
+	if err != nil {
+		return 0, 0, vterrors.Wrapf(err, "failed to parse backup name '%s'", name)
+	}
+	return feIdx, -1, nil
+}
+
+type backupWorkItem struct {
+	feIndex    int
+	chunkIndex int    // -1 means whole-file (non-chunked)
+	name       string // storage name: "5" or "5-0"
+}
+
+// backupWorkItems dispatches backup work items concurrently up to the defined concurrency limit.
+// Each work item is either a whole file or a single chunk of a large file.
+func (be *BuiltinBackupEngine) backupWorkItems(ctx context.Context, workItems []backupWorkItem, fes []FileEntry, bh backupstorage.BackupHandle, params BackupParams) error {
 	ctxCancel, cancel := context.WithCancel(ctx)
 	defer func() {
 		// If we reached this defer in all cases we can cancel the context.
-		// The only ways to get here are: a panic, an error when ending the backup, a successful backup.
+		// The only ways to get here are: a panic, an error when waiting for pending uploads, a successful backup.
 		// For all three options, it is safe to cancel the context, there should be no pending operations
 		// that 1) haven't completed, 2) we care about anymore.
 		cancel()
@@ -697,45 +841,42 @@ func (be *BuiltinBackupEngine) backupFileEntries(ctx context.Context, fes []File
 
 	g := errgroup.Group{}
 	g.SetLimit(params.Concurrency)
-	for i := range fes {
-		if fes[i].Name == "" {
-			continue
+	for _, wi := range workItems {
+		if ctxCancel.Err() != nil {
+			break
 		}
 		g.Go(func() error {
-			fe := &fes[i]
-			name := fmt.Sprintf("%v", i)
+			fe := &fes[wi.feIndex]
 
-			// Check for context cancellation explicitly because, the way semaphore code is written, theoretically we might
-			// end up not throwing an error even after cancellation. Please see https://cs.opensource.google/go/x/sync/+/refs/tags/v0.1.0:semaphore/semaphore.go;l=66,
-			// which suggests that if the context is already done, `Acquire()` may still succeed without blocking. This introduces
-			// unpredictability in my test cases, so in order to avoid that, I am adding this cancellation check.
 			select {
+			// Skip work if the context has been cancelled (e.g. another goroutine failed).
 			case <-ctxCancel.Done():
-				log.Errorf("Context canceled or timed out during %q backup", fe.Name)
-				bh.RecordError(name, vterrors.Errorf(vtrpcpb.Code_CANCELED, "context canceled"))
+				params.Logger.Errorf("Context canceled or timed out during %q backup", fe.Name)
+				bh.RecordError(wi.name, vterrors.Errorf(vtrpcpb.Code_CANCELED, "context canceled"))
 				return nil
 			default:
 			}
 
-			// Backup the individual file.
-			var errBackupFile error
-			if errBackupFile = be.backupFile(ctxCancel, params, bh, fe, name); errBackupFile != nil {
-				bh.RecordError(name, vterrors.Wrapf(errBackupFile, "failed to backup file '%s'", name))
-				if fe.RetryCount >= maxRetriesPerFile || vterrors.Code(errBackupFile) == vtrpcpb.Code_FAILED_PRECONDITION {
-					// this is the last attempt, and we have an error, we can cancel everything and fail fast.
+			if errBackupFile := be.backupFile(ctxCancel, params, bh, fe, wi.name, wi.chunkIndex); errBackupFile != nil {
+				bh.RecordError(wi.name, vterrors.Wrapf(errBackupFile, "failed to backup '%s'", wi.name))
+				if hasErrorCode(errBackupFile, vtrpcpb.Code_FAILED_PRECONDITION) {
+					cancel()
+					return errBackupFile
+				}
+				if fe.RetryCount >= maxRetriesPerFile {
 					cancel()
 				}
 			}
 			return nil
 		})
 	}
-	_ = g.Wait()
-
-	err := bh.EndBackup(ctx)
-	if err != nil {
+	if err := g.Wait(); err != nil {
+		bh.Wait()
 		return err
 	}
-	return bh.Error()
+
+	bh.Wait()
+	return errors.Join(bh.Error(), ctxCancel.Err())
 }
 
 type backupPipe struct {
@@ -847,8 +988,10 @@ func (bp *backupPipe) ReportProgress(ctx context.Context, period time.Duration, 
 	}
 }
 
-// backupFile backs up an individual file.
-func (be *BuiltinBackupEngine) backupFile(ctx context.Context, params BackupParams, bh backupstorage.BackupHandle, fe *FileEntry, name string) (finalErr error) {
+// backupFile backs up an individual file or a single chunk of a large file.
+// When chunkIndex is -1, the entire file is backed up as a single unit.
+// When chunkIndex >= 0, only the specified chunk (from fe.Chunks) is backed up.
+func (be *BuiltinBackupEngine) backupFile(ctx context.Context, params BackupParams, bh backupstorage.BackupHandle, fe *FileEntry, name string, chunkIndex int) (finalErr error) {
 	// We need another context that does not live outside of this function.
 	// Reporting progress, compressing and writing are operations that will be
 	// over by the time we exit this function, they can use this cancelable context.
@@ -876,21 +1019,46 @@ func (be *BuiltinBackupEngine) backupFile(ctx context.Context, params BackupPara
 	}()
 
 	readStats := params.Stats.Scope(stats.Operation("Source:Read"))
-	timedSource := ioutil.NewMeteredReadCloser(source, readStats.TimedIncrementBytes)
 
-	fi, err := source.Stat()
-	if err != nil {
-		return err
+	var sourceReader io.Reader
+	var dataSize int64
+	var label string
+
+	if chunkIndex >= 0 {
+		// Chunked backup: seek to the chunk's offset and read only chunk.Size bytes.
+		// Each chunk is stored independently with its own name in the backup storage.
+		chunk := &fe.Chunks[chunkIndex]
+		name = chunk.StorageName
+		label = fmt.Sprintf("%s[%d]", fe.Name, chunkIndex)
+
+		if _, err := source.Seek(chunk.Offset, io.SeekStart); err != nil {
+			return vterrors.Wrapf(err, "cannot seek to offset %d in %v", chunk.Offset, fe.Name)
+		}
+		sourceReader = ioutil.NewMeteredReader(io.LimitReader(source, chunk.Size), readStats.TimedIncrementBytes)
+		dataSize = chunk.Size
+	} else {
+		// Whole-file backup: read the entire file.
+		label = fe.Name
+		fi, err := source.Stat()
+		if err != nil {
+			return err
+		}
+		sourceReader = ioutil.NewMeteredReadCloser(source, readStats.TimedIncrementBytes)
+		dataSize = fi.Size()
 	}
 
 	retryStr := retryToString(fe.RetryCount)
-	br := newBackupReader(fe.Name, fi.Size(), timedSource)
+	br := newBackupReader(label, dataSize, sourceReader)
 	go br.ReportProgress(cancelableCtx, builtinBackupProgress, params.Logger, false /*restore*/, retryStr)
 
 	// Open the destination file for writing, and a buffer.
-	params.Logger.Infof("Backing up file: %v %s", fe.Name, retryStr)
+	if chunkIndex >= 0 {
+		params.Logger.Infof("Backing up chunk %d of file %v (offset=%d, size=%d) %s", chunkIndex, fe.Name, fe.Chunks[chunkIndex].Offset, fe.Chunks[chunkIndex].Size, retryStr)
+	} else {
+		params.Logger.Infof("Backing up file: %v %s", fe.Name, retryStr)
+	}
 	openDestAt := time.Now()
-	dest, err := bh.AddFile(ctx, name, fi.Size())
+	dest, err := bh.AddFile(ctx, name, dataSize)
 	if err != nil {
 		return vterrors.Wrapf(err, "cannot add file: %v,%v", name, fe.Name)
 	}
@@ -910,17 +1078,13 @@ func (be *BuiltinBackupEngine) backupFile(ctx context.Context, params BackupPara
 	destStats := params.Stats.Scope(stats.Operation("Destination:Write"))
 	timedDest := ioutil.NewMeteredWriteCloser(dest, destStats.TimedIncrementBytes)
 
-	bw := newBackupWriter(fe.Name, builtinBackupStorageWriteBufferSize, fi.Size(), timedDest)
+	bw := newBackupWriter(label, builtinBackupStorageWriteBufferSize, dataSize, timedDest)
 
-	// We create the following inner function because:
-	// - we must `defer` the compressor's Close() function
-	// - but it must take place before we close the pipe reader&writer
 	createAndCopy := func() (createAndCopyErr error) {
 		var reader io.Reader = br
 		var writer io.Writer = bw
 
 		defer func() {
-			// Close the backupPipe to finish writing on destination.
 			if err := bw.Close(createAndCopyErr == nil); err != nil {
 				createAndCopyErr = errors.Join(createAndCopyErr, vterrors.Wrapf(err, "cannot flush destination: %v", name))
 			}
@@ -930,7 +1094,7 @@ func (be *BuiltinBackupEngine) backupFile(ctx context.Context, params BackupPara
 			}
 
 		}()
-		// Create the gzip compression pipe, if necessary.
+
 		if backupStorageCompress {
 			var compressor io.WriteCloser
 			if ExternalCompressorCmd != "" {
@@ -947,11 +1111,10 @@ func (be *BuiltinBackupEngine) backupFile(ctx context.Context, params BackupPara
 
 			closer := ioutil.NewTimeoutCloser(cancelableCtx, compressor, closeTimeout)
 			defer func() {
-				// Close gzip to flush it, after that all data is sent to writer.
-				params.Logger.Infof("Closing compressor for file: %s %s", fe.Name, retryStr)
+				params.Logger.Infof("Closing compressor for file: %s %s", label, retryStr)
 				closeCompressorAt := time.Now()
 				if cerr := closeWithRetry(ctx, params.Logger, closer, "compressor"); cerr != nil {
-					cerr = vterrors.Wrapf(cerr, "failed to close compressor %v", fe.Name)
+					cerr = vterrors.Wrapf(cerr, "failed to close compressor %v", label)
 					params.Logger.Error(cerr)
 					createAndCopyErr = errors.Join(createAndCopyErr, cerr)
 					return
@@ -964,8 +1127,6 @@ func (be *BuiltinBackupEngine) backupFile(ctx context.Context, params BackupPara
 			reader = bufio.NewReaderSize(br, int(builtinBackupFileReadBufferSize))
 		}
 
-		// Copy from the source file to writer (optional gzip,
-		// optional pipe, tee, output file and hasher).
 		_, err = io.Copy(writer, reader)
 		if err != nil {
 			return vterrors.Wrap(err, "cannot copy data")
@@ -977,8 +1138,12 @@ func (be *BuiltinBackupEngine) backupFile(ctx context.Context, params BackupPara
 		return errors.Join(finalErr, err)
 	}
 
-	// Save the hash.
-	fe.Hash = bw.HashString()
+	// Save the hash — each chunk goroutine writes a distinct index, no race.
+	if chunkIndex >= 0 {
+		fe.Chunks[chunkIndex].Hash = bw.HashString()
+	} else {
+		fe.Hash = bw.HashString()
+	}
 	return nil
 }
 
@@ -1007,7 +1172,7 @@ func (be *BuiltinBackupEngine) backupManifest(
 	}()
 
 	// Creating this function allows us to ensure we always close the writer no matter what,
-	// and in case of success that we close it before calling bh.EndBackup.
+	// and in case of success that we close it before calling bh.Wait.
 	addAndWrite := func() (addAndWriteError error) {
 		// open the MANIFEST
 		wc, err := bh.AddFile(ctx, backupManifestFileName, backupstorage.FileSizeUnknown)
@@ -1070,10 +1235,7 @@ func (be *BuiltinBackupEngine) backupManifest(
 		return err
 	}
 
-	err = bh.EndBackup(ctx)
-	if err != nil {
-		return err
-	}
+	bh.Wait()
 	return bh.Error()
 }
 
@@ -1198,21 +1360,40 @@ func (be *BuiltinBackupEngine) restoreFiles(ctx context.Context, params RestoreP
 		}
 	}
 	fes := bm.FileEntries
-	_ = be.restoreFileEntries(ctx, fes, bh, bm, params, createdDir)
-	if files := bh.GetFailedFiles(); len(files) > 0 {
+
+	// For chunked files, we pre-create the files at the right size, each chunk then only writes to the right offset.
+	// This is done to prevent them from being truncated when retries happen.
+	if err := createChunkedDestinations(ctx, fes, params.Cnf, createdDir, params.Logger); err != nil {
+		return "", err
+	}
+
+	restoreErr := be.restoreFileEntries(ctx, fes, bh, bm, params, createdDir)
+	if errors.Is(restoreErr, errRestoreFatal) {
+		return "", restoreErr
+	}
+	files := bh.GetFailedFiles()
+	if restoreErr != nil && len(files) == 0 {
+		return "", restoreErr
+	}
+	if len(files) > 0 {
 		newFEs := make([]FileEntry, len(fes))
 		for _, file := range files {
-			fileNb, err := strconv.Atoi(file)
-			if err != nil {
-				return "", vterrors.Wrapf(err, "failed to retry file '%s'", file)
+			feIdx, chunkIdx, parseErr := parseBackupName(file)
+			if parseErr != nil {
+				return "", parseErr
 			}
-			oldFes := fes[fileNb]
-			newFEs[fileNb] = FileEntry{
-				Base:       oldFes.Base,
-				Name:       oldFes.Name,
-				ParentPath: oldFes.ParentPath,
-				Hash:       oldFes.Hash,
-				RetryCount: 1,
+			oldFe := fes[feIdx]
+			if newFEs[feIdx].Name == "" {
+				newFEs[feIdx] = FileEntry{
+					Base:       oldFe.Base,
+					Name:       oldFe.Name,
+					ParentPath: oldFe.ParentPath,
+					Hash:       oldFe.Hash,
+					RetryCount: 1,
+				}
+			}
+			if chunkIdx >= 0 {
+				newFEs[feIdx].Chunks = append(newFEs[feIdx].Chunks, oldFe.Chunks[chunkIdx])
 			}
 			bh.ResetErrorForFile(file)
 		}
@@ -1224,49 +1405,213 @@ func (be *BuiltinBackupEngine) restoreFiles(ctx context.Context, params RestoreP
 	return createdDir, nil
 }
 
+// validateChunkMetadata checks that a file's chunk list is well-formed: no negative
+// offsets, no non-positive sizes, no int64 overflow, correct StorageName format, and
+// contiguous coverage with no gaps or overlaps. Sorts chunks by offset in place.
+// Returns the total file size on success.
+func validateChunkMetadata(fe *FileEntry, fileIndex int) (int64, error) {
+	sort.Slice(fe.Chunks, func(a, b int) bool {
+		return fe.Chunks[a].Offset < fe.Chunks[b].Offset
+	})
+
+	var expectedOffset int64
+	for j, c := range fe.Chunks {
+		if c.Offset < 0 || c.Size <= 0 {
+			return 0, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "invalid chunk metadata for file %v chunk %d: offset=%d, size=%d", fe.Name, j, c.Offset, c.Size)
+		}
+		if c.Offset > math.MaxInt64-c.Size {
+			return 0, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "chunk metadata for file %v chunk %d overflows int64: offset=%d, size=%d", fe.Name, j, c.Offset, c.Size)
+		}
+		expectedName := fmt.Sprintf("%d-%d", fileIndex, j)
+		if c.StorageName != expectedName {
+			return 0, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "unexpected storage name for file %v chunk %d: got %q, expected %q", fe.Name, j, c.StorageName, expectedName)
+		}
+		if c.Offset != expectedOffset {
+			return 0, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "chunk metadata for file %v chunk %d has gap/overlap: expected offset %d, got %d", fe.Name, j, expectedOffset, c.Offset)
+		}
+		expectedOffset = c.Offset + c.Size
+	}
+
+	return expectedOffset, nil
+}
+
+// createChunkedDestinations pre-creates and pre-sizes destination files for chunked
+// entries. This is called once before any restore pass so that restoreFileEntries can
+// always open them with O_WRONLY (no truncation), making retries safe.
+func createChunkedDestinations(ctx context.Context, fes []FileEntry, cnf *Mycnf, createdDir string, logger logutil.Logger) error {
+	for i := range fes {
+		fe := &fes[i]
+		if len(fe.Chunks) == 0 {
+			// Non-chunked files are not pre-created. this is handled by the restoreFileEntries function.
+			continue
+		}
+		fe.ParentPath = createdDir
+
+		totalSize, err := validateChunkMetadata(fe, i)
+		if err != nil {
+			return err
+		}
+
+		dest, err := fe.open(cnf, false)
+		if err != nil {
+			return vterrors.Wrapf(err, "can't create destination for chunked file %v", fe.Name)
+		}
+		if err := dest.Truncate(totalSize); err != nil {
+			closeWithRetry(ctx, logger, dest, fe.Name)
+			return vterrors.Wrapf(err, "can't pre-size chunked file %v", fe.Name)
+		}
+		if err := closeWithRetry(ctx, logger, dest, fe.Name); err != nil {
+			return vterrors.Wrapf(err, "can't close pre-sized chunked file %v", fe.Name)
+		}
+	}
+	return nil
+}
+
+// restoreWorkItem represents a single unit of restore work: either a chunk of a
+// chunked file, or a whole non-chunked file.
+type restoreWorkItem struct {
+	fe       *FileEntry
+	chunk    *FileChunk // nil for non-chunked files
+	destPath string     // full path for chunked files, empty for non-chunked
+	name     string     // storage name for error recording
+}
+
 func (be *BuiltinBackupEngine) restoreFileEntries(ctx context.Context, fes []FileEntry, bh backupstorage.BackupHandle, bm builtinBackupManifest, params RestoreParams, createdDir string) error {
+	parentCtx := ctx
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(params.Concurrency)
 
+	// Build work items. Chunked files resolve their destination path here;
+	// each chunk opens/closes the fd independently during execution.
+	var workItems []restoreWorkItem
+	var setupErr error
 	for i := range fes {
 		if fes[i].Name == "" {
 			continue
 		}
+		fe := &fes[i]
+		fe.ParentPath = createdDir
+
+		if len(fe.Chunks) > 0 {
+			fullPath, pathErr := fe.fullPath(params.Cnf)
+			if pathErr != nil {
+				setupErr = vterrors.Wrapf(pathErr, "can't get path for chunked file %v", fe.Name)
+				break
+			}
+
+			for j := range fe.Chunks {
+				workItems = append(workItems, restoreWorkItem{
+					fe:       fe,
+					chunk:    &fe.Chunks[j],
+					destPath: fullPath,
+					name:     fe.Chunks[j].StorageName,
+				})
+			}
+		} else {
+			workItems = append(workItems, restoreWorkItem{
+				fe:   fe,
+				name: strconv.Itoa(i),
+			})
+		}
+	}
+
+	if setupErr != nil {
+		return fmt.Errorf("%w: %w", errRestoreFatal, setupErr)
+	}
+
+	// Phase 2: Dispatch all work items concurrently.
+	for _, wi := range workItems {
+		if ctx.Err() != nil {
+			break
+		}
 		g.Go(func() error {
-			fe := &fes[i]
-			name := fmt.Sprintf("%v", i)
-			// Check for context cancellation explicitly because, the way semaphore code is written, theoretically we might
-			// end up not throwing an error even after cancellation. Please see https://cs.opensource.google/go/x/sync/+/refs/tags/v0.1.0:semaphore/semaphore.go;l=66,
-			// which suggests that if the context is already done, `Acquire()` may still succeed without blocking. This introduces
-			// unpredictability in my test cases, so in order to avoid that, I am adding this cancellation check.
 			select {
 			case <-ctx.Done():
-				log.Errorf("Context canceled or timed out during %q restore", fe.Name)
-				bh.RecordError(name, vterrors.Errorf(vtrpcpb.Code_CANCELED, "context canceled"))
+				params.Logger.Errorf("Context canceled or timed out during %q restore", wi.fe.Name)
+				bh.RecordError(wi.name, vterrors.Errorf(vtrpcpb.Code_CANCELED, "context canceled"))
 				return nil
 			default:
 			}
 
-			fe.ParentPath = createdDir
+			var err error
+			if wi.chunk != nil {
+				params.Logger.Infof("Restoring chunk %s of file %v (offset=%d, size=%d)", wi.name, wi.fe.Name, wi.chunk.Offset, wi.chunk.Size)
+				err = be.restoreFileChunk(ctx, params, bh, wi.chunk, bm, wi.destPath)
+			} else {
+				params.Logger.Infof("Copying file %v: %v %s", wi.name, wi.fe.Name, retryToString(wi.fe.RetryCount))
+				err = be.restoreFile(ctx, params, bh, wi.fe, bm, wi.name)
+			}
 
-			// And restore the file.
-			params.Logger.Infof("Copying file %v: %v %s", name, fe.Name, retryToString(fe.RetryCount))
-			if errRestore := be.restoreFile(ctx, params, bh, fe, bm, name); errRestore != nil {
-				bh.RecordError(name, vterrors.Wrapf(errRestore, "failed to restore file %v to %v", name, fe.Name))
-				if fe.RetryCount >= maxRetriesPerFile || vterrors.Code(errRestore) == vtrpcpb.Code_FAILED_PRECONDITION {
-					// this is the last attempt, and we have an error, we can return an error, which will let errgroup
-					// know it can cancel the context
-					return errRestore
+			if err != nil {
+				wrappedErr := vterrors.Wrapf(err, "failed to restore %v", wi.name)
+				bh.RecordError(wi.name, wrappedErr)
+				if wi.fe.RetryCount >= maxRetriesPerFile || hasErrorCode(err, vtrpcpb.Code_FAILED_PRECONDITION) {
+					// This is the last attempt, and we have an error, we can return an error,
+					// which will let errgroup know it can cancel the context.
+					return wrappedErr
 				}
 			}
 			return nil
 		})
 	}
-	_ = g.Wait()
-	return bh.Error()
+
+	if err := g.Wait(); err != nil {
+		if hasErrorCode(err, vtrpcpb.Code_FAILED_PRECONDITION) {
+			return fmt.Errorf("%w: %w", errRestoreFatal, err)
+		}
+		return err
+	}
+	return errors.Join(bh.Error(), parentCtx.Err())
 }
 
-// restoreFile restores an individual file.
+// createDecompressor sets up decompression based on the backup manifest settings.
+// Returns the wrapped reader, a cleanup function (must be deferred), and error.
+func createDecompressor(ctx context.Context, bm builtinBackupManifest, reader io.Reader, params RestoreParams, name string) (io.Reader, func() error, error) {
+	deCompressionEngine := bm.CompressionEngine
+	if deCompressionEngine == "" {
+		deCompressionEngine = PgzipCompressor
+	}
+
+	externalDecompressorCmd := resolveExternalDecompressor(bm.ExternalDecompressor)
+
+	var decompressor io.ReadCloser
+	var err error
+	if externalDecompressorCmd != "" {
+		if deCompressionEngine == ExternalCompressor {
+			deCompressionEngine = externalDecompressorCmd
+			decompressor, err = newExternalDecompressor(ctx, deCompressionEngine, reader, params.Logger)
+		} else {
+			decompressor, err = newBuiltinDecompressor(deCompressionEngine, reader, params.Logger)
+		}
+	} else {
+		if deCompressionEngine == ExternalCompressor {
+			return nil, nil, fmt.Errorf("%w value: %q", errUnsupportedDeCompressionEngine, ExternalCompressor)
+		}
+		decompressor, err = newBuiltinDecompressor(deCompressionEngine, reader, params.Logger)
+	}
+	if err != nil {
+		return nil, nil, vterrors.Wrap(err, "can't create decompressor")
+	}
+
+	closer := ioutil.NewTimeoutCloser(ctx, decompressor, closeTimeout)
+	decompressStats := params.Stats.Scope(stats.Operation("Decompressor:Read"))
+	wrappedReader := ioutil.NewMeteredReader(decompressor, decompressStats.TimedIncrementBytes)
+
+	cleanup := func() error {
+		params.Logger.Infof("closing decompressor for %s", name)
+		closeAt := time.Now()
+		cerr := closeWithRetry(ctx, params.Logger, closer, "decompressor")
+		if cerr != nil {
+			cerr = vterrors.Wrapf(cerr, "failed to close decompressor %v", name)
+			params.Logger.Error(cerr)
+		}
+		params.Stats.Scope(stats.Operation("Decompressor:Close")).TimedIncrement(time.Since(closeAt))
+		return cerr
+	}
+	return wrappedReader, cleanup, nil
+}
+
+// restoreFile restores an individual non-chunked file.
 func (be *BuiltinBackupEngine) restoreFile(ctx context.Context, params RestoreParams, bh backupstorage.BackupHandle, fe *FileEntry, bm builtinBackupManifest, name string) (finalErr error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -1291,7 +1636,6 @@ func (be *BuiltinBackupEngine) restoreFile(ctx context.Context, params RestorePa
 		params.Stats.Scope(stats.Operation("Source:Close")).TimedIncrement(time.Since(closeSourceAt))
 	}()
 
-	// Create the backup/source reader and start reporting progress
 	retryStr := retryToString(fe.RetryCount)
 	br := newBackupReader(fe.Name, 0, timedSource)
 	go br.ReportProgress(ctx, builtinBackupProgress, params.Logger, true, retryStr)
@@ -1322,67 +1666,143 @@ func (be *BuiltinBackupEngine) restoreFile(ctx context.Context, params RestorePa
 
 	writeStats := params.Stats.Scope(stats.Operation("Destination:Write"))
 	timedDest := ioutil.NewMeteredWriter(dest, writeStats.TimedIncrementBytes)
-
 	bufferedDest := bufio.NewWriterSize(timedDest, int(builtinBackupFileWriteBufferSize))
 
-	// Create the uncompresser if needed.
 	if !bm.SkipCompress {
-		var decompressor io.ReadCloser
-		deCompressionEngine := bm.CompressionEngine
-
-		if deCompressionEngine == "" {
-			// for backward compatibility
-			deCompressionEngine = PgzipCompressor
-		}
-		externalDecompressorCmd := resolveExternalDecompressor(bm.ExternalDecompressor)
-		if externalDecompressorCmd != "" {
-			if deCompressionEngine == ExternalCompressor {
-				deCompressionEngine = externalDecompressorCmd
-				decompressor, err = newExternalDecompressor(ctx, deCompressionEngine, reader, params.Logger)
-			} else {
-				decompressor, err = newBuiltinDecompressor(deCompressionEngine, reader, params.Logger)
-			}
-		} else {
-			if deCompressionEngine == ExternalCompressor {
-				return fmt.Errorf("%w value: %q", errUnsupportedDeCompressionEngine, ExternalCompressor)
-			}
-			decompressor, err = newBuiltinDecompressor(deCompressionEngine, reader, params.Logger)
-		}
+		var decompressCleanup func() error
+		reader, decompressCleanup, err = createDecompressor(ctx, bm, reader, params, name)
 		if err != nil {
-			return vterrors.Wrap(err, "can't create decompressor")
+			return err
 		}
-		closer := ioutil.NewTimeoutCloser(ctx, decompressor, closeTimeout)
-
-		decompressStats := params.Stats.Scope(stats.Operation("Decompressor:Read"))
-		reader = ioutil.NewMeteredReader(decompressor, decompressStats.TimedIncrementBytes)
-
 		defer func() {
-			params.Logger.Infof("closing decompressor")
-			closeDecompressorAt := time.Now()
-			if cerr := closeWithRetry(ctx, params.Logger, closer, "decompressor"); cerr != nil {
-				cerr = vterrors.Wrapf(cerr, "failed to close decompressor %v", name)
-				params.Logger.Error(cerr)
+			if cerr := decompressCleanup(); cerr != nil {
 				finalErr = errors.Join(finalErr, cerr)
-				return
 			}
-			params.Stats.Scope(stats.Operation("Decompressor:Close")).TimedIncrement(time.Since(closeDecompressorAt))
 		}()
 	}
 
-	// Copy the data. Will also write to the hasher.
 	if _, err := io.Copy(bufferedDest, reader); err != nil {
 		return vterrors.Wrap(err, "failed to copy file contents")
 	}
 
-	// Check the hash.
 	hash := br.HashString()
 	if hash != fe.Hash {
 		return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "hash mismatch for %v, got %v expected %v", fe.Name, hash, fe.Hash)
 	}
 
-	// Flush the buffer.
 	if err := bufferedDest.Flush(); err != nil {
 		return vterrors.Wrap(err, "failed to flush destination buffer")
+	}
+
+	return nil
+}
+
+// offsetWriter writes to a file at a specific offset using pwrite semantics.
+// Multiple offsetWriters can write to the same file concurrently at different offsets.
+type offsetWriter struct {
+	f      *os.File
+	offset int64
+}
+
+func (w *offsetWriter) Write(p []byte) (int, error) {
+	n, err := w.f.WriteAt(p, w.offset)
+	w.offset += int64(n)
+	return n, err
+}
+
+// restoreFileChunk restores a single chunk of a large file. The destination
+// file has been pre-created and pre-sized by createChunkedDestinations; this
+// function opens it for pwrite and closes it when done.
+func (be *BuiltinBackupEngine) restoreFileChunk(ctx context.Context, params RestoreParams, bh backupstorage.BackupHandle, chunk *FileChunk, bm builtinBackupManifest, destPath string) (finalErr error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	openDestAt := time.Now()
+	dest, err := openFile(destPath, os.O_WRONLY, 0o644)
+	if err != nil {
+		return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "can't open destination for chunk %v: %v", chunk.StorageName, err)
+	}
+	params.Stats.Scope(stats.Operation("Destination:Open")).TimedIncrement(time.Since(openDestAt))
+	defer func() {
+		closeDestAt := time.Now()
+		if cerr := closeWithRetry(ctx, params.Logger, dest, chunk.StorageName); cerr != nil {
+			if finalErr != nil {
+				params.Logger.Errorf("Chunk %s had prior error before close failure: %v", chunk.StorageName, finalErr)
+			}
+			// Overwrite (not join) so that closeWithRetry's FAILED_PRECONDITION code
+			// propagates through the dispatch's vterrors.Code() check, ensuring the
+			// error is treated as fatal and not retried.
+			finalErr = cerr
+			return
+		}
+		params.Stats.Scope(stats.Operation("Destination:Close")).TimedIncrement(time.Since(closeDestAt))
+	}()
+
+	openSourceAt := time.Now()
+	source, err := bh.ReadFile(ctx, chunk.StorageName)
+	if err != nil {
+		return vterrors.Wrapf(err, "can't open source chunk %v for reading", chunk.StorageName)
+	}
+	params.Stats.Scope(stats.Operation("Source:Open")).TimedIncrement(time.Since(openSourceAt))
+
+	readStats := params.Stats.Scope(stats.Operation("Source:Read"))
+	timedSource := ioutil.NewMeteredReader(source, readStats.TimedIncrementBytes)
+
+	defer func() {
+		closeSourceAt := time.Now()
+		if err := closeWithRetry(ctx, params.Logger, source, chunk.StorageName); err != nil {
+			params.Logger.Errorf("Failed to close source chunk %s during restore: %v", chunk.StorageName, err)
+			return
+		}
+		params.Stats.Scope(stats.Operation("Source:Close")).TimedIncrement(time.Since(closeSourceAt))
+	}()
+
+	br := newBackupReader(chunk.StorageName, 0, timedSource)
+	go br.ReportProgress(ctx, builtinBackupProgress, params.Logger, true, "")
+	defer func() {
+		if err := br.Close(finalErr == nil); err != nil {
+			finalErr = errors.Join(finalErr, vterrors.Wrap(err, "failed to close source reader"))
+		}
+	}()
+	var reader io.Reader = br
+
+	if !bm.SkipCompress {
+		var decompressCleanup func() error
+		reader, decompressCleanup, err = createDecompressor(ctx, bm, reader, params, chunk.StorageName)
+		if err != nil {
+			return err
+		}
+		defer func() {
+			if cerr := decompressCleanup(); cerr != nil {
+				finalErr = errors.Join(finalErr, cerr)
+			}
+		}()
+	}
+
+	ow := &offsetWriter{f: dest, offset: chunk.Offset}
+	writeStats := params.Stats.Scope(stats.Operation("Destination:Write"))
+	timedDest := ioutil.NewMeteredWriter(ow, writeStats.TimedIncrementBytes)
+	bufferedDest := bufio.NewWriterSize(timedDest, int(builtinBackupFileWriteBufferSize))
+
+	if _, err := io.Copy(bufferedDest, reader); err != nil {
+		return vterrors.Wrapf(err, "failed to copy chunk %v", chunk.StorageName)
+	}
+
+	if err := bufferedDest.Flush(); err != nil {
+		return vterrors.Wrapf(err, "failed to flush chunk %v", chunk.StorageName)
+	}
+
+	// Hash check first: a truncated read fails with INTERNAL (retryable).
+	// Size check second: if the hash passes but the size is wrong, the MANIFEST metadata is corrupt (fatal).
+	hash := br.HashString()
+	if hash != chunk.Hash {
+		return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "hash mismatch for chunk %v, got %v expected %v", chunk.StorageName, hash, chunk.Hash)
+	}
+
+	// ow.offset holds initial offset + bytes written, so we can obtain how much we wrote by subtracting the initial offset.
+	written := ow.offset - chunk.Offset
+	if written != chunk.Size {
+		return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "chunk %v: decompressed size mismatch: wrote %d bytes, expected %d", chunk.StorageName, written, chunk.Size)
 	}
 
 	return nil

--- a/go/vt/mysqlctl/builtinbackupengine_test.go
+++ b/go/vt/mysqlctl/builtinbackupengine_test.go
@@ -18,13 +18,39 @@ limitations under the License.
 package mysqlctl
 
 import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"hash/crc32"
+	"io"
+	"math"
+	"os"
+	"path"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/fileutil"
+	"vitess.io/vitess/go/mysql/fakesqldb"
+	"vitess.io/vitess/go/mysql/replication"
+	"vitess.io/vitess/go/os2"
+	"vitess.io/vitess/go/vt/logutil"
+	"vitess.io/vitess/go/vt/mysqlctl/backupstats"
+	"vitess.io/vitess/go/vt/mysqlctl/filebackupstorage"
 	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"
+	"vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/proto/vttime"
+	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/topo/memorytopo"
+	"vitess.io/vitess/go/vt/vterrors"
+
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 )
 
 func TestGetIncrementalFromPosGTIDSet(t *testing.T) {
@@ -159,6 +185,375 @@ func TestFileEntryFullPath(t *testing.T) {
 	}
 }
 
+func TestParseBackupStorageName(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantFeIdx  int
+		wantChkIdx int
+		wantErr    bool
+	}{
+		{name: "whole file", input: "5", wantFeIdx: 5, wantChkIdx: -1},
+		{name: "chunk", input: "5-2", wantFeIdx: 5, wantChkIdx: 2},
+		{name: "zero index", input: "0-0", wantFeIdx: 0, wantChkIdx: 0},
+		{name: "large indices", input: "123-456", wantFeIdx: 123, wantChkIdx: 456},
+		{name: "invalid file index", input: "abc", wantErr: true},
+		{name: "invalid chunk index", input: "5-abc", wantErr: true},
+		{name: "invalid file index with chunk", input: "abc-2", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			feIdx, chkIdx, err := parseBackupName(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantFeIdx, feIdx)
+			assert.Equal(t, tt.wantChkIdx, chkIdx)
+		})
+	}
+}
+
+func TestComputeFileChunks(t *testing.T) {
+	tests := []struct {
+		name       string
+		fileIndex  int
+		fileSize   int64
+		chunkSize  int64
+		wantChunks []FileChunk
+	}{
+		{
+			name:      "exact multiple",
+			fileIndex: 3,
+			fileSize:  100,
+			chunkSize: 50,
+			wantChunks: []FileChunk{
+				{StorageName: "3-0", Offset: 0, Size: 50},
+				{StorageName: "3-1", Offset: 50, Size: 50},
+			},
+		},
+		{
+			name:      "last chunk is smaller",
+			fileIndex: 0,
+			fileSize:  70,
+			chunkSize: 30,
+			wantChunks: []FileChunk{
+				{StorageName: "0-0", Offset: 0, Size: 30},
+				{StorageName: "0-1", Offset: 30, Size: 30},
+				{StorageName: "0-2", Offset: 60, Size: 10},
+			},
+		},
+		{
+			name:      "file smaller than chunk size",
+			fileIndex: 5,
+			fileSize:  10,
+			chunkSize: 100,
+			wantChunks: []FileChunk{
+				{StorageName: "5-0", Offset: 0, Size: 10},
+			},
+		},
+		{
+			name:      "single byte file",
+			fileIndex: 0,
+			fileSize:  1,
+			chunkSize: 1024,
+			wantChunks: []FileChunk{
+				{StorageName: "0-0", Offset: 0, Size: 1},
+			},
+		},
+		{
+			name:      "max int64 chunk size",
+			fileIndex: 0,
+			fileSize:  100,
+			chunkSize: math.MaxInt64,
+			wantChunks: []FileChunk{
+				{StorageName: "0-0", Offset: 0, Size: 100},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := computeFileChunks(tt.fileIndex, tt.fileSize, tt.chunkSize)
+			require.Len(t, got, len(tt.wantChunks))
+			for i, want := range tt.wantChunks {
+				assert.Equal(t, want.StorageName, got[i].StorageName)
+				assert.Equal(t, want.Offset, got[i].Offset)
+				assert.Equal(t, want.Size, got[i].Size)
+			}
+		})
+	}
+}
+
+func TestOffsetWriter(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "offsetwriter")
+	require.NoError(t, err)
+	t.Cleanup(func() { f.Close() })
+
+	// Pre-size the file.
+	require.NoError(t, f.Truncate(100))
+
+	// Write "hello" at offset 10.
+	ow := &offsetWriter{f: f, offset: 10}
+	n, err := ow.Write([]byte("hello"))
+	require.NoError(t, err)
+	assert.Equal(t, 5, n)
+	assert.Equal(t, int64(15), ow.offset)
+
+	// Write "world" at offset 50.
+	ow2 := &offsetWriter{f: f, offset: 50}
+	n, err = ow2.Write([]byte("world"))
+	require.NoError(t, err)
+	assert.Equal(t, 5, n)
+	assert.Equal(t, int64(55), ow2.offset)
+
+	// Verify contents.
+	buf := make([]byte, 100)
+	_, err = f.ReadAt(buf, 0)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("hello"), buf[10:15])
+	assert.Equal(t, []byte("world"), buf[50:55])
+	// Gaps should be zero-filled.
+	assert.Equal(t, make([]byte, 10), buf[0:10])
+	assert.Equal(t, make([]byte, 35), buf[15:50])
+}
+
+// crc32Hash computes the CRC32 IEEE hash of data, matching what backupPipe.HashString() produces.
+func crc32Hash(data []byte) string {
+	h := crc32.NewIEEE()
+	h.Write(data)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// TestRestoreChunkedRetryPreservesData verifies that when a chunk fails during
+// restore and is retried, the previously-restored chunks are not destroyed.
+// This guards against the bug where os2.Create (which truncates) is used on retry,
+// wiping the already-restored data.
+func TestRestoreChunkedRetryPreservesData(t *testing.T) {
+	tmpDir := t.TempDir()
+	cnf := &Mycnf{DataDir: tmpDir}
+
+	// Simulate a file split into 3 chunks of 10 bytes each.
+	chunk0Data := []byte("AAAAAAAAAA")
+	chunk1Data := []byte("BBBBBBBBBB")
+	chunk2Data := []byte("CCCCCCCCCC")
+
+	fes := []FileEntry{
+		{
+			Base: backupData,
+			Name: "testfile.ibd",
+			Chunks: []FileChunk{
+				{StorageName: "0-0", Offset: 0, Size: 10, Hash: crc32Hash(chunk0Data)},
+				{StorageName: "0-1", Offset: 10, Size: 10, Hash: crc32Hash(chunk1Data)},
+				{StorageName: "0-2", Offset: 20, Size: 10, Hash: crc32Hash(chunk2Data)},
+			},
+		},
+	}
+
+	// Chunk "0-1" fails on first attempt.
+	var attempted sync.Map
+	bh := &FakeBackupHandle{
+		ReadFileReturnF: func(_ context.Context, filename string) (io.ReadCloser, error) {
+			count := 0
+			if v, ok := attempted.Load(filename); ok {
+				count = v.(int)
+			}
+			count++
+			attempted.Store(filename, count)
+
+			if filename == "0-1" && count == 1 {
+				return nil, errors.New("simulated read failure")
+			}
+			files := map[string][]byte{
+				"0-0": chunk0Data,
+				"0-1": chunk1Data,
+				"0-2": chunk2Data,
+			}
+			data, ok := files[filename]
+			if !ok {
+				return nil, fmt.Errorf("file %s not found", filename)
+			}
+			return io.NopCloser(bytes.NewReader(data)), nil
+		},
+	}
+
+	bm := builtinBackupManifest{SkipCompress: true}
+	params := RestoreParams{
+		Cnf:         cnf,
+		Logger:      logutil.NewMemoryLogger(),
+		Stats:       backupstats.NoStats(),
+		Concurrency: 1,
+	}
+
+	be := &BuiltinBackupEngine{}
+
+	// Pre-create and pre-size destination files, as restoreFiles() would.
+	require.NoError(t, createChunkedDestinations(t.Context(), fes, cnf, "", logutil.NewConsoleLogger()))
+
+	// First pass: chunk 0-1 will fail.
+	err := be.restoreFileEntries(t.Context(), fes, bh, bm, params, "")
+	require.Error(t, err)
+	require.Len(t, bh.GetFailedFiles(), 1)
+
+	// Verify chunks 0 and 2 were written correctly.
+	filePath := tmpDir + "/testfile.ibd"
+	content, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+	assert.Equal(t, chunk0Data, content[0:10], "chunk 0 should be intact after first pass")
+	assert.Equal(t, chunk2Data, content[20:30], "chunk 2 should be intact after first pass")
+
+	// Retry: build newFEs with only the failed chunk, as restoreFiles would.
+	failedFiles := bh.GetFailedFiles()
+	require.Len(t, failedFiles, 1)
+
+	newFEs := make([]FileEntry, len(fes))
+	for _, file := range failedFiles {
+		feIdx, chunkIdx, parseErr := parseBackupName(file)
+		require.NoError(t, parseErr)
+		oldFe := fes[feIdx]
+		if newFEs[feIdx].Name == "" {
+			newFEs[feIdx] = FileEntry{
+				Base:       oldFe.Base,
+				Name:       oldFe.Name,
+				ParentPath: oldFe.ParentPath,
+				RetryCount: 1,
+			}
+		}
+		newFEs[feIdx].Chunks = append(newFEs[feIdx].Chunks, oldFe.Chunks[chunkIdx])
+		bh.ResetErrorForFile(file)
+	}
+
+	// Second pass: retry the failed chunk.
+	err = be.restoreFileEntries(t.Context(), newFEs, bh, bm, params, "")
+	require.NoError(t, err)
+
+	// Verify ALL chunks are correct after retry.
+	content, err = os.ReadFile(filePath)
+	require.NoError(t, err)
+	assert.Equal(t, chunk0Data, content[0:10], "chunk 0 should still be intact after retry")
+	assert.Equal(t, chunk1Data, content[10:20], "chunk 1 should be restored after retry")
+	assert.Equal(t, chunk2Data, content[20:30], "chunk 2 should still be intact after retry")
+}
+
+func TestRestoreFileEntriesSetupErrIsFatal(t *testing.T) {
+	tmpDir := t.TempDir()
+	cnf := &Mycnf{DataDir: tmpDir}
+
+	fes := []FileEntry{
+		{
+			Base: backupData,
+			Name: "good.ibd",
+		},
+		{
+			Base: "invalid-base",
+			Name: "bad.ibd",
+			Chunks: []FileChunk{
+				{StorageName: "1-0", Offset: 0, Size: 10},
+			},
+		},
+	}
+
+	bh := &FakeBackupHandle{
+		ReadFileReturnF: func(_ context.Context, filename string) (io.ReadCloser, error) {
+			return nil, errors.New("simulated read failure")
+		},
+	}
+
+	bm := builtinBackupManifest{SkipCompress: true}
+	params := RestoreParams{
+		Cnf:         cnf,
+		Logger:      logutil.NewMemoryLogger(),
+		Stats:       backupstats.NoStats(),
+		Concurrency: 1,
+	}
+
+	be := &BuiltinBackupEngine{}
+	err := be.restoreFileEntries(t.Context(), fes, bh, bm, params, "")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errRestoreFatal)
+}
+
+func TestRestoreCloseErrorIsFatal(t *testing.T) {
+	tmpDir := t.TempDir()
+	cnf := &Mycnf{DataDir: tmpDir}
+
+	chunk0Data := []byte("AAAAAAAAAA")
+	chunk1Data := []byte("BBBBBBBBBB")
+
+	fes := []FileEntry{
+		{
+			Base: backupData,
+			Name: "testfile.ibd",
+			Chunks: []FileChunk{
+				{StorageName: "0-0", Offset: 0, Size: 10, Hash: crc32Hash(chunk0Data)},
+				{StorageName: "0-1", Offset: 10, Size: 10, Hash: crc32Hash(chunk1Data)},
+			},
+		},
+	}
+
+	bh := &FakeBackupHandle{
+		ReadFileReturnF: func(_ context.Context, filename string) (io.ReadCloser, error) {
+			if filename == "0-1" {
+				return nil, errors.New("simulated read failure")
+			}
+			files := map[string][]byte{
+				"0-0": chunk0Data,
+				"0-1": chunk1Data,
+			}
+			return io.NopCloser(bytes.NewReader(files[filename])), nil
+		},
+	}
+
+	oldMaxRetries := maxFileCloseRetries
+	oldOpenFile := openFile
+	t.Cleanup(func() {
+		maxFileCloseRetries = oldMaxRetries
+		openFile = oldOpenFile
+	})
+
+	maxFileCloseRetries = 0
+	openFile = func(name string, flag int, perm os.FileMode) (*os.File, error) {
+		f, err := os.OpenFile(name, flag, perm)
+		if err != nil {
+			return nil, err
+		}
+		f.Close()
+		return f, nil
+	}
+
+	bm := builtinBackupManifest{SkipCompress: true}
+	params := RestoreParams{
+		Cnf:         cnf,
+		Logger:      logutil.NewMemoryLogger(),
+		Stats:       backupstats.NoStats(),
+		Concurrency: 1,
+	}
+
+	be := &BuiltinBackupEngine{}
+	require.NoError(t, createChunkedDestinations(t.Context(), fes, cnf, "", logutil.NewConsoleLogger()))
+
+	err := be.restoreFileEntries(t.Context(), fes, bh, bm, params, "")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errRestoreFatal)
+}
+
+func TestExecuteBackupRejectsOversizedChunkSize(t *testing.T) {
+	oldThreshold := backupFileChunkThreshold
+	oldSize := backupFileChunkSize
+	t.Cleanup(func() {
+		backupFileChunkThreshold = oldThreshold
+		backupFileChunkSize = oldSize
+	})
+
+	backupFileChunkThreshold = 1024
+	backupFileChunkSize = math.MaxInt64 + 1
+
+	be := &BuiltinBackupEngine{}
+	_, err := be.ExecuteBackup(t.Context(), BackupParams{Logger: logutil.NewMemoryLogger()}, nil)
+	require.ErrorContains(t, err, "exceeds maximum allowed value")
+}
+
 func TestShouldDrainForBackupBuiltIn(t *testing.T) {
 	be := &BuiltinBackupEngine{}
 
@@ -166,4 +561,408 @@ func TestShouldDrainForBackupBuiltIn(t *testing.T) {
 	assert.False(t, be.ShouldDrainForBackup(&tabletmanagerdatapb.BackupRequest{IncrementalFromPos: "auto"}))
 	assert.False(t, be.ShouldDrainForBackup(&tabletmanagerdatapb.BackupRequest{IncrementalFromPos: "99ca8ed4-399c-11ee-861b-0a43f95f28a3:1-197"}))
 	assert.False(t, be.ShouldDrainForBackup(&tabletmanagerdatapb.BackupRequest{IncrementalFromPos: "MySQL56/99ca8ed4-399c-11ee-861b-0a43f95f28a3:1-197"}))
+}
+
+type nopWriteCloser struct{}
+
+func (nopWriteCloser) Write(p []byte) (int, error) { return len(p), nil }
+func (nopWriteCloser) Close() error                { return nil }
+
+func TestBackupFilesDoesNotCallEndBackup(t *testing.T) {
+	tmpDir := t.TempDir()
+	dataDir := path.Join(tmpDir, "datadir", "test1")
+	require.NoError(t, os.MkdirAll(dataDir, 0o755))
+	require.NoError(t, os.MkdirAll(path.Join(tmpDir, "innodb"), 0o755))
+	require.NoError(t, os.MkdirAll(path.Join(tmpDir, "log"), 0o755))
+
+	for _, name := range []string{"0.ibd", "1.ibd"} {
+		f, err := os2.Create(path.Join(dataDir, name))
+		require.NoError(t, err)
+		_, err = f.WriteString("test data for backup")
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+	}
+
+	var addFileCalls sync.Map
+	bh := &FakeBackupHandle{
+		AddFileReturnF: func(filename string) FakeBackupHandleAddFileReturn {
+			count := 0
+			if v, ok := addFileCalls.Load(filename); ok {
+				count = v.(int)
+			}
+			count++
+			addFileCalls.Store(filename, count)
+
+			// Fail file "0" on first attempt to trigger a retry.
+			if filename == "0" && count == 1 {
+				return FakeBackupHandleAddFileReturn{WriteCloser: nil, Err: errors.New("simulated transient error")}
+			}
+			return FakeBackupHandleAddFileReturn{WriteCloser: nopWriteCloser{}}
+		},
+	}
+
+	be := &BuiltinBackupEngine{}
+	err := be.backupFiles(
+		t.Context(),
+		BackupParams{
+			Cnf: &Mycnf{
+				InnodbDataHomeDir:     path.Join(tmpDir, "innodb"),
+				InnodbLogGroupHomeDir: path.Join(tmpDir, "log"),
+				DataDir:               path.Join(tmpDir, "datadir"),
+			},
+			Logger:      logutil.NewMemoryLogger(),
+			Stats:       backupstats.NoStats(),
+			Concurrency: 1,
+		},
+		bh,
+		replication.Position{},
+		replication.Position{},
+		replication.Position{},
+		"",
+		nil,
+		"",
+		"",
+		nil,
+	)
+	require.NoError(t, err)
+
+	assert.Empty(t, bh.EndBackupCalls, "backupFiles must not call EndBackup; only the top-level Backup() caller should")
+	assert.Positive(t, bh.WaitCalls, "backupFiles must call Wait() to flush pending async operations")
+}
+
+// TestBackupRestoreWithManyChunks exercises backup and restore with a high
+// chunk count (256 chunks) by overriding minBackupFileChunkSize below the
+// production floor. This validates that chunking works correctly under heavy
+// fan-out without requiring the large file sizes that the 4MiB minimum would
+// impose.
+func TestBackupRestoreWithManyChunks(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		fileSize  = 16 * 1024 * 1024 // 16MiB
+		chunkSize = 64 * 1024        // 64KiB → 256 chunks
+	)
+
+	// Override the minimum chunk size so we can use 64KiB chunks without
+	// hitting the 4MiB production floor validation in ExecuteBackup.
+	oldThreshold := backupFileChunkThreshold
+	oldSize := backupFileChunkSize
+	oldMin := minBackupFileChunkSize
+	t.Cleanup(func() {
+		backupFileChunkThreshold = oldThreshold
+		backupFileChunkSize = oldSize
+		minBackupFileChunkSize = oldMin
+	})
+	backupFileChunkThreshold = chunkSize
+	backupFileChunkSize = chunkSize
+	minBackupFileChunkSize = chunkSize
+
+	// Create a single 16MiB file filled with random (incompressible) data.
+	backupRoot := t.TempDir()
+	filebackupstorage.FileBackupStorageRoot = backupRoot
+	require.NoError(t, os.MkdirAll(path.Join(backupRoot, "innodb"), 0o755))
+	require.NoError(t, os.MkdirAll(path.Join(backupRoot, "log"), 0o755))
+	dataDir := path.Join(backupRoot, "datadir", "test1")
+	require.NoError(t, os.MkdirAll(dataDir, 0o755))
+
+	filePath := path.Join(dataDir, "0.ibd")
+	f, err := os2.Create(filePath)
+	require.NoError(t, err)
+	_, err = io.CopyN(f, rand.Reader, fileSize)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	// Checksum the original file before backup.
+	originalData, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+	originalChecksum := crc32.ChecksumIEEE(originalData)
+
+	// Set up topo — required by ExecuteBackup for MANIFEST metadata.
+	keyspace, shard := "mykeyspace", "-"
+	ts := memorytopo.NewServer(ctx, "cell1")
+	t.Cleanup(ts.Close)
+
+	require.NoError(t, ts.CreateKeyspace(ctx, keyspace, &topodata.Keyspace{}))
+	require.NoError(t, ts.CreateShard(ctx, keyspace, shard))
+	tablet := topo.NewTablet(100, "cell1", "mykeyspace-00-80-0100")
+	tablet.Keyspace = keyspace
+	tablet.Shard = shard
+	require.NoError(t, ts.CreateTablet(ctx, tablet))
+	_, err = ts.UpdateShardFields(ctx, keyspace, shard, func(si *topo.ShardInfo) error {
+		si.PrimaryAlias = &topodata.TabletAlias{Uid: 100, Cell: "cell1"}
+		now := time.Now()
+		si.PrimaryTermStartTime = &vttime.Time{Seconds: now.Unix(), Nanoseconds: int32(now.Nanosecond())}
+		return nil
+	})
+	require.NoError(t, err)
+
+	oldDeadline := BuiltinBackupMysqldTimeout
+	BuiltinBackupMysqldTimeout = time.Second
+	t.Cleanup(func() { BuiltinBackupMysqldTimeout = oldDeadline })
+
+	// Backup: should split the 16MiB file into 256 chunks of 64KiB each.
+	be := &BuiltinBackupEngine{}
+	bh := filebackupstorage.NewBackupHandle(nil, "", "", false)
+
+	fakedb := fakesqldb.New(t)
+	t.Cleanup(fakedb.Close)
+	mysqld := NewFakeMysqlDaemon(fakedb)
+	t.Cleanup(mysqld.Close)
+	mysqld.ExpectedExecuteSuperQueryList = []string{"STOP REPLICA", "START REPLICA"}
+
+	backupResult, err := be.ExecuteBackup(ctx, BackupParams{
+		Logger: logutil.NewMemoryLogger(),
+		Mysqld: mysqld,
+		Cnf: &Mycnf{
+			InnodbDataHomeDir:     path.Join(backupRoot, "innodb"),
+			InnodbLogGroupHomeDir: path.Join(backupRoot, "log"),
+			DataDir:               path.Join(backupRoot, "datadir"),
+		},
+		Stats:                backupstats.NoStats(),
+		Concurrency:          4,
+		HookExtraEnv:         map[string]string{},
+		TopoServer:           ts,
+		Keyspace:             keyspace,
+		Shard:                shard,
+		MysqlShutdownTimeout: time.Minute,
+	}, bh)
+
+	require.NoError(t, err)
+	require.Equal(t, BackupUsable, backupResult)
+
+	// Restore: read back all 256 chunks and reassemble into the original file.
+	restoreBh := filebackupstorage.NewBackupHandle(nil, "", "", true)
+	fakedb2 := fakesqldb.New(t)
+	t.Cleanup(fakedb2.Close)
+	mysqld2 := NewFakeMysqlDaemon(fakedb2)
+	t.Cleanup(mysqld2.Close)
+	mysqld2.ExpectedExecuteSuperQueryList = []string{"STOP REPLICA", "START REPLICA"}
+
+	bm, err := be.ExecuteRestore(ctx, RestoreParams{
+		Cnf: &Mycnf{
+			InnodbDataHomeDir:     path.Join(backupRoot, "innodb"),
+			InnodbLogGroupHomeDir: path.Join(backupRoot, "log"),
+			DataDir:               path.Join(backupRoot, "datadir"),
+			BinLogPath:            path.Join(backupRoot, "binlog"),
+			RelayLogPath:          path.Join(backupRoot, "relaylog"),
+			RelayLogIndexPath:     path.Join(backupRoot, "relaylogindex"),
+			RelayLogInfoPath:      path.Join(backupRoot, "relayloginfo"),
+		},
+		Logger:               logutil.NewMemoryLogger(),
+		Mysqld:               mysqld2,
+		Concurrency:          4,
+		HookExtraEnv:         map[string]string{},
+		DeleteBeforeRestore:  false,
+		DbName:               "test",
+		Keyspace:             "test",
+		Shard:                "-",
+		StartTime:            time.Now(),
+		RestoreToPos:         replication.Position{},
+		RestoreToTimestamp:   time.Time{},
+		DryRun:               false,
+		Stats:                backupstats.NoStats(),
+		MysqlShutdownTimeout: time.Minute,
+	}, restoreBh)
+
+	require.NoError(t, err)
+	require.NotNil(t, bm)
+
+	// Verify restored file matches the original.
+	restoredData, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+	assert.Equal(t, originalChecksum, crc32.ChecksumIEEE(restoredData))
+}
+
+func TestCreateChunkedDestinationsRejectsBadStorageName(t *testing.T) {
+	tmpDir := t.TempDir()
+	cnf := &Mycnf{DataDir: tmpDir}
+
+	fes := []FileEntry{
+		{
+			Base: backupData,
+			Name: "testfile.ibd",
+			Chunks: []FileChunk{
+				{StorageName: "0-0", Offset: 0, Size: 10},
+				{StorageName: "wrong-name", Offset: 10, Size: 10},
+			},
+		},
+	}
+
+	err := createChunkedDestinations(t.Context(), fes, cnf, "", logutil.NewConsoleLogger())
+	require.ErrorContains(t, err, "unexpected storage name")
+	require.ErrorContains(t, err, `got "wrong-name"`)
+	require.ErrorContains(t, err, `expected "0-1"`)
+}
+
+func TestRestoreFileChunkRejectsDecompressedSizeMismatch(t *testing.T) {
+	tmpDir := t.TempDir()
+	cnf := &Mycnf{DataDir: tmpDir}
+
+	chunkData := []byte("AAAAAAAAAA")
+
+	fes := []FileEntry{
+		{
+			Base: backupData,
+			Name: "testfile.ibd",
+			Chunks: []FileChunk{
+				{StorageName: "0-0", Offset: 0, Size: 20, Hash: crc32Hash(chunkData)},
+			},
+		},
+	}
+
+	bh := &FakeBackupHandle{
+		ReadFileReturnF: func(_ context.Context, filename string) (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(chunkData)), nil
+		},
+	}
+
+	bm := builtinBackupManifest{SkipCompress: true}
+	params := RestoreParams{
+		Cnf:         cnf,
+		Logger:      logutil.NewMemoryLogger(),
+		Stats:       backupstats.NoStats(),
+		Concurrency: 1,
+	}
+
+	be := &BuiltinBackupEngine{}
+	require.NoError(t, createChunkedDestinations(t.Context(), fes, cnf, "", logutil.NewConsoleLogger()))
+
+	err := be.restoreFileEntries(t.Context(), fes, bh, bm, params, "")
+	require.ErrorContains(t, err, "decompressed size mismatch")
+	require.ErrorContains(t, err, "wrote 10 bytes, expected 20")
+}
+
+func TestCreateChunkedDestinationsRejectsGap(t *testing.T) {
+	tmpDir := t.TempDir()
+	cnf := &Mycnf{DataDir: tmpDir}
+
+	fes := []FileEntry{
+		{
+			Base: backupData,
+			Name: "testfile.ibd",
+			Chunks: []FileChunk{
+				{StorageName: "0-0", Offset: 0, Size: 10},
+				{StorageName: "0-1", Offset: 20, Size: 10},
+			},
+		},
+	}
+
+	err := createChunkedDestinations(t.Context(), fes, cnf, "", logutil.NewConsoleLogger())
+	require.ErrorContains(t, err, "gap/overlap")
+	require.ErrorContains(t, err, "expected offset 10, got 20")
+}
+
+func TestCreateChunkedDestinationsRejectsOverlap(t *testing.T) {
+	tmpDir := t.TempDir()
+	cnf := &Mycnf{DataDir: tmpDir}
+
+	fes := []FileEntry{
+		{
+			Base: backupData,
+			Name: "testfile.ibd",
+			Chunks: []FileChunk{
+				{StorageName: "0-0", Offset: 0, Size: 15},
+				{StorageName: "0-1", Offset: 10, Size: 10},
+			},
+		},
+	}
+
+	err := createChunkedDestinations(t.Context(), fes, cnf, "", logutil.NewConsoleLogger())
+	require.ErrorContains(t, err, "gap/overlap")
+	require.ErrorContains(t, err, "expected offset 15, got 10")
+}
+
+// TestCreateChunkedDestinationsAcceptsOutOfOrderChunks verifies that chunks listed
+// out of offset order in the MANIFEST are accepted as long as the file is complete
+// (contiguous coverage with no gaps or overlaps and correct StorageNames).
+func TestCreateChunkedDestinationsAcceptsOutOfOrderChunks(t *testing.T) {
+	tmpDir := t.TempDir()
+	cnf := &Mycnf{DataDir: tmpDir}
+
+	fes := []FileEntry{
+		{
+			Base: backupData,
+			Name: "testfile.ibd",
+			Chunks: []FileChunk{
+				{StorageName: "0-1", Offset: 10, Size: 10},
+				{StorageName: "0-0", Offset: 0, Size: 10},
+			},
+		},
+	}
+
+	err := createChunkedDestinations(t.Context(), fes, cnf, "", logutil.NewConsoleLogger())
+	require.NoError(t, err)
+}
+
+func TestHasErrorCode(t *testing.T) {
+	precondition := vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "fatal error")
+	internal := vterrors.Errorf(vtrpcpb.Code_INTERNAL, "transient error")
+
+	tests := []struct {
+		name     string
+		err      error
+		code     vtrpcpb.Code
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			code:     vtrpcpb.Code_FAILED_PRECONDITION,
+			expected: false,
+		},
+		{
+			name:     "single error with matching code",
+			err:      precondition,
+			code:     vtrpcpb.Code_FAILED_PRECONDITION,
+			expected: true,
+		},
+		{
+			name:     "single error with non-matching code",
+			err:      internal,
+			code:     vtrpcpb.Code_FAILED_PRECONDITION,
+			expected: false,
+		},
+		{
+			name:     "joined error with matching code in second position",
+			err:      errors.Join(internal, precondition),
+			code:     vtrpcpb.Code_FAILED_PRECONDITION,
+			expected: true,
+		},
+		{
+			name:     "joined error with no matching code",
+			err:      errors.Join(internal, errors.New("plain error")),
+			code:     vtrpcpb.Code_FAILED_PRECONDITION,
+			expected: false,
+		},
+		{
+			name:     "nested join with matching code",
+			err:      errors.Join(errors.New("outer"), errors.Join(internal, precondition)),
+			code:     vtrpcpb.Code_FAILED_PRECONDITION,
+			expected: true,
+		},
+		{
+			name:     "wrapped error with matching code",
+			err:      vterrors.Wrapf(precondition, "context"),
+			code:     vtrpcpb.Code_FAILED_PRECONDITION,
+			expected: true,
+		},
+		{
+			name:     "wrapped joined error with matching code",
+			err:      vterrors.Wrapf(errors.Join(internal, precondition), "context"),
+			code:     vtrpcpb.Code_FAILED_PRECONDITION,
+			expected: true,
+		},
+		{
+			name:     "fmt wrapped joined error with matching code",
+			err:      fmt.Errorf("outer: %w", errors.Join(internal, precondition)),
+			code:     vtrpcpb.Code_FAILED_PRECONDITION,
+			expected: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, hasErrorCode(tc.err, tc.code))
+		})
+	}
 }

--- a/go/vt/mysqlctl/cephbackupstorage/ceph.go
+++ b/go/vt/mysqlctl/cephbackupstorage/ceph.go
@@ -113,12 +113,17 @@ func (bh *CephBackupHandle) AddFile(ctx context.Context, filename string, filesi
 	return writer, nil
 }
 
+// Wait implements BackupHandle.
+func (bh *CephBackupHandle) Wait() {
+	bh.waitGroup.Wait()
+}
+
 // EndBackup implements BackupHandle.
 func (bh *CephBackupHandle) EndBackup(ctx context.Context) error {
 	if bh.readOnly {
 		return fmt.Errorf("EndBackup cannot be called on read-only backup")
 	}
-	bh.waitGroup.Wait()
+	bh.Wait()
 	// Return the saved PutObject() errors, if any.
 	return bh.Error()
 }

--- a/go/vt/mysqlctl/fakebackupstorage.go
+++ b/go/vt/mysqlctl/fakebackupstorage.go
@@ -18,24 +18,28 @@ package mysqlctl
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"io"
+	"sync"
 
 	"vitess.io/vitess/go/vt/mysqlctl/backupstorage"
-	"vitess.io/vitess/go/vt/mysqlctl/errors"
+	mysqlctlerrors "vitess.io/vitess/go/vt/mysqlctl/errors"
 )
 
 type FakeBackupHandle struct {
+	mu sync.Mutex
+
 	Dir      string
 	NameV    string
 	ReadOnly bool
-	errors.PerFileErrorRecorder
+	mysqlctlerrors.PerFileErrorRecorder
 
 	AbortBackupCalls  []context.Context
 	AbortBackupReturn error
 	AddFileCalls      []FakeBackupHandleAddFileCall
 	AddFileReturn     FakeBackupHandleAddFileReturn
 	AddFileReturnF    func(filename string) FakeBackupHandleAddFileReturn
+	WaitCalls         int
 	EndBackupCalls    []context.Context
 	EndBackupReturn   error
 	ReadFileCalls     []FakeBackupHandleReadFileCall
@@ -67,31 +71,51 @@ func (fbh *FakeBackupHandle) Name() string {
 }
 
 func (fbh *FakeBackupHandle) AddFile(ctx context.Context, filename string, filesize int64) (io.WriteCloser, error) {
+	fbh.mu.Lock()
 	fbh.AddFileCalls = append(fbh.AddFileCalls, FakeBackupHandleAddFileCall{ctx, filename, filesize})
+	// Capture return fields under the lock since AddFile is called from concurrent goroutines.
+	returnF := fbh.AddFileReturnF
+	returnVal := fbh.AddFileReturn
+	fbh.mu.Unlock()
 
-	if fbh.AddFileReturnF != nil {
-		r := fbh.AddFileReturnF(filename)
+	if returnF != nil {
+		r := returnF(filename)
 		return r.WriteCloser, r.Err
 	}
-	return fbh.AddFileReturn.WriteCloser, fbh.AddFileReturn.Err
+	return returnVal.WriteCloser, returnVal.Err
+}
+
+func (fbh *FakeBackupHandle) Wait() {
+	fbh.mu.Lock()
+	fbh.WaitCalls++
+	fbh.mu.Unlock()
 }
 
 func (fbh *FakeBackupHandle) EndBackup(ctx context.Context) error {
+	fbh.mu.Lock()
 	fbh.EndBackupCalls = append(fbh.EndBackupCalls, ctx)
+	fbh.mu.Unlock()
 	return fbh.EndBackupReturn
 }
 
 func (fbh *FakeBackupHandle) AbortBackup(ctx context.Context) error {
+	fbh.mu.Lock()
 	fbh.AbortBackupCalls = append(fbh.AbortBackupCalls, ctx)
+	fbh.mu.Unlock()
 	return fbh.AbortBackupReturn
 }
 
 func (fbh *FakeBackupHandle) ReadFile(ctx context.Context, filename string) (io.ReadCloser, error) {
+	fbh.mu.Lock()
 	fbh.ReadFileCalls = append(fbh.ReadFileCalls, FakeBackupHandleReadFileCall{ctx, filename})
-	if fbh.ReadFileReturnF == nil {
-		return nil, fmt.Errorf("FakeBackupHandle has not defined a ReadFileReturnF")
+	// Capture return field under the lock since ReadFile may be called from concurrent goroutines.
+	readF := fbh.ReadFileReturnF
+	fbh.mu.Unlock()
+
+	if readF == nil {
+		return nil, errors.New("FakeBackupHandle has not defined a ReadFileReturnF")
 	}
-	return fbh.ReadFileReturnF(ctx, filename)
+	return readF(ctx, filename)
 }
 
 type FakeBackupStorage struct {

--- a/go/vt/mysqlctl/file_close_test.go
+++ b/go/vt/mysqlctl/file_close_test.go
@@ -162,6 +162,8 @@ func (m *mockBackupHandle) ReadFile(ctx context.Context, filename string) (io.Re
 	return m.readFileReturn, nil
 }
 
+func (m *mockBackupHandle) Wait() {}
+
 func (m *mockBackupHandle) EndBackup(ctx context.Context) error {
 	return nil
 }
@@ -326,7 +328,7 @@ func TestBackupFileSourceCloseError(t *testing.T) {
 	}
 
 	// backupFile should handle the error gracefully.
-	err = be.backupFile(ctx, params, bh, fe, "0")
+	err = be.backupFile(ctx, params, bh, fe, "0", -1)
 
 	// Should succeed after retries.
 	assert.NoError(t, err)
@@ -365,7 +367,7 @@ func TestBackupFileDestinationCloseError(t *testing.T) {
 		Name: "source.txt",
 	}
 
-	err = be.backupFile(ctx, params, bh, fe, "0")
+	err = be.backupFile(ctx, params, bh, fe, "0", -1)
 
 	// Should succeed after retries.
 	assert.NoError(t, err)
@@ -411,7 +413,7 @@ func TestBackupFileDestinationCloseMaxRetries(t *testing.T) {
 		Name: "destination.txt",
 	}
 
-	err = be.backupFile(ctx, params, bh, fe, "0")
+	err = be.backupFile(ctx, params, bh, fe, "0", -1)
 
 	// Should fail due to close error (context deadline exceeded).
 	assert.Error(t, err)

--- a/go/vt/mysqlctl/filebackupstorage/file.go
+++ b/go/vt/mysqlctl/filebackupstorage/file.go
@@ -107,7 +107,10 @@ func (fbh *FileBackupHandle) AddFile(ctx context.Context, filename string, files
 	return ioutil.NewMeteredWriteCloser(f, stat.TimedIncrementBytes), nil
 }
 
-// EndBackup is part of the BackupHandle interface
+// Wait is part of the BackupHandle interface.
+func (fbh *FileBackupHandle) Wait() {}
+
+// EndBackup is part of the BackupHandle interface.
 func (fbh *FileBackupHandle) EndBackup(ctx context.Context) error {
 	if fbh.readOnly {
 		return fmt.Errorf("EndBackup cannot be called on read-only backup")

--- a/go/vt/mysqlctl/gcsbackupstorage/gcs.go
+++ b/go/vt/mysqlctl/gcsbackupstorage/gcs.go
@@ -88,6 +88,9 @@ func (bh *GCSBackupHandle) AddFile(ctx context.Context, filename string, filesiz
 	return bh.client.Bucket(bucket).Object(object).NewWriter(ctx), nil
 }
 
+// Wait implements BackupHandle.
+func (bh *GCSBackupHandle) Wait() {}
+
 // EndBackup implements BackupHandle.
 func (bh *GCSBackupHandle) EndBackup(ctx context.Context) error {
 	if bh.readOnly {

--- a/go/vt/mysqlctl/s3backupstorage/s3.go
+++ b/go/vt/mysqlctl/s3backupstorage/s3.go
@@ -254,12 +254,17 @@ func calculateUploadPartSize(filesize int64) (partSizeBytes int64, err error) {
 	return
 }
 
+// Wait is part of the backupstorage.BackupHandle interface.
+func (bh *S3BackupHandle) Wait() {
+	bh.waitGroup.Wait()
+}
+
 // EndBackup is part of the backupstorage.BackupHandle interface.
 func (bh *S3BackupHandle) EndBackup(ctx context.Context) error {
 	if bh.readOnly {
 		return fmt.Errorf("EndBackup cannot be called on read-only backup")
 	}
-	bh.waitGroup.Wait()
+	bh.Wait()
 	return bh.Error()
 }
 
@@ -521,7 +526,8 @@ func (bs *S3BackupStorage) client() (*s3.Client, error) {
 
 		httpClient := &http.Client{Transport: bs.transport}
 
-		cfg, err := config.LoadDefaultConfig(context.Background(),
+		cfg, err := config.LoadDefaultConfig(
+			context.Background(),
 			config.WithRegion(region),
 			config.WithClientLogMode(logLevel),
 			config.WithHTTPClient(httpClient),

--- a/go/vt/mysqlctl/s3backupstorage/s3_mock.go
+++ b/go/vt/mysqlctl/s3backupstorage/s3_mock.go
@@ -26,6 +26,8 @@ import (
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/mysqlctl/backupstats"
 	"vitess.io/vitess/go/vt/mysqlctl/backupstorage"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/vterrors"
 )
 
 type FakeS3BackupHandle struct {
@@ -108,6 +110,10 @@ func (fbh *FakeS3BackupHandle) AddFile(ctx context.Context, filename string, fil
 	return fbh.S3BackupHandle.AddFile(ctx, filename, filesize)
 }
 
+func (fbh *FakeS3BackupHandle) Wait() {
+	fbh.S3BackupHandle.Wait()
+}
+
 func (fbh *FakeS3BackupHandle) EndBackup(ctx context.Context) error {
 	return fbh.S3BackupHandle.EndBackup(ctx)
 }
@@ -147,6 +153,26 @@ func (fbh *FakeS3BackupHandle) GetFailedFiles() []string {
 
 func (fbh *FakeS3BackupHandle) ResetErrorForFile(s string) {
 	fbh.S3BackupHandle.ResetErrorForFile(s)
+}
+
+func (fbh *FakeS3BackupHandle) AddFileAttempts() int {
+	fbh.mu.Lock()
+	defer fbh.mu.Unlock()
+	total := 0
+	for _, v := range fbh.addPerFile {
+		total += v
+	}
+	return total
+}
+
+func (fbh *FakeS3BackupHandle) ReadFileAttempts() int {
+	fbh.mu.Lock()
+	defer fbh.mu.Unlock()
+	total := 0
+	for _, v := range fbh.readPerFile {
+		total += v
+	}
+	return total
 }
 
 type failReadPipeReader struct {
@@ -228,4 +254,16 @@ func FailAllReadExpectManifest(s3bh *S3BackupHandle, ctx context.Context, filena
 		return s3bh.ReadFile(ctx, filename)
 	}
 	return &failRead{}, nil
+}
+
+func FailWithFatalError(_ *S3BackupHandle, _ context.Context, _ string, _ int64, _ bool) (io.WriteCloser, error) {
+	return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "simulated non-retryable error")
+}
+
+func FailWithFatalReadError(s3bh *S3BackupHandle, ctx context.Context, filename string, _ bool) (io.ReadCloser, error) {
+	const manifestFileName = "MANIFEST"
+	if filename == manifestFileName {
+		return s3bh.ReadFile(ctx, filename)
+	}
+	return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "simulated non-retryable error")
 }


### PR DESCRIPTION


<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

Backport upstream PR https://github.com/vitessio/vitess/pull/20167 that implements backup chunking on the `builtin` backup engine.

## Related Issue(s)

- https://github.com/vitessio/vitess/issues/20159
  - https://github.com/vitessio/vitess/pull/20167

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

