### PR TITLE
fix: prevent ERS panic when all candidates have errant GTIDs

### DIFF
--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -240,6 +240,9 @@ func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *eve
 		if err != nil {
 			return err
 		}
+		if len(validCandidates) == 0 {
+			return vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "no valid candidates for emergency reparent after errant GTID detection")
+		}
 	}
 
 	// Find the intermediate source for replication that we want other tablets to replicate from.


### PR DESCRIPTION
## Summary
- Fixes a panic (`index out of range [0] with length 0`) in VTOrc DeadPrimary recovery when `findErrantGTIDs` removes all candidates from the valid set.
- Adds an emptiness check after errant GTID detection to return a clear `FAILED_PRECONDITION` error instead of crashing.
- Backport of #903 to slack-22.0.

## Root Cause
`findErrantGTIDs` can filter out every tablet (all have errant GTIDs), but the only emptiness guard was before that step (after `restrictValidCandidates`). The empty map flows into `findMostAdvanced` which converts it to a zero-length slice and panics at `validTablets[0]`.

## Test plan
- [x] Existing `TestEmergencyReparenter` tests pass
- [x] `go build ./go/vt/vtctl/reparentutil/...` compiles cleanly
- [ ] Verify in staging with a shard where all replicas have errant GTIDs - ERS should fail gracefully instead of panicking