### PR TITLE
backport: Allow skipping MySQL version check when restoring from a mysql-shell backup (#20521)

### DIFF
--- a/go/flags/endtoend/vtbackup.txt
+++ b/go/flags/endtoend/vtbackup.txt
@@ -191,6 +191,7 @@ Flags:
       --mysql-shell-dump-flags string                               flags to pass to mysql shell dump utility. This should be a JSON string and will be saved in the MANIFEST (default "{\"threads\": 4}")
       --mysql-shell-flags string                                    execution flags to pass to mysqlsh binary to be used during dump/load (default "--defaults-file=/dev/null --js -h localhost")
       --mysql-shell-load-flags string                               flags to pass to mysql shell load utility. This should be a JSON string (default "{\"threads\": 4, \"loadUsers\": true, \"updateGtidSet\": \"replace\", \"skipBinlog\": true, \"progressFile\": \"\"}")
+      --mysql-shell-restore-skip-version-check                      skip the MySQL version compatibility check when restoring from a mysql-shell backup
       --mysql-shell-should-drain                                    decide if we should drain while taking a backup or continue to serving traffic
       --mysql-shell-speedup-restore                                 speed up restore by disabling redo logging and double write buffer during the restore process
       --mysql-shutdown-timeout duration                             how long to wait for mysqld shutdown (default 5m0s)

--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -234,6 +234,7 @@ Flags:
       --mysql-shell-dump-flags string                                    flags to pass to mysql shell dump utility. This should be a JSON string and will be saved in the MANIFEST (default "{\"threads\": 4}")
       --mysql-shell-flags string                                         execution flags to pass to mysqlsh binary to be used during dump/load (default "--defaults-file=/dev/null --js -h localhost")
       --mysql-shell-load-flags string                                    flags to pass to mysql shell load utility. This should be a JSON string (default "{\"threads\": 4, \"loadUsers\": true, \"updateGtidSet\": \"replace\", \"skipBinlog\": true, \"progressFile\": \"\"}")
+      --mysql-shell-restore-skip-version-check                           skip the MySQL version compatibility check when restoring from a mysql-shell backup
       --mysql-shell-should-drain                                         decide if we should drain while taking a backup or continue to serving traffic
       --mysql-shell-speedup-restore                                      speed up restore by disabling redo logging and double write buffer during the restore process
       --mysql-shutdown-timeout duration                                  Timeout to use when MySQL is being shut down. (default 5m0s)

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -253,6 +253,7 @@ Flags:
       --mysql-shell-dump-flags string                                    flags to pass to mysql shell dump utility. This should be a JSON string and will be saved in the MANIFEST (default "{\"threads\": 4}")
       --mysql-shell-flags string                                         execution flags to pass to mysqlsh binary to be used during dump/load (default "--defaults-file=/dev/null --js -h localhost")
       --mysql-shell-load-flags string                                    flags to pass to mysql shell load utility. This should be a JSON string (default "{\"threads\": 4, \"loadUsers\": true, \"updateGtidSet\": \"replace\", \"skipBinlog\": true, \"progressFile\": \"\"}")
+      --mysql-shell-restore-skip-version-check                           skip the MySQL version compatibility check when restoring from a mysql-shell backup
       --mysql-shell-should-drain                                         decide if we should drain while taking a backup or continue to serving traffic
       --mysql-shell-speedup-restore                                      speed up restore by disabling redo logging and double write buffer during the restore process
       --mysql-shutdown-timeout duration                                  Timeout to use when MySQL is being shut down. (default 5m0s)

--- a/go/flags/endtoend/vttestserver.txt
+++ b/go/flags/endtoend/vttestserver.txt
@@ -98,6 +98,7 @@ Flags:
       --mysql-shell-dump-flags string                                    flags to pass to mysql shell dump utility. This should be a JSON string and will be saved in the MANIFEST (default "{\"threads\": 4}")
       --mysql-shell-flags string                                         execution flags to pass to mysqlsh binary to be used during dump/load (default "--defaults-file=/dev/null --js -h localhost")
       --mysql-shell-load-flags string                                    flags to pass to mysql shell load utility. This should be a JSON string (default "{\"threads\": 4, \"loadUsers\": true, \"updateGtidSet\": \"replace\", \"skipBinlog\": true, \"progressFile\": \"\"}")
+      --mysql-shell-restore-skip-version-check                           skip the MySQL version compatibility check when restoring from a mysql-shell backup
       --mysql-shell-should-drain                                         decide if we should drain while taking a backup or continue to serving traffic
       --mysql-shell-speedup-restore                                      speed up restore by disabling redo logging and double write buffer during the restore process
       --mysql_bind_host string                                           which host to bind vtgate mysql listener to (default "localhost")

--- a/go/vt/mysqlctl/backup_test.go
+++ b/go/vt/mysqlctl/backup_test.go
@@ -529,6 +529,88 @@ func TestRestoreManifestMySQLVersionValidation(t *testing.T) {
 
 }
 
+// TestFindBackupToRestoreSkipVersionCheck tests that FindBackupToRestore skips
+// the MySQL version compatibility check exactly when the engine that created the
+// backup reports ShouldSkipVersionCheck() == true.
+func TestFindBackupToRestoreSkipVersionCheck(t *testing.T) {
+	// 8.4.10 -> 8.0.36 is a downgrade, which is never version-compatible.
+	const (
+		backupVersion  = "mysqld  Ver 8.4.10"
+		restoreVersion = "mysqld  Ver 8.0.36"
+	)
+
+	testCases := []struct {
+		name string
+		// engineSkips is the value the backup's engine returns from
+		// ShouldSkipVersionCheck().
+		engineSkips bool
+		wantBackup  bool
+	}{
+		{
+			name:        "engine skips version check",
+			engineSkips: true,
+			wantBackup:  true,
+		},
+		{
+			name:        "engine enforces version check",
+			engineSkips: false,
+			wantBackup:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := createFakeBackupRestoreEnv(t)
+			env.mysqld.Version = restoreVersion
+			env.backupEngine.ShouldSkipVersionCheckReturn = tc.engineSkips
+			// look at all backups, regardless of when they were taken.
+			env.restoreParams.StartTime = time.Time{}
+
+			manifest := BackupManifest{
+				BackupTime:   FormatRFC3339(time.Now().Add(-1 * time.Hour)),
+				BackupMethod: fakeBackupEngineName,
+				Keyspace:     "test",
+				Shard:        "-",
+				MySQLVersion: backupVersion,
+				UpgradeSafe:  false,
+			}
+			manifestBytes, err := json.Marshal(manifest)
+			require.NoError(t, err)
+
+			bhs := []backupstorage.BackupHandle{
+				&FakeBackupHandle{
+					ReadFileReturnF: func(context.Context, string) (io.ReadCloser, error) {
+						return io.NopCloser(bytes.NewBuffer(manifestBytes)), nil
+					},
+				},
+			}
+
+			restorePath, err := FindBackupToRestore(env.ctx, env.restoreParams, bhs)
+			if tc.wantBackup {
+				require.NoError(t, err)
+				require.False(t, restorePath.IsEmpty())
+			} else {
+				require.ErrorIs(t, err, ErrNoCompleteBackup)
+			}
+		})
+	}
+}
+
+// TestMySQLShellEngineShouldSkipVersionCheck verifies that the mysql-shell engine
+// wires ShouldSkipVersionCheck() to the --mysql-shell-restore-skip-version-check flag.
+func TestMySQLShellEngineShouldSkipVersionCheck(t *testing.T) {
+	originalSkip := mysqlShellRestoreSkipVersionCheck
+	t.Cleanup(func() { mysqlShellRestoreSkipVersionCheck = originalSkip })
+
+	be := &MySQLShellBackupEngine{}
+
+	mysqlShellRestoreSkipVersionCheck = true
+	require.True(t, be.ShouldSkipVersionCheck())
+
+	mysqlShellRestoreSkipVersionCheck = false
+	require.False(t, be.ShouldSkipVersionCheck())
+}
+
 type forTest []FileEntry
 
 func (f forTest) Len() int           { return len(f) }

