### PR TITLE
Record Snake self-contention valve depth as a histogram

### DIFF
--- a/go/vt/vttablet/tabletserver/loadshed/snake.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake.go
@@ -66,6 +66,7 @@ type (
 		interval     *stats.Histogram
 		dropCount    *stats.Histogram
 		timerLag     *stats.Histogram
+		valveDepth   *stats.Histogram
 
 		droppingNanos   int64
 		droppingSinceNs int64
@@ -100,6 +101,7 @@ func NewSnake(cfg SnakeConfig) *Snake {
 		interval:     stats.NewHistogram("", "", intervalBucketCutoffs),
 		dropCount:    stats.NewHistogram("", "", lengthBucketCutoffs),
 		timerLag:     stats.NewHistogram("", "", loadshedBucketCutoffs),
+		valveDepth:   stats.NewHistogram("", "", lengthBucketCutoffs),
 	}
 	s.q = newValvedCoDelQueue(cfg.CoDel, defaultClock, s.lockedScheduleDropTimer, s.lockedStopDropTimer)
 	return s
@@ -108,6 +110,10 @@ func NewSnake(cfg SnakeConfig) *Snake {
 func (s *Snake) lockedObserveLengths() {
 	s.queueLen.Add(int64(s.q.lockedLen()))
 	s.droppableLen.Add(int64(s.q.lockedDroppableLen()))
+}
+
+func (s *Snake) lockedObserveValveDepth(valveID string) {
+	s.valveDepth.Add(int64(s.q.lockedValveDepth(valveID)))
 }
 
 func (s *Snake) capacity() int {
@@ -137,6 +143,9 @@ func (s *Snake) Acquire(ctx context.Context, valveID string, priority float64) (
 
 	s.mu.Lock()
 	req := s.q.lockedEnqueue(valveID, priority)
+	if valveID != "" {
+		s.lockedObserveValveDepth(valveID)
+	}
 
 	if s.hasCapacity() && req.codelqElem != nil {
 		s.lockedGrant(req)

--- a/go/vt/vttablet/tabletserver/loadshed/snake_stats.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_stats.go
@@ -80,4 +80,5 @@ func PublishStats(exporter statsExporter, prefix string, s *Snake) {
 	s.interval = exporter.NewHistogram(prefix+"IntervalObservedNs", "Distribution of Snake CoDel control interval in nanoseconds, sampled at each timer fire", intervalBucketCutoffs)
 	s.dropCount = exporter.NewHistogram(prefix+"DropCountObserved", "Distribution of Snake CoDel drop count (control-law state), sampled at each timer fire", lengthBucketCutoffs)
 	s.timerLag = exporter.NewHistogram(prefix+"DropTimerLagNs", "Distribution of how late the Snake CoDel drop timer fired versus its scheduled time, in nanoseconds; high values mean shedding decisions are delayed under CPU contention", loadshedBucketCutoffs)
+	s.valveDepth = exporter.NewHistogram(prefix+"ValveDepthObserved", "Distribution of Snake self-contention valve depth (requests stacked behind one valve's droppable representative), sampled at each valve-keyed enqueue", lengthBucketCutoffs)
 }

--- a/go/vt/vttablet/tabletserver/loadshed/snake_stats_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_stats_test.go
@@ -63,7 +63,7 @@ func TestPublishStats_RegistersCountersAndHistograms(t *testing.T) {
 	for _, name := range []string{"ShedCount", "DroppingNanosTotal"} {
 		assert.Contains(t, exp.counters, "SnakeOltpRead"+name)
 	}
-	for _, name := range []string{"SojournNs", "QueueLenObserved", "DroppableLenObserved", "HolderCountObserved", "IntervalObservedNs", "DropCountObserved", "DropTimerLagNs"} {
+	for _, name := range []string{"SojournNs", "QueueLenObserved", "DroppableLenObserved", "HolderCountObserved", "IntervalObservedNs", "DropCountObserved", "DropTimerLagNs", "ValveDepthObserved"} {
 		assert.Contains(t, exp.histograms, "SnakeOltpRead"+name)
 	}
 }
@@ -84,8 +84,8 @@ func TestPublishStats_PrefixIsolation(t *testing.T) {
 	assert.Contains(t, exp.histograms, "SnakeOltpReadQueueLenObserved")
 	assert.Contains(t, exp.histograms, "SnakeDmlQueueLenObserved")
 	// sojourn + queueLen + droppableLen + holderCount + interval + dropCount +
-	// timerLag, per snake.
-	assert.Len(t, exp.histograms, 14, "expected 7 histograms per snake, two snakes")
+	// timerLag + valveDepth, per snake.
+	assert.Len(t, exp.histograms, 16, "expected 8 histograms per snake, two snakes")
 }
 
 func TestPublishStats_ShedCountTracksDrops(t *testing.T) {
@@ -240,6 +240,57 @@ func TestPublishStats_QueueAndHolderHistogramsRecord(t *testing.T) {
 	require.NoError(t, unlock.Release())
 	assert.Greater(t, queueLen.Count(), beforeQueue, "release should record another queue-length observation")
 	assert.Greater(t, holderCount.Count(), beforeHolder, "release should record another holder-count observation")
+}
+
+func TestPublishStats_ValveDepthHistogramRecords(t *testing.T) {
+	s := newTestSnake(defaultSnakeConfig()) // capacity 1
+	exp := newFakeExporter()
+	PublishStats(exp, "SnakeOltpRead", s)
+
+	valveDepth := exp.histograms["SnakeOltpReadValveDepthObserved"]
+	require.NotNil(t, valveDepth)
+	assert.Equal(t, int64(0), valveDepth.Count(), "no observations before any acquire")
+
+	// Occupy the single slot with an empty-valve acquire. This also covers the
+	// exclusion rule: an empty valve ID bypasses the valve and is not observed.
+	holder, err := s.Acquire(t.Context(), "", 0)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), valveDepth.Count(), "empty valve ID should not record a valve-depth observation")
+
+	// With the slot occupied, a valve-keyed acquire cannot be granted, so it
+	// waits in the CoDel queue as valve "v"'s droppable representative. Its
+	// enqueue records depth 0 (nothing stacked behind it yet). The observation
+	// is synchronous inside Acquire before it blocks, so wait for the count.
+	errCh := make(chan error, 2)
+	go func() {
+		_, err := s.Acquire(t.Context(), "v", 0)
+		errCh <- err
+	}()
+	assert.Eventually(t, func() bool { return valveDepth.Count() == 1 }, 2*time.Second, time.Millisecond,
+		"valve-keyed representative enqueue should record a depth observation")
+	assert.Equal(t, int64(0), valveDepth.Total(), "first valve entry becomes the representative, depth 0")
+
+	// A second acquire on the same valve ID stacks behind the representative
+	// and records depth 1.
+	go func() {
+		_, err := s.Acquire(t.Context(), "v", 0)
+		errCh <- err
+	}()
+	assert.Eventually(t, func() bool { return valveDepth.Count() == 2 }, 2*time.Second, time.Millisecond,
+		"stacked valve entry should record a second depth observation")
+	assert.Equal(t, int64(1), valveDepth.Total(), "second same-valve entry stacks at depth 1")
+
+	// Release the holder so the queued "v" entries drain and the goroutines
+	// return. Whether each is granted or shed by CoDel is irrelevant here — this
+	// is teardown; the depth observations above are the assertions under test.
+	require.NoError(t, holder.Release())
+	for range 2 {
+		select {
+		case <-errCh:
+		case <-time.After(2 * time.Second):
+			t.Fatal("queued goroutine did not return")
+		}
+	}
 }
 
 func TestPublishStats_DroppableAndIntervalHistogramsRecordUnderLoad(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/loadshed/valved_codelq.go
+++ b/go/vt/vttablet/tabletserver/loadshed/valved_codelq.go
@@ -137,6 +137,10 @@ func (q *ValvedCoDelQueue) lockedLen() int {
 	return q.codelq.lockedLen()
 }
 
+func (q *ValvedCoDelQueue) lockedValveDepth(valveID string) int {
+	return len(q.valves[valveID])
+}
+
 // lockedIsHealthy reports whether the CoDel queue is healthy.
 func (q *ValvedCoDelQueue) lockedIsHealthy() bool {
 	return q.codelq.lockedIsHealthy()


### PR DESCRIPTION
### Background / Why?

Snake's self-contention valve serializes a caller's concurrent same-shard queries behind a single droppable CoDel representative; the overflow — everything stacked behind that representative — lives in `q.valves[valveID]` and is deliberately *not* in the CoDel queue. That means the length histograms already emitted (`QueueLenObserved`, `DroppableLenObserved`, `HolderCountObserved`) are structurally blind to valve depth: there is currently no metric of any kind for valve state, so we can't see whether a caller's fan-out is stacking up on one shard.

This records per-valve depth as a histogram, following the same boundary-read pattern as the existing length histograms: at each valve-keyed enqueue in `Acquire`, observe `len(q.valves[valveID])` — `0` when the request becomes the representative, `N` when it stacks `N`-deep behind one. Percentiles then distinguish one pathological deep valve (`P99=50`) from many shallow ones (`P99=1`), which a single scalar can't. Empty valve IDs bypass the valve entirely and are excluded, so structural zeros don't dilute the distribution. Only the rising edge (enqueue) is observed, not valve drain via promotion — consistent with the length histograms, the peak is what a shedder dashboard cares about.

Naming: siblings are `…LenObserved`, but "length" is the ambiguity that made "valve depth" the chosen reading over valve cardinality or total-in-valves, so `ValveDepthObserved` names the semantic precisely. Happy to rename to `ValveLenObserved` if you'd rather match the siblings.

### Testing

new unit tests

### Monitoring

- New histogram `vttablet_snake_<pool>_valve_depth_observed`. `histogram_quantile(0.99, ...)` gives the tail of how deep valves stack; a healthy fleet sits at `P50=0` with a low `P99`. A rising `P99` means a caller is fanning out hard to a single shard — the self-contention the valve exists to absorb. Dashboard panel is a follow-up in `viz/`.
