### PR TITLE
fix(vdiff): preserve PK definition order in getSourcePKCols

### DIFF
--- a/go/vt/vttablet/tabletmanager/vdiff/source_pk_cols_ordering_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/source_pk_cols_ordering_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vdiff
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/sqltypes"
+
+	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"
+)
+
+// TestSourcePKColsOrdering verifies that getSourcePKCols preserves PK
+// definition order (SEQ_IN_INDEX) rather than column ordinal position.
+//
+// Before the fix, the function put PrimaryKeyColumns into a map (losing order)
+// then scanned td.table.Columns in ORDINAL_POSITION order. This produced
+// sourcePkCols in ordinal order which corrupted lastpk on VDiff resume.
+func TestSourcePKColsOrdering(t *testing.T) {
+	tvde := newTestVDiffEnv(t)
+	defer tvde.close()
+
+	ct := tvde.createController(t, 1)
+
+	testCases := []struct {
+		name              string
+		columns           []string
+		primaryKeyColumns []string
+		wantSourcePkCols  []int
+	}{
+		{
+			name:              "pk_order_differs_from_ordinal",
+			columns:           []string{"a", "b", "c", "d", "e"},
+			primaryKeyColumns: []string{"c", "a"},
+			wantSourcePkCols:  []int{2, 0},
+		},
+		{
+			name:              "three_col_pk_not_in_ordinal_order",
+			columns:           []string{"a", "b", "c", "d", "e", "f"},
+			primaryKeyColumns: []string{"b", "d", "a"},
+			wantSourcePkCols:  []int{1, 3, 0},
+		},
+		{
+			name:              "two_col_pk_reversed",
+			columns:           []string{"a", "b", "c"},
+			primaryKeyColumns: []string{"b", "a"},
+			wantSourcePkCols:  []int{1, 0},
+		},
+		{
+			name:              "pk_matches_ordinal",
+			columns:           []string{"a", "b", "c"},
+			primaryKeyColumns: []string{"a", "b"},
+			wantSourcePkCols:  []int{0, 1},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fieldTypes := ""
+			for i := range tc.columns {
+				if i > 0 {
+					fieldTypes += "|"
+				}
+				fieldTypes += "varbinary"
+			}
+
+			fields := ""
+			for i, col := range tc.columns {
+				if i > 0 {
+					fields += "|"
+				}
+				fields += col
+			}
+
+			table := &tabletmanagerdatapb.TableDefinition{
+				Name:              tc.name,
+				Columns:           tc.columns,
+				PrimaryKeyColumns: tc.primaryKeyColumns,
+				Fields:            sqltypes.MakeTestFields(fields, fieldTypes),
+			}
+
+			tvde.tmc.schema = &tabletmanagerdatapb.SchemaDefinition{
+				TableDefinitions: []*tabletmanagerdatapb.TableDefinition{table},
+			}
+
+			td := &tableDiffer{
+				wd: &workflowDiffer{
+					ct: ct,
+				},
+				table: table,
+				tablePlan: &tablePlan{
+					table: table,
+				},
+			}
+
+			err := td.getSourcePKCols()
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.wantSourcePkCols, td.tablePlan.sourcePkCols,
+				"sourcePkCols should reflect PK definition order (SEQ_IN_INDEX), not column ordinal position")
+		})
+	}
+}

--- a/go/vt/vttablet/tabletmanager/vdiff/table_differ.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/table_differ.go
@@ -984,14 +984,14 @@ func (td *tableDiffer) getSourcePKCols() error {
 		}
 	}
 
-	sourcePKColumns := make(map[string]struct{}, len(sourceTable.PrimaryKeyColumns))
+	colIndex := make(map[string]int, len(td.table.Columns))
+	for i, col := range td.table.Columns {
+		colIndex[col] = i
+	}
 	td.tablePlan.sourcePkCols = make([]int, 0, len(sourceTable.PrimaryKeyColumns))
 	for _, pkc := range sourceTable.PrimaryKeyColumns {
-		sourcePKColumns[pkc] = struct{}{}
-	}
-	for i, pkc := range td.table.Columns {
-		if _, ok := sourcePKColumns[pkc]; ok {
-			td.tablePlan.sourcePkCols = append(td.tablePlan.sourcePkCols, i)
+		if idx, ok := colIndex[pkc]; ok {
+			td.tablePlan.sourcePkCols = append(td.tablePlan.sourcePkCols, idx)
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Fix `getSourcePKCols` to preserve PK definition order (SEQ_IN_INDEX) instead of column ordinal position
- The bug causes false VDiff mismatches (ExtraRowsSource/ExtraRowsTarget) on resume when PK column order differs from ordinal position
- Add regression test covering 4 PK ordering scenarios

## Root Cause

`getSourcePKCols` put `PrimaryKeyColumns` into a `map[string]struct{}` (losing order), then iterated `td.table.Columns` in `ORDINAL_POSITION` order. On VDiff resume, `VStreamRows` receives the wrongly-ordered `lastpk` values and the row streamer pairs them positionally with its own `pkColumns` (which ARE in correct SEQ_IN_INDEX order from `BaseShowPrimary`). This corrupts the WHERE clause.

## Fix

Replace the map+ordinal-scan with a column index lookup that preserves PK definition order.

## Impact

Only affects tables where PK column order differs from column ordinal position AND VDiff resumes (via `max-diff-duration` timeout, auto-retry, or manual resume). Single uninterrupted VDiff passes are unaffected.

## Test Plan

- [x] `TestSourcePKColsOrdering` regression test with 4 cases
- [ ] CI passes

## References

- Upstream PR: https://github.com/vitessio/vitess/pull/20603
- Upstream issue: https://github.com/vitessio/vitess/issues/20601