--- a/go/vt/mysqlctl/backupengine.go
+++ b/go/vt/mysqlctl/backupengine.go
@@ -189,6 +189,13 @@ type RestoreEngine interface {
 	ShouldStartMySQLAfterRestore() bool
 }
 
+// versionCheckSkipper is an optional interface a RestoreEngine may implement to
+// opt out of the MySQL version compatibility check when restoring its backups.
+// Engines that don't implement it are treated as requiring the check.
+type versionCheckSkipper interface {
+	ShouldSkipVersionCheck() bool
+}
+
 // BackupRestoreEngine is a combination of BackupEngine and RestoreEngine.
 type BackupRestoreEngine interface {
 	BackupEngine
@@ -566,8 +573,18 @@ func FindBackupToRestore(ctx context.Context, params RestoreParams, bhs []backup
 				}
 				bh := manifestHandleMap.Handle(bm)
 
-				// check if the backup can be used with this MySQL version.
-				if bm.MySQLVersion != "" {
+				// check if the backup can be used with this MySQL version, unless
+				// the engine that created the backup opts out of the version check.
+				engineName := bm.BackupMethod
+				if engineName == "" {
+					// The builtin engine is the only one that ever left BackupMethod unset.
+					engineName = builtinBackupEngineName
+				}
+				skipVersionCheck := false
+				if skipper, ok := BackupRestoreEngineMap[engineName].(versionCheckSkipper); ok {
+					skipVersionCheck = skipper.ShouldSkipVersionCheck()
+				}
+				if bm.MySQLVersion != "" && !skipVersionCheck {
 					if err := validateMySQLVersionUpgradeCompatible(mysqlVersion, bm.MySQLVersion, bm.UpgradeSafe); err != nil {
 						params.Logger.Warningf("Skipping backup %v/%v with incompatible MySQL version %v (upgrade safe: %v): %v", backupDir, bh.Name(), bm.MySQLVersion, bm.UpgradeSafe, err)
 						continue

--- a/go/vt/mysqlctl/fakebackupengine.go
+++ b/go/vt/mysqlctl/fakebackupengine.go
@@ -27,14 +27,15 @@ import (
 const fakeBackupEngineName = "fake"
 
 type FakeBackupEngine struct {
-	ExecuteBackupCalls         []FakeBackupEngineExecuteBackupCall
-	ExecuteBackupDuration      time.Duration
-	ExecuteBackupReturn        FakeBackupEngineExecuteBackupReturn
-	ExecuteRestoreCalls        []FakeBackupEngineExecuteRestoreCall
-	ExecuteRestoreDuration     time.Duration
-	ExecuteRestoreReturn       FakeBackupEngineExecuteRestoreReturn
-	ShouldDrainForBackupCalls  int
-	ShouldDrainForBackupReturn bool
+	ExecuteBackupCalls           []FakeBackupEngineExecuteBackupCall
+	ExecuteBackupDuration        time.Duration
+	ExecuteBackupReturn          FakeBackupEngineExecuteBackupReturn
+	ExecuteRestoreCalls          []FakeBackupEngineExecuteRestoreCall
+	ExecuteRestoreDuration       time.Duration
+	ExecuteRestoreReturn         FakeBackupEngineExecuteRestoreReturn
+	ShouldDrainForBackupCalls    int
+	ShouldDrainForBackupReturn   bool
+	ShouldSkipVersionCheckReturn bool
 }
 
 type FakeBackupEngineExecuteBackupCall struct {
@@ -98,4 +99,8 @@ func (be *FakeBackupEngine) Name() string { return fakeBackupEngineName }
 
 func (be *FakeBackupEngine) ShouldStartMySQLAfterRestore() bool {
 	return true
+}
+
+func (be *FakeBackupEngine) ShouldSkipVersionCheck() bool {
+	return be.ShouldSkipVersionCheckReturn
 }

--- a/go/vt/mysqlctl/mysqlshellbackupengine.go
+++ b/go/vt/mysqlctl/mysqlshellbackupengine.go
@@ -61,6 +61,8 @@ var (
 	mysqlShellBackupShouldDrain = false
 	// disable redo logging and double write buffer
 	mysqlShellSpeedUpRestore = false
+	// skip the MySQL version compatibility check when restoring from a mysql-shell backup
+	mysqlShellRestoreSkipVersionCheck = false
 
 	// use when checking if we need to create the directory on the local filesystem or not.
 	knownObjectStoreParams = []string{"s3BucketName", "osBucketName", "azureContainerName"}
@@ -107,6 +109,7 @@ func registerMysqlShellBackupEngineFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&mysqlShellLoadFlags, "mysql-shell-load-flags", mysqlShellLoadFlags, "flags to pass to mysql shell load utility. This should be a JSON string")
 	fs.BoolVar(&mysqlShellBackupShouldDrain, "mysql-shell-should-drain", mysqlShellBackupShouldDrain, "decide if we should drain while taking a backup or continue to serving traffic")
 	fs.BoolVar(&mysqlShellSpeedUpRestore, "mysql-shell-speedup-restore", mysqlShellSpeedUpRestore, "speed up restore by disabling redo logging and double write buffer during the restore process")
+	fs.BoolVar(&mysqlShellRestoreSkipVersionCheck, "mysql-shell-restore-skip-version-check", mysqlShellRestoreSkipVersionCheck, "skip the MySQL version compatibility check when restoring from a mysql-shell backup")
 }
 
 // MySQLShellBackupEngine encapsulates the logic to implement the restoration
@@ -437,6 +440,15 @@ func (be *MySQLShellBackupEngine) ShouldDrainForBackup(req *tabletmanagerdatapb.
 // Since MySQL Shell operates on a live MySQL instance, there is no need to start it once the restore is completed
 func (be *MySQLShellBackupEngine) ShouldStartMySQLAfterRestore() bool {
 	return false
+}
+
+// ShouldSkipVersionCheck returns whether the MySQL version compatibility check
+// should be skipped when restoring a mysql-shell backup. Because mysql-shell
+// performs a logical restore, its backups are not tied to the on-disk data
+// dictionary format the way physical backups are, so operators can opt out of
+// the version check via --mysql-shell-restore-skip-version-check.
+func (be *MySQLShellBackupEngine) ShouldSkipVersionCheck() bool {
+	return mysqlShellRestoreSkipVersionCheck
 }
 
 func (be *MySQLShellBackupEngine) Name() string { return mysqlShellBackupEngineName }


### PR DESCRIPTION
## What's this?

Backport of upstream [vitessio/vitess#20521](https://github.com/vitessio/vitess/pull/20521) onto `slack-22.0`.

Adds a new `--mysql-shell-restore-skip-version-check` flag (default `false`) to VTTablet and VTBackup. When enabled, the MySQL version compatibility check that normally gates restores is skipped — but **only** for backups taken with the `mysqlshell` engine. Backups from other engines still go through the usual version check regardless of this flag.

## How it works

- New optional `versionCheckSkipper` interface in `backupengine.go`. `FindBackupToRestore` type-asserts the backup's engine against it; engines that don't implement it are treated as requiring the check (backward compatible).
- `MySQLShellBackupEngine.ShouldSkipVersionCheck()` wires the behavior to the new flag.
- Because mysql-shell does a logical restore, its backups aren't tied to the on-disk data dictionary format the way physical backups are, so restoring across otherwise-incompatible MySQL versions can be safe.

## Backport notes

- Code across all 8 files cherry-picked cleanly.
- The only conflict was `changelog/25.0/25.0.0/summary.md` — that changelog directory doesn't exist on this fork's `slack-22.0` branch, so it was dropped (consistent with prior backports #899 and #874).
- Verified: `go build ./go/vt/mysqlctl/` passes; new tests `TestFindBackupToRestoreSkipVersionCheck` and `TestMySQLShellEngineShouldSkipVersionCheck` pass.

## Testing
Deployed from branch to `dev` `loadtest/80-`, then built a tablet there with the flag enabled & verified restoring worked as expected. See details of testing on internal chef PR #159464

---
_Backport cherry-picked and verified by Claude Code - I just provided direction._