### PR TITLE
Parse `LOADSHED_VALVE_ID` comment directive in vtgate

### DIFF
--- a/go/vt/sqlparser/comments.go
+++ b/go/vt/sqlparser/comments.go
@@ -621,7 +621,6 @@ func getWorkload(directives *CommentDirectives) string {
 	return workloadName
 }
 
-// getLoadshedValveId gets the load shedder valve ID from the provided directives, using DirectiveLoadshedValveId.
 func getLoadshedValveId(directives *CommentDirectives) string {
 	valveID, _ := directives.GetString(DirectiveLoadshedValveId, "")
 	return valveID

--- a/go/vt/sqlparser/comments.go
+++ b/go/vt/sqlparser/comments.go
@@ -58,6 +58,9 @@ const (
 	// DirectivePriority specifies the priority of a workload. It should be an integer between 0 and MaxPriorityValue,
 	// where 0 is the highest priority, and MaxPriorityValue is the lowest one.
 	DirectivePriority = "PRIORITY"
+	// DirectiveLoadshedValveId identifies the logical caller (request, job, etc.) issuing the query, so the vttablet
+	// load shedder can treat one caller's fan-out to a single shard as self-contention rather than independent load.
+	DirectiveLoadshedValveId = "LOADSHED_VALVE_ID"
 
 	// MaxPriorityValue specifies the maximum value allowed for the priority query directive. Valid priority values are
 	// between zero and MaxPriorityValue.
@@ -568,6 +571,7 @@ type QueryHints struct {
 	Workload            string
 	ForeignKeyChecks    *bool
 	Priority            string
+	LoadshedValveId     string
 	Timeout             *int
 }
 
@@ -588,6 +592,7 @@ func BuildQueryHints(stmt Statement) (qh QueryHints, err error) {
 	qh.IgnoreMaxMemoryRows = directives.IsSet(DirectiveIgnoreMaxMemoryRows)
 	qh.Consolidator = getConsolidator(stmt, directives)
 	qh.Workload = getWorkload(directives)
+	qh.LoadshedValveId = getLoadshedValveId(directives)
 	qh.ForeignKeyChecks = getForeignKeyChecksState(comment)
 	qh.Timeout = getQueryTimeout(directives)
 
@@ -614,6 +619,12 @@ func getConsolidator(stmt Statement, directives *CommentDirectives) querypb.Exec
 func getWorkload(directives *CommentDirectives) string {
 	workloadName, _ := directives.GetString(DirectiveWorkloadName, "")
 	return workloadName
+}
+
+// getLoadshedValveId gets the load shedder valve ID from the provided directives, using DirectiveLoadshedValveId.
+func getLoadshedValveId(directives *CommentDirectives) string {
+	valveID, _ := directives.GetString(DirectiveLoadshedValveId, "")
+	return valveID
 }
 
 // getForeignKeyChecksState returns the state of foreign_key_checks variable if it is part of a SET_VAR optimizer hint in the comments.

--- a/go/vt/sqlparser/comments_test.go
+++ b/go/vt/sqlparser/comments_test.go
@@ -698,3 +698,28 @@ func TestQueryTimeout(t *testing.T) {
 		})
 	}
 }
+
+// TestLoadshedValveId tests the extraction of LOADSHED_VALVE_ID from the comments.
+func TestLoadshedValveId(t *testing.T) {
+	testCases := []struct {
+		query      string
+		expectedID string
+	}{{
+		query:      "select * from a_table",
+		expectedID: "",
+	}, {
+		query:      "select /*vt+ LOADSHED_VALVE_ID=req123 */ * from another_table",
+		expectedID: "req123",
+	}}
+
+	parser := NewTestParser()
+	for _, tc := range testCases {
+		t.Run(tc.query, func(t *testing.T) {
+			stmt, err := parser.Parse(tc.query)
+			assert.NoError(t, err)
+			qh, err := BuildQueryHints(stmt)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedID, qh.LoadshedValveId)
+		})
+	}
+}

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -1208,6 +1208,7 @@ func (e *Executor) applyQueryHints(vcursor *econtext.VCursorImpl, plan *engine.P
 	vcursor.SetConsolidator(qh.Consolidator)
 	vcursor.SetWorkloadName(qh.Workload)
 	vcursor.SetPriority(qh.Priority)
+	vcursor.SetLoadshedValveId(qh.LoadshedValveId)
 	vcursor.SetExecQueryTimeout(qh.Timeout)
 }
 

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -1852,8 +1852,8 @@ func TestGetPlanLoadshedValveId(t *testing.T) {
 		{name: "no valve ID", sql: "select * from music_user_map", expectedValveID: ""},
 	}
 
-	// A single session is reused across cases so a query without the directive
-	// must not inherit the prior query's valve ID.
+	// A single session is reused across cases so we also cover the clear-on-empty
+	// path: a query without the directive must not inherit the prior query's valve ID.
 	session := econtext.NewSafeSession(&vtgatepb.Session{TargetString: "@unknown", Options: &querypb.ExecuteOptions{}})
 
 	for _, aTestCase := range testCases {

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -1841,6 +1841,38 @@ func TestGetPlanPriority(t *testing.T) {
 
 }
 
+func TestGetPlanLoadshedValveId(t *testing.T) {
+
+	testCases := []struct {
+		name            string
+		sql             string
+		expectedValveID string
+	}{
+		{name: "valve ID set", sql: "select /*vt+ LOADSHED_VALVE_ID=req123 */ * from music_user_map", expectedValveID: "req123"},
+		{name: "no valve ID", sql: "select * from music_user_map", expectedValveID: ""},
+	}
+
+	// A single session is reused across cases so we also cover the clear-on-empty
+	// path: a query without the directive must not inherit the prior query's valve ID.
+	session := econtext.NewSafeSession(&vtgatepb.Session{TargetString: "@unknown", Options: &querypb.ExecuteOptions{}})
+
+	for _, aTestCase := range testCases {
+		testCase := aTestCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			r, _, _, _, ctx := createExecutorEnvWithConfig(t, createExecutorConfigWithNormalizer())
+
+			logStats := logstats.NewLogStats(ctx, "Test", "", "", nil, streamlog.NewQueryLogConfigForTest())
+
+			plan, _, _, err := r.fetchOrCreatePlan(context.Background(), session, testCase.sql, map[string]*querypb.BindVariable{}, r.config.Normalize, false, logStats, true)
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.expectedValveID, plan.QueryHints.LoadshedValveId)
+			assert.Equal(t, testCase.expectedValveID, session.Options.LoadshedValveId)
+		})
+	}
+
+}
+
 func TestPassthroughDDL(t *testing.T) {
 	executor, sbc1, sbc2, _, ctx := createExecutorEnvWithConfig(t, createExecutorConfigWithNormalizer())
 	session := &vtgatepb.Session{

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -1852,8 +1852,8 @@ func TestGetPlanLoadshedValveId(t *testing.T) {
 		{name: "no valve ID", sql: "select * from music_user_map", expectedValveID: ""},
 	}
 
-	// A single session is reused across cases so we also cover the clear-on-empty
-	// path: a query without the directive must not inherit the prior query's valve ID.
+	// A single session is reused across cases so a query without the directive
+	// must not inherit the prior query's valve ID.
 	session := econtext.NewSafeSession(&vtgatepb.Session{TargetString: "@unknown", Options: &querypb.ExecuteOptions{}})
 
 	for _, aTestCase := range testCases {

--- a/go/vt/vtgate/executorcontext/vcursor_impl.go
+++ b/go/vt/vtgate/executorcontext/vcursor_impl.go
@@ -1175,6 +1175,14 @@ func (vc *VCursorImpl) SetPriority(priority string) {
 	}
 }
 
+func (vc *VCursorImpl) SetLoadshedValveId(valveID string) {
+	if valveID != "" {
+		vc.SafeSession.GetOrCreateOptions().LoadshedValveId = valveID
+	} else if vc.SafeSession.Options != nil && vc.SafeSession.Options.LoadshedValveId != "" {
+		vc.SafeSession.Options.LoadshedValveId = ""
+	}
+}
+
 func (vc *VCursorImpl) SetExecQueryTimeout(timeout *int) {
 	// Determine the effective timeout: use passed timeout if non-nil, otherwise use session's query timeout if available
 	var execTimeout *int

--- a/go/vt/vtgate/executorcontext/vcursor_impl.go
+++ b/go/vt/vtgate/executorcontext/vcursor_impl.go
@@ -1176,11 +1176,7 @@ func (vc *VCursorImpl) SetPriority(priority string) {
 }
 
 func (vc *VCursorImpl) SetLoadshedValveId(valveID string) {
-	if valveID != "" {
-		vc.SafeSession.GetOrCreateOptions().LoadshedValveId = valveID
-	} else if vc.SafeSession.Options != nil && vc.SafeSession.Options.LoadshedValveId != "" {
-		vc.SafeSession.Options.LoadshedValveId = ""
-	}
+	vc.SafeSession.GetOrCreateOptions().LoadshedValveId = valveID
 }
 
 func (vc *VCursorImpl) SetExecQueryTimeout(timeout *int) {

--- a/go/vt/vtgate/executorcontext/vcursor_impl.go
+++ b/go/vt/vtgate/executorcontext/vcursor_impl.go
@@ -1176,7 +1176,11 @@ func (vc *VCursorImpl) SetPriority(priority string) {
 }
 
 func (vc *VCursorImpl) SetLoadshedValveId(valveID string) {
-	vc.SafeSession.GetOrCreateOptions().LoadshedValveId = valveID
+	if valveID != "" {
+		vc.SafeSession.GetOrCreateOptions().LoadshedValveId = valveID
+	} else if vc.SafeSession.Options != nil && vc.SafeSession.Options.LoadshedValveId != "" {
+		vc.SafeSession.Options.LoadshedValveId = ""
+	}
 }
 
 func (vc *VCursorImpl) SetExecQueryTimeout(timeout *int) {


### PR DESCRIPTION
### Background / Why?

The vttablet Snake load shedder reads `ExecuteOptions.loadshed_valve_id` — the self-contention key that lets one caller's fan-out to a single shard share a droppable queue slot rather than count as independent load — but until now nothing populated that field for MySQL-protocol clients. gRPC clients get it for free (vtgate forwards the `ExecuteOptions` pointer to the tablet verbatim), but MySQL-protocol clients like the Slack webapp can only set `ExecuteOptions` fields that vtgate parses out of `/*vt+ ... */` comment directives. `PRIORITY` already works this way; the valve ID had no directive, so it was unreachable from webapp.

This teaches vtgate to parse a `LOADSHED_VALVE_ID` directive into the field, mirroring the `PRIORITY` path end to end: a `DirectiveLoadshedValveId` constant, a `QueryHints.LoadshedValveId` field, a `getLoadshedValveId` extractor (free-form string, modeled on `WORKLOAD_NAME` rather than the numeric-validated `PRIORITY`), and a `SetLoadshedValveId` vcursor setter wired through `applyQueryHints`. The setter writes the parsed value onto the session unconditionally, so a directive-less query on a pooled connection overwrites (rather than inherits) a prior query's valve ID. The proto field already exists, so there's no proto regen here.

An unrecognized directive is a no-op in vtgate, so this is safe to land ahead of the webapp side that will emit it: [`ParsedComments.Directives()`](https://github.com/slackhq/vitess/blob/555f57fd37c64cff689f599c10eb81fe6381d543/go/vt/sqlparser/comments.go#L250-L275) parses every `key=val` into a generic map with no allowlist, and a key has effect only if some `getX` helper explicitly reads it — an unread directive is simply never acted on.

Webapp side: https://slack-github.com/slack/webapp/pull/403501

### Testing

new unit tests