### PR TITLE
Consolidate Snake priority inversion into one helper

### DIFF
--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -819,9 +819,7 @@ func (qre *QueryExecutor) getConn() (*connpool.PooledConn, func(), error) {
 	snake := qre.tsv.qe.snake
 	if snake != nil {
 		valveID := qre.options.GetLoadshedValveId()
-		// Translate the Vitess proto priority (0 = most important) into
-		// Snake's convention (higher priority shed last).
-		snakePriority := float64(sqlparser.MaxPriorityValue - qre.tsv.getPriorityFromOptions(qre.options))
+		snakePriority := snakePriorityFromOptions(qre.options, qre.tsv.config.TxThrottlerDefaultPriority)
 		unlock, err := snake.Acquire(ctx, valveID, snakePriority)
 		if err != nil {
 			return nil, nil, vterrors.Errorf(vtrpcpb.Code_RESOURCE_EXHAUSTED, "load shed: %v", err)

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -624,6 +624,14 @@ func priorityFromOptions(options *querypb.ExecuteOptions, defaultPriority int) i
 	return optionsPriority
 }
 
+// snakePriorityFromOptions reads the proto priority and inverts it into Snake's
+// convention. Vitess proto priority runs 0 (most important) to MaxPriorityValue
+// (least important); Snake sheds the lowest value first, so we flip it: the most
+// important query gets the highest Snake priority and is shed last.
+func snakePriorityFromOptions(options *querypb.ExecuteOptions, defaultPriority int) float64 {
+	return float64(sqlparser.MaxPriorityValue - priorityFromOptions(options, defaultPriority))
+}
+
 // resolveTargetType returns the appropriate target tablet type for a
 // TabletServer request. If the caller has a local context then it's
 // an internal request and the target is the local tablet's current

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -2967,3 +2967,45 @@ func TestPriorityFromOptions(t *testing.T) {
 		})
 	}
 }
+
+func TestSnakePriorityFromOptions(t *testing.T) {
+	const defaultPriority = 100
+
+	tests := []struct {
+		name    string
+		options *querypb.ExecuteOptions
+		want    float64
+	}{
+		{
+			name:    "most important proto priority inverts to highest snake priority",
+			options: &querypb.ExecuteOptions{Priority: "0"},
+			want:    100,
+		},
+		{
+			name:    "least important proto priority inverts to lowest snake priority",
+			options: &querypb.ExecuteOptions{Priority: "100"},
+			want:    0,
+		},
+		{
+			name:    "mid-range proto priority inverts",
+			options: &querypb.ExecuteOptions{Priority: "30"},
+			want:    70,
+		},
+		{
+			name:    "empty priority uses default then inverts",
+			options: &querypb.ExecuteOptions{Priority: ""},
+			want:    0,
+		},
+		{
+			name:    "nil options uses default then inverts",
+			options: nil,
+			want:    0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, snakePriorityFromOptions(tt.options, defaultPriority))
+		})
+	}
+}

--- a/go/vt/vttablet/tabletserver/tx_pool.go
+++ b/go/vt/vttablet/tabletserver/tx_pool.go
@@ -255,10 +255,7 @@ func (tp *TxPool) Begin(ctx context.Context, options *querypb.ExecuteOptions, re
 
 		if tp.snake != nil {
 			valveID := options.GetLoadshedValveId()
-			// Translate the Vitess proto priority (0 = most important) into
-			// Snake's convention (higher priority shed last).
-			protoPriority := priorityFromOptions(options, tp.env.Config().TxThrottlerDefaultPriority)
-			snakePriority := float64(sqlparser.MaxPriorityValue - protoPriority)
+			snakePriority := snakePriorityFromOptions(options, tp.env.Config().TxThrottlerDefaultPriority)
 			unlock, snakeErr := tp.snake.Acquire(ctx, valveID, snakePriority)
 			if snakeErr != nil {
 				tp.limiter.Release(immediateCaller, effectiveCaller)


### PR DESCRIPTION
### Background / Why?

Snake reads the query's priority from `ExecuteOptions` and inverts it: Vitess proto priority runs 0 (most important) → `MaxPriorityValue` (least important), but Snake sheds the lowest value first, so the most important query needs the *highest* Snake priority. Both Snake acquisition sites — the OLTP read path in `query_executor.go` and the DML path in `tx_pool.go` — carried this `float64(MaxPriorityValue - proto)` inversion inline, duplicating both the arithmetic and the explanatory comment.

This extracts a single `snakePriorityFromOptions` helper next to the existing `priorityFromOptions`, so the inversion and its rationale live in one place and the two pools can't drift apart. No behavior change: same default (`TxThrottlerDefaultPriority`), same parse, same inversion.

### Testing

new unit tests
