### PR TITLE
Extend `querythrottler` with lifetime-scoped admission control

### DIFF
--- a/go/vt/proto/query/query.pb.go
+++ b/go/vt/proto/query/query.pb.go
@@ -1410,11 +1410,7 @@ type ExecuteOptions struct {
 	// currently honored by StreamExecute. This is useful for warming reads
 	// where the goal is to warm the buffer pool, not to retrieve data.
 	NoResult bool `protobuf:"varint,21,opt,name=no_result,json=noResult,proto3" json:"no_result,omitempty"`
-	// app_execution_context_id identifies the logical request or job that issued
-	// this query. An admission-control strategy may use it to detect fan-out from
-	// a single caller (e.g., an async helper issuing N queries against the same
-	// shard) and apply per-context fairness. When empty, admission control still
-	// applies but without the per-context grouping.
+	// app_execution_context_id identifies the logical request or job that issued this query.
 	AppExecutionContextId string `protobuf:"bytes,22,opt,name=app_execution_context_id,json=appExecutionContextId,proto3" json:"app_execution_context_id,omitempty"`
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache

--- a/go/vt/proto/query/query.pb.go
+++ b/go/vt/proto/query/query.pb.go
@@ -1409,9 +1409,15 @@ type ExecuteOptions struct {
 	// but will not return rows or fields in the response. This flag is not
 	// currently honored by StreamExecute. This is useful for warming reads
 	// where the goal is to warm the buffer pool, not to retrieve data.
-	NoResult      bool `protobuf:"varint,21,opt,name=no_result,json=noResult,proto3" json:"no_result,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	NoResult bool `protobuf:"varint,21,opt,name=no_result,json=noResult,proto3" json:"no_result,omitempty"`
+	// app_execution_context_id identifies the logical request or job that issued
+	// this query. An admission-control strategy may use it to detect fan-out from
+	// a single caller (e.g., an async helper issuing N queries against the same
+	// shard) and apply per-context fairness. When empty, admission control still
+	// applies but without the per-context grouping.
+	AppExecutionContextId string `protobuf:"bytes,22,opt,name=app_execution_context_id,json=appExecutionContextId,proto3" json:"app_execution_context_id,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *ExecuteOptions) Reset() {
@@ -1570,6 +1576,13 @@ func (x *ExecuteOptions) GetNoResult() bool {
 		return x.NoResult
 	}
 	return false
+}
+
+func (x *ExecuteOptions) GetAppExecutionContextId() string {
+	if x != nil {
+		return x.AppExecutionContextId
+	}
+	return ""
 }
 
 type isExecuteOptions_Timeout interface {
@@ -5839,7 +5852,7 @@ const file_query_proto_rawDesc = "" +
 	"\x0ebind_variables\x18\x02 \x03(\v2$.query.BoundQuery.BindVariablesEntryR\rbindVariables\x1aU\n" +
 	"\x12BindVariablesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12)\n" +
-	"\x05value\x18\x02 \x01(\v2\x13.query.BindVariableR\x05value:\x028\x01\"\xa0\r\n" +
+	"\x05value\x18\x02 \x01(\v2\x13.query.BindVariableR\x05value:\x028\x01\"\xd9\r\n" +
 	"\x0eExecuteOptions\x12M\n" +
 	"\x0fincluded_fields\x18\x04 \x01(\x0e2$.query.ExecuteOptions.IncludedFieldsR\x0eincludedFields\x12*\n" +
 	"\x11client_found_rows\x18\x05 \x01(\bR\x0fclientFoundRows\x12:\n" +
@@ -5858,7 +5871,8 @@ const file_query_proto_rawDesc = "" +
 	"\x14fetch_last_insert_id\x18\x12 \x01(\bR\x11fetchLastInsertId\x12(\n" +
 	"\x10in_dml_execution\x18\x13 \x01(\bR\x0einDmlExecution\x124\n" +
 	"\x13transaction_timeout\x18\x14 \x01(\x03H\x01R\x12transactionTimeout\x88\x01\x01\x12\x1b\n" +
-	"\tno_result\x18\x15 \x01(\bR\bnoResult\";\n" +
+	"\tno_result\x18\x15 \x01(\bR\bnoResult\x127\n" +
+	"\x18app_execution_context_id\x18\x16 \x01(\tR\x15appExecutionContextId\";\n" +
 	"\x0eIncludedFields\x12\x11\n" +
 	"\rTYPE_AND_NAME\x10\x00\x12\r\n" +
 	"\tTYPE_ONLY\x10\x01\x12\a\n" +

--- a/go/vt/proto/query/query_vtproto.pb.go
+++ b/go/vt/proto/query/query_vtproto.pb.go
@@ -179,6 +179,7 @@ func (m *ExecuteOptions) CloneVT() *ExecuteOptions {
 	r.FetchLastInsertId = m.FetchLastInsertId
 	r.InDmlExecution = m.InDmlExecution
 	r.NoResult = m.NoResult
+	r.AppExecutionContextId = m.AppExecutionContextId
 	if rhs := m.TransactionAccessMode; rhs != nil {
 		tmpContainer := make([]ExecuteOptions_TransactionAccessMode, len(rhs))
 		copy(tmpContainer, rhs)
@@ -1900,6 +1901,15 @@ func (m *ExecuteOptions) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 			return 0, err
 		}
 		i -= size
+	}
+	if len(m.AppExecutionContextId) > 0 {
+		i -= len(m.AppExecutionContextId)
+		copy(dAtA[i:], m.AppExecutionContextId)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.AppExecutionContextId)))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xb2
 	}
 	if m.NoResult {
 		i--
@@ -6242,6 +6252,10 @@ func (m *ExecuteOptions) SizeVT() (n int) {
 	if m.NoResult {
 		n += 3
 	}
+	l = len(m.AppExecutionContextId)
+	if l > 0 {
+		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -9070,6 +9084,38 @@ func (m *ExecuteOptions) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.NoResult = bool(v != 0)
+		case 22:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AppExecutionContextId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.AppExecutionContextId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/go/vt/proto/querythrottler/querythrottler.pb.go
+++ b/go/vt/proto/querythrottler/querythrottler.pb.go
@@ -25,8 +25,9 @@ const (
 type ThrottlingStrategy int32
 
 const (
-	ThrottlingStrategy_UNKNOWN          ThrottlingStrategy = 0
-	ThrottlingStrategy_TABLET_THROTTLER ThrottlingStrategy = 1
+	ThrottlingStrategy_UNKNOWN           ThrottlingStrategy = 0
+	ThrottlingStrategy_TABLET_THROTTLER  ThrottlingStrategy = 1
+	ThrottlingStrategy_ADMISSION_CONTROL ThrottlingStrategy = 2
 )
 
 // Enum value maps for ThrottlingStrategy.
@@ -34,10 +35,12 @@ var (
 	ThrottlingStrategy_name = map[int32]string{
 		0: "UNKNOWN",
 		1: "TABLET_THROTTLER",
+		2: "ADMISSION_CONTROL",
 	}
 	ThrottlingStrategy_value = map[string]int32{
-		"UNKNOWN":          0,
-		"TABLET_THROTTLER": 1,
+		"UNKNOWN":           0,
+		"TABLET_THROTTLER":  1,
+		"ADMISSION_CONTROL": 2,
 	}
 )
 
@@ -402,10 +405,11 @@ const file_querythrottler_proto_rawDesc = "" +
 	"thresholds\"E\n" +
 	"\x11ThrottleThreshold\x12\x14\n" +
 	"\x05above\x18\x01 \x01(\x01R\x05above\x12\x1a\n" +
-	"\bthrottle\x18\x02 \x01(\x05R\bthrottle*7\n" +
+	"\bthrottle\x18\x02 \x01(\x05R\bthrottle*N\n" +
 	"\x12ThrottlingStrategy\x12\v\n" +
 	"\aUNKNOWN\x10\x00\x12\x14\n" +
-	"\x10TABLET_THROTTLER\x10\x01B-Z+vitess.io/vitess/go/vt/proto/querythrottlerb\x06proto3"
+	"\x10TABLET_THROTTLER\x10\x01\x12\x15\n" +
+	"\x11ADMISSION_CONTROL\x10\x02B-Z+vitess.io/vitess/go/vt/proto/querythrottlerb\x06proto3"
 
 var (
 	file_querythrottler_proto_rawDescOnce sync.Once

--- a/go/vt/sqlparser/cached_size.go
+++ b/go/vt/sqlparser/cached_size.go
@@ -3963,7 +3963,7 @@ func (cached *QueryHints) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(64)
+		size += int64(80)
 	}
 	// field Workload string
 	size += hack.RuntimeAllocSize(int64(len(cached.Workload)))
@@ -3973,6 +3973,8 @@ func (cached *QueryHints) CachedSize(alloc bool) int64 {
 	}
 	// field Priority string
 	size += hack.RuntimeAllocSize(int64(len(cached.Priority)))
+	// field AppExecutionContextID string
+	size += hack.RuntimeAllocSize(int64(len(cached.AppExecutionContextID)))
 	// field Timeout *int
 	if cached.Timeout != nil {
 		size += hack.RuntimeAllocSize(int64(8))

--- a/go/vt/sqlparser/comments.go
+++ b/go/vt/sqlparser/comments.go
@@ -62,6 +62,10 @@ const (
 	// DirectivePriority specifies the priority of a workload. It should be an integer between 0 and MaxPriorityValue,
 	// where 0 is the highest priority, and MaxPriorityValue is the lowest one.
 	DirectivePriority = "PRIORITY"
+	// DirectiveAppExecutionContextID identifies the logical caller (request, job, etc.) issuing the query, so a
+	// vttablet admission-control strategy can treat one caller's fan-out to a single shard as self-contention
+	// rather than independent load.
+	DirectiveAppExecutionContextID = "APP_EXECUTION_CONTEXT_ID"
 
 	// MaxPriorityValue specifies the maximum value allowed for the priority query directive. Valid priority values are
 	// between zero and MaxPriorityValue.
@@ -590,12 +594,13 @@ func checkDirective(stmt Statement, key string) bool {
 }
 
 type QueryHints struct {
-	IgnoreMaxMemoryRows bool
-	Consolidator        querypb.ExecuteOptions_Consolidator
-	Workload            string
-	ForeignKeyChecks    *bool
-	Priority            string
-	Timeout             *int
+	IgnoreMaxMemoryRows   bool
+	Consolidator          querypb.ExecuteOptions_Consolidator
+	Workload              string
+	ForeignKeyChecks      *bool
+	Priority              string
+	AppExecutionContextID string
+	Timeout               *int
 }
 
 func BuildQueryHints(stmt Statement) (qh QueryHints, err error) {
@@ -615,6 +620,7 @@ func BuildQueryHints(stmt Statement) (qh QueryHints, err error) {
 	qh.IgnoreMaxMemoryRows = directives.IsSet(DirectiveIgnoreMaxMemoryRows)
 	qh.Consolidator = getConsolidator(stmt, directives)
 	qh.Workload = getWorkload(directives)
+	qh.AppExecutionContextID = getAppExecutionContextID(directives)
 	qh.ForeignKeyChecks = getForeignKeyChecksState(comment)
 	qh.Timeout = getQueryTimeout(directives)
 
@@ -641,6 +647,11 @@ func getConsolidator(stmt Statement, directives *CommentDirectives) querypb.Exec
 func getWorkload(directives *CommentDirectives) string {
 	workloadName, _ := directives.GetString(DirectiveWorkloadName, "")
 	return workloadName
+}
+
+func getAppExecutionContextID(directives *CommentDirectives) string {
+	contextID, _ := directives.GetString(DirectiveAppExecutionContextID, "")
+	return contextID
 }
 
 // getForeignKeyChecksState returns the state of foreign_key_checks variable if it is part of a SET_VAR optimizer hint in the comments.

--- a/go/vt/sqlparser/comments.go
+++ b/go/vt/sqlparser/comments.go
@@ -62,9 +62,7 @@ const (
 	// DirectivePriority specifies the priority of a workload. It should be an integer between 0 and MaxPriorityValue,
 	// where 0 is the highest priority, and MaxPriorityValue is the lowest one.
 	DirectivePriority = "PRIORITY"
-	// DirectiveAppExecutionContextID identifies the logical caller (request, job, etc.) issuing the query, so a
-	// vttablet admission-control strategy can treat one caller's fan-out to a single shard as self-contention
-	// rather than independent load.
+	// DirectiveAppExecutionContextID identifies the logical caller (request, job, etc.) issuing the query.
 	DirectiveAppExecutionContextID = "APP_EXECUTION_CONTEXT_ID"
 
 	// MaxPriorityValue specifies the maximum value allowed for the priority query directive. Valid priority values are

--- a/go/vt/sqlparser/comments_test.go
+++ b/go/vt/sqlparser/comments_test.go
@@ -709,3 +709,28 @@ func TestQueryTimeout(t *testing.T) {
 		})
 	}
 }
+
+// TestAppExecutionContextID tests the extraction of APP_EXECUTION_CONTEXT_ID from the comments.
+func TestAppExecutionContextID(t *testing.T) {
+	testCases := []struct {
+		query      string
+		expectedID string
+	}{{
+		query:      "select * from a_table",
+		expectedID: "",
+	}, {
+		query:      "select /*vt+ APP_EXECUTION_CONTEXT_ID=req123 */ * from another_table",
+		expectedID: "req123",
+	}}
+
+	parser := NewTestParser()
+	for _, tc := range testCases {
+		t.Run(tc.query, func(t *testing.T) {
+			stmt, err := parser.Parse(tc.query)
+			assert.NoError(t, err)
+			qh, err := BuildQueryHints(stmt)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedID, qh.AppExecutionContextID)
+		})
+	}
+}

--- a/go/vt/vtgate/engine/cached_size.go
+++ b/go/vt/vtgate/engine/cached_size.go
@@ -827,7 +827,7 @@ func (cached *Plan) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(224)
+		size += int64(240)
 	}
 	// field Original string
 	size += hack.RuntimeAllocSize(int64(len(cached.Original)))

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -1242,6 +1242,7 @@ func (e *Executor) applyQueryHints(vcursor *econtext.VCursorImpl, plan *engine.P
 	vcursor.SetConsolidator(qh.Consolidator)
 	vcursor.SetWorkloadName(qh.Workload)
 	vcursor.SetPriority(qh.Priority)
+	vcursor.SetAppExecutionContextID(qh.AppExecutionContextID)
 	vcursor.SetExecQueryTimeout(qh.Timeout)
 }
 

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -1798,6 +1798,36 @@ func TestGetPlanPriority(t *testing.T) {
 	}
 }
 
+func TestGetPlanAppExecutionContextID(t *testing.T) {
+	testCases := []struct {
+		name              string
+		sql               string
+		expectedContextID string
+	}{
+		{name: "context ID set", sql: "select /*vt+ APP_EXECUTION_CONTEXT_ID=req123 */ * from music_user_map", expectedContextID: "req123"},
+		{name: "no context ID", sql: "select * from music_user_map", expectedContextID: ""},
+	}
+
+	// A single session is reused across cases so we also cover the clear-on-empty
+	// path: a query without the directive must not inherit the prior query's context ID.
+	session := econtext.NewSafeSession(&vtgatepb.Session{TargetString: "@unknown", Options: &querypb.ExecuteOptions{}})
+
+	for _, aTestCase := range testCases {
+		testCase := aTestCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			r, _, _, _, ctx := createExecutorEnvWithConfig(t, createExecutorConfigWithNormalizer())
+
+			logStats := logstats.NewLogStats(ctx, "Test", "", "", nil, streamlog.NewQueryLogConfigForTest())
+
+			plan, _, _, err := r.fetchOrCreatePlan(context.Background(), session, testCase.sql, map[string]*querypb.BindVariable{}, r.config.Normalize, false, logStats, true)
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.expectedContextID, plan.QueryHints.AppExecutionContextID)
+			assert.Equal(t, testCase.expectedContextID, session.Options.AppExecutionContextId)
+		})
+	}
+}
+
 func TestPassthroughDDL(t *testing.T) {
 	executor, sbc1, sbc2, _, ctx := createExecutorEnvWithConfig(t, createExecutorConfigWithNormalizer())
 	session := &vtgatepb.Session{

--- a/go/vt/vtgate/executorcontext/vcursor_impl.go
+++ b/go/vt/vtgate/executorcontext/vcursor_impl.go
@@ -1252,11 +1252,7 @@ func (vc *VCursorImpl) SetPriority(priority string) {
 }
 
 func (vc *VCursorImpl) SetAppExecutionContextID(contextID string) {
-	if contextID != "" {
-		vc.SafeSession.GetOrCreateOptions().AppExecutionContextId = contextID
-	} else if vc.SafeSession.Options != nil && vc.SafeSession.Options.AppExecutionContextId != "" {
-		vc.SafeSession.Options.AppExecutionContextId = ""
-	}
+	vc.SafeSession.GetOrCreateOptions().AppExecutionContextId = contextID
 }
 
 func (vc *VCursorImpl) SetExecQueryTimeout(timeout *int) {

--- a/go/vt/vtgate/executorcontext/vcursor_impl.go
+++ b/go/vt/vtgate/executorcontext/vcursor_impl.go
@@ -1251,6 +1251,14 @@ func (vc *VCursorImpl) SetPriority(priority string) {
 	}
 }
 
+func (vc *VCursorImpl) SetAppExecutionContextID(contextID string) {
+	if contextID != "" {
+		vc.SafeSession.GetOrCreateOptions().AppExecutionContextId = contextID
+	} else if vc.SafeSession.Options != nil && vc.SafeSession.Options.AppExecutionContextId != "" {
+		vc.SafeSession.Options.AppExecutionContextId = ""
+	}
+}
+
 func (vc *VCursorImpl) SetExecQueryTimeout(timeout *int) {
 	// Determine the effective timeout: use passed timeout if non-nil, otherwise use session's query timeout if available
 	var execTimeout *int

--- a/go/vt/vttablet/tabletserver/planbuilder/cached_size.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/cached_size.go
@@ -42,7 +42,7 @@ func (cached *Plan) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(128)
+		size += int64(144)
 	}
 	// field Table *vitess.io/vitess/go/vt/vttablet/tabletserver/schema.Table
 	size += cached.Table.CachedSize(true)
@@ -71,6 +71,13 @@ func (cached *Plan) CachedSize(alloc bool) int64 {
 	// field FullStmt vitess.io/vitess/go/vt/sqlparser.Statement
 	if cc, ok := cached.FullStmt.(cachedObject); ok {
 		size += cc.CachedSize(true)
+	}
+	// field SchemaQualifiers []string
+	{
+		size += hack.RuntimeAllocSize(int64(cap(cached.SchemaQualifiers)) * int64(16))
+		for _, elem := range cached.SchemaQualifiers {
+			size += hack.RuntimeAllocSize(int64(len(elem)))
+		}
 	}
 	return size
 }

--- a/go/vt/vttablet/tabletserver/planbuilder/plan.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan.go
@@ -179,10 +179,8 @@ type Plan struct {
 	// NeedsReservedConn indicates at a reserved connection is needed to execute this plan
 	NeedsReservedConn bool
 
-	// SchemaQualifiers holds the distinct, lower-cased schema qualifiers of the
-	// tables referenced by the query (e.g. "performance_schema"). Empty for the
-	// common case of unqualified tables. Computed once at plan-build time and
-	// cached on the plan, so the per-request load-shedding path only reads it.
+	// SchemaQualifiers holds the distinct schema qualifiers of the query's tables
+	// (e.g. "performance_schema"); nil for the common unqualified case.
 	SchemaQualifiers []string
 }
 
@@ -271,13 +269,6 @@ func Build(env *vtenv.Environment, statement sqlparser.Statement, tables map[str
 	return plan, nil
 }
 
-// extractSchemaQualifiers returns the distinct schema qualifiers of the tables
-// referenced by the statement (e.g. "performance_schema"). Tables without an
-// explicit schema qualifier — the common case — contribute nothing, so this
-// returns nil for typical data-plane queries. Used to let the load shedder mark
-// queries against configured schemas (e.g. monitoring against performance_schema)
-// as undroppable. Dedup is case-insensitive; the stored form preserves the
-// original case and is compared case-insensitively by the caller.
 func extractSchemaQualifiers(statement sqlparser.Statement) []string {
 	var qualifiers []string
 	seen := make(map[string]struct{})

--- a/go/vt/vttablet/tabletserver/planbuilder/plan.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan.go
@@ -178,6 +178,12 @@ type Plan struct {
 
 	// NeedsReservedConn indicates at a reserved connection is needed to execute this plan
 	NeedsReservedConn bool
+
+	// SchemaQualifiers holds the distinct, lower-cased schema qualifiers of the
+	// tables referenced by the query (e.g. "performance_schema"). Empty for the
+	// common case of unqualified tables. Computed once at plan-build time and
+	// cached on the plan, so the per-request load-shedding path only reads it.
+	SchemaQualifiers []string
 }
 
 // TableName returns the table name for the plan.
@@ -261,7 +267,32 @@ func Build(env *vtenv.Environment, statement sqlparser.Statement, tables map[str
 	}
 	plan.AllTables = lookupAllTables(statement, tables)
 	plan.Permissions = BuildPermissions(statement)
+	plan.SchemaQualifiers = extractSchemaQualifiers(statement)
 	return plan, nil
+}
+
+// extractSchemaQualifiers returns the distinct schema qualifiers of the tables
+// referenced by the statement (e.g. "performance_schema"). Tables without an
+// explicit schema qualifier — the common case — contribute nothing, so this
+// returns nil for typical data-plane queries. Used to let the load shedder mark
+// queries against configured schemas (e.g. monitoring against performance_schema)
+// as undroppable. Dedup is case-insensitive; the stored form preserves the
+// original case and is compared case-insensitively by the caller.
+func extractSchemaQualifiers(statement sqlparser.Statement) []string {
+	var qualifiers []string
+	seen := make(map[string]struct{})
+	_ = sqlparser.Walk(func(node sqlparser.SQLNode) (bool, error) {
+		if tn, ok := node.(sqlparser.TableName); ok && tn.Qualifier.NotEmpty() {
+			q := tn.Qualifier.String()
+			key := strings.ToLower(q)
+			if _, dup := seen[key]; !dup {
+				seen[key] = struct{}{}
+				qualifiers = append(qualifiers, q)
+			}
+		}
+		return true, nil
+	}, statement)
+	return qualifiers
 }
 
 // BuildStreaming builds a streaming plan based on the schema.

--- a/go/vt/vttablet/tabletserver/planbuilder/schema_qualifiers_test.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/schema_qualifiers_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package planbuilder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/vt/sqlparser"
+)
+
+func TestExtractSchemaQualifiers(t *testing.T) {
+	tcases := []struct {
+		input string
+		want  []string
+	}{
+		{"select * from t", nil},
+		{"select * from performance_schema.events_statements_summary_by_digest", []string{"performance_schema"}},
+		{"select 1 from information_schema.tables", []string{"information_schema"}},
+		{"select * from performance_schema.a join performance_schema.b", []string{"performance_schema"}},
+		{"select * from performance_schema.a join information_schema.b", []string{"performance_schema", "information_schema"}},
+		{"select * from user_table join performance_schema.metrics", []string{"performance_schema"}},
+		// Case is preserved in the stored value; dedup is case-insensitive.
+		{"select * from Performance_Schema.a join PERFORMANCE_SCHEMA.b", []string{"Performance_Schema"}},
+	}
+
+	parser := sqlparser.NewTestParser()
+	for _, tc := range tcases {
+		t.Run(tc.input, func(t *testing.T) {
+			stmt, err := parser.Parse(tc.input)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, extractSchemaQualifiers(stmt))
+		})
+	}
+}

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -45,6 +45,7 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/connpool"
 	p "vitess.io/vitess/go/vt/vttablet/tabletserver/planbuilder"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/querythrottler/registry"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/rules"
 	eschema "vitess.io/vitess/go/vt/vttablet/tabletserver/schema"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
@@ -89,6 +90,13 @@ var (
 		},
 	}
 	errTxThrottled = vterrors.Errorf(vtrpcpb.Code_RESOURCE_EXHAUSTED, "Transaction throttled")
+
+	// errAdmissionRejected and errDMLAdmissionRejected are pre-built so that an
+	// admission rejection — an expected, high-volume outcome under overload —
+	// does not call vterrors.Errorf per rejection, which captures a stack trace
+	// (runtime.Callers) and allocates.
+	errAdmissionRejected    = vterrors.Errorf(vtrpcpb.Code_RESOURCE_EXHAUSTED, "admission rejected")
+	errDMLAdmissionRejected = vterrors.Errorf(vtrpcpb.Code_RESOURCE_EXHAUSTED, "dml admission rejected")
 )
 
 func returnStreamResult(result *sqltypes.Result) error {
@@ -140,6 +148,10 @@ func (qre *QueryExecutor) Execute() (reply *sqltypes.Result, err error) {
 		var errCode string
 		vtErrorCode := vterrors.Code(err)
 		errCode = vtErrorCode.String()
+
+		// Split timings by result code so successful-request latency (errCode "OK")
+		// can be measured apart from fast-failing shed rejections (RESOURCE_EXHAUSTED).
+		qre.tsv.stats.QueryTimingsByErrorCode.Add(errCode, duration)
 
 		if reply == nil {
 			qre.tsv.qe.AddStats(qre.plan, tableName, qre.options.GetWorkloadName(), qre.targetTabletType, 1, duration, mysqlTime, 0, 0, 1, errCode)
@@ -755,12 +767,13 @@ func (qre *QueryExecutor) execSelect() (*sqltypes.Result, error) {
 		waiterCapExceeded := false
 		if original {
 			defer q.Broadcast()
-			conn, err := qre.getConn()
+			conn, release, err := qre.getConn()
 
 			if err != nil {
 				q.SetErr(err)
 			} else {
 				defer conn.Recycle()
+				defer release()
 				res, err := qre.execDBConn(conn.Conn, sql, true)
 				if qre.tsv.config.ConsolidatorCacheProto3Rows && q.HasWaiters() {
 					res.CacheProto3Rows()
@@ -791,11 +804,12 @@ func (qre *QueryExecutor) execSelect() (*sqltypes.Result, error) {
 		}
 		// If waiter cap exceeded, fall through to independent execution
 	}
-	conn, err := qre.getConn()
+	conn, release, err := qre.getConn()
 	if err != nil {
 		return nil, err
 	}
 	defer conn.Recycle()
+	defer release()
 	res, err := qre.execDBConn(conn.Conn, sql, true)
 	if err != nil {
 		return nil, err
@@ -833,22 +847,42 @@ func (qre *QueryExecutor) verifyRowCount(count, maxrows int64) error {
 }
 
 func (qre *QueryExecutor) execOther() (*sqltypes.Result, error) {
-	conn, err := qre.getConn()
+	conn, release, err := qre.getConn()
 	if err != nil {
 		return nil, err
 	}
 	defer conn.Recycle()
+	defer release()
 	return qre.execDBConn(conn.Conn, qre.query, true)
 }
 
-func (qre *QueryExecutor) getConn() (*connpool.PooledConn, error) {
+func (qre *QueryExecutor) getConn() (*connpool.PooledConn, func(), error) {
 	span, ctx := trace.NewSpan(qre.ctx, "QueryExecutor.getConn")
 	defer span.Finish()
 
 	defer func(start time.Time) {
 		qre.logStats.WaitingForConnection += time.Since(start)
 	}(time.Now())
-	return qre.tsv.qe.conns.Get(ctx, qre.setting)
+
+	release, err := qre.tsv.queryThrottler.AcquireAdmission(ctx, qre.admissionAttrs(), tabletenv.PoolTypeOltpRead)
+	if err != nil {
+		return nil, nil, errAdmissionRejected
+	}
+	conn, err := qre.tsv.qe.conns.Get(ctx, qre.setting)
+	if err != nil {
+		release(err)
+		return nil, nil, err
+	}
+	return conn, func() { release(nil) }, nil
+}
+
+func (qre *QueryExecutor) admissionAttrs() registry.QueryAttributes {
+	return registry.QueryAttributes{
+		WorkloadName:          qre.options.GetWorkloadName(),
+		Priority:              priorityFromOptions(qre.options, qre.tsv.config.TxThrottlerDefaultPriority),
+		AppExecutionContextID: qre.options.GetAppExecutionContextId(),
+		SchemaQualifiers:      qre.plan.SchemaQualifiers,
+	}
 }
 
 func (qre *QueryExecutor) getStreamConn() (*connpool.PooledConn, error) {
@@ -963,11 +997,12 @@ func rewriteOUTParamError(err error) error {
 }
 
 func (qre *QueryExecutor) execCallProc() (*sqltypes.Result, error) {
-	conn, err := qre.getConn()
+	conn, release, err := qre.getConn()
 	if err != nil {
 		return nil, err
 	}
 	defer conn.Recycle()
+	defer release()
 	sql, _, err := qre.generateFinalSQL(qre.plan.FullQuery, qre.bindVars)
 	if err != nil {
 		return nil, err

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -91,10 +91,6 @@ var (
 	}
 	errTxThrottled = vterrors.Errorf(vtrpcpb.Code_RESOURCE_EXHAUSTED, "Transaction throttled")
 
-	// errAdmissionRejected and errDMLAdmissionRejected are pre-built so that an
-	// admission rejection — an expected, high-volume outcome under overload —
-	// does not call vterrors.Errorf per rejection, which captures a stack trace
-	// (runtime.Callers) and allocates.
 	errAdmissionRejected    = vterrors.Errorf(vtrpcpb.Code_RESOURCE_EXHAUSTED, "admission rejected")
 	errDMLAdmissionRejected = vterrors.Errorf(vtrpcpb.Code_RESOURCE_EXHAUSTED, "dml admission rejected")
 )
@@ -149,8 +145,6 @@ func (qre *QueryExecutor) Execute() (reply *sqltypes.Result, err error) {
 		vtErrorCode := vterrors.Code(err)
 		errCode = vtErrorCode.String()
 
-		// Split timings by result code so successful-request latency (errCode "OK")
-		// can be measured apart from fast-failing shed rejections (RESOURCE_EXHAUSTED).
 		qre.tsv.stats.QueryTimingsByErrorCode.Add(errCode, duration)
 
 		if reply == nil {

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1707,10 +1707,11 @@ func TestGetConnectionLogStats(t *testing.T) {
 
 	// getConn() happy path
 	qre := newTestQueryExecutor(ctx, tsv, input, 0)
-	conn, err := qre.getConn()
+	conn, release, err := qre.getConn()
 	assert.NoError(t, err)
 	assert.NotNil(t, conn)
 	assert.True(t, qre.logStats.WaitingForConnection > 0)
+	release()
 
 	// getStreamConn() happy path
 	qre = newTestQueryExecutor(ctx, tsv, input, 0)
@@ -1724,7 +1725,7 @@ func TestGetConnectionLogStats(t *testing.T) {
 
 	// getConn() error path
 	qre = newTestQueryExecutor(ctx, tsv, input, 0)
-	_, err = qre.getConn()
+	_, _, err = qre.getConn()
 	assert.Error(t, err)
 	assert.True(t, qre.logStats.WaitingForConnection > 0)
 

--- a/go/vt/vttablet/tabletserver/querythrottler/admission_test.go
+++ b/go/vt/vttablet/tabletserver/querythrottler/admission_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package querythrottler
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	querythrottlerpb "vitess.io/vitess/go/vt/proto/querythrottler"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/querythrottler/registry"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
+)
+
+type predicateOnlyStrategy struct{}
+
+func (predicateOnlyStrategy) Evaluate(context.Context, topodatapb.TabletType, *sqlparser.ParsedQuery, int64, registry.QueryAttributes) registry.ThrottleDecision {
+	return registry.ThrottleDecision{Throttle: false}
+}
+func (predicateOnlyStrategy) Start()                  {}
+func (predicateOnlyStrategy) Stop()                   {}
+func (predicateOnlyStrategy) GetStrategyName() string { return "predicate-only" }
+
+type admissionStrategy struct {
+	predicateOnlyStrategy
+	admitErr    error
+	released    bool
+	releasedErr error
+	gotPool     tabletenv.PoolType
+	called      bool
+}
+
+func (a *admissionStrategy) Admit(_ context.Context, _ registry.QueryAttributes, pool tabletenv.PoolType) (func(err error), error) {
+	a.called = true
+	a.gotPool = pool
+	if a.admitErr != nil {
+		return nil, a.admitErr
+	}
+	return func(err error) { a.released = true; a.releasedErr = err }, nil
+}
+
+func TestAcquireAdmission_NonAdmissionStrategyIsNoOp(t *testing.T) {
+	qt := &QueryThrottler{strategyHandlerInstance: predicateOnlyStrategy{}}
+
+	release, err := qt.AcquireAdmission(context.Background(), registry.QueryAttributes{}, tabletenv.PoolTypeOltpRead)
+	require.NoError(t, err)
+	require.NotNil(t, release, "release must be non-nil so callers can defer it unconditionally")
+	release(nil)
+}
+
+func TestAcquireAdmission_RoutesToAdmissionController(t *testing.T) {
+	strategy := &admissionStrategy{}
+	qt := &QueryThrottler{strategyHandlerInstance: strategy}
+
+	release, err := qt.AcquireAdmission(context.Background(), registry.QueryAttributes{}, tabletenv.PoolTypeTx)
+	require.NoError(t, err)
+	require.NotNil(t, release)
+	assert.True(t, strategy.called, "Admit should have been invoked")
+	assert.Equal(t, tabletenv.PoolTypeTx, strategy.gotPool, "pool must be forwarded to the strategy")
+
+	release(errors.New("done"))
+	assert.True(t, strategy.released, "release must reach the strategy's release func")
+	assert.EqualError(t, strategy.releasedErr, "done", "release error must be forwarded")
+}
+
+func TestAcquireAdmission_PropagatesRejection(t *testing.T) {
+	strategy := &admissionStrategy{admitErr: errors.New("shed")}
+	qt := &QueryThrottler{strategyHandlerInstance: strategy}
+
+	release, err := qt.AcquireAdmission(context.Background(), registry.QueryAttributes{}, tabletenv.PoolTypeOltpRead)
+	assert.Nil(t, release, "no release on rejection")
+	assert.EqualError(t, err, "shed")
+}
+
+// admissionFactory registers admissionStrategy for a strategy name and records
+// the Deps it was built with, so the test can assert the pool accessors reach
+// the factory.
+type admissionFactory struct {
+	built *admissionStrategy
+	deps  registry.Deps
+}
+
+func (f *admissionFactory) New(deps registry.Deps, _ registry.StrategyConfig) (registry.ThrottlingStrategyHandler, error) {
+	f.deps = deps
+	f.built = &admissionStrategy{}
+	return f.built, nil
+}
+
+func TestSelectThrottlingStrategy_BuildsAdmissionStrategyWithPoolCapacities(t *testing.T) {
+	fac := &admissionFactory{}
+	registry.Register(querythrottlerpb.ThrottlingStrategy_ADMISSION_CONTROL, fac)
+	t.Cleanup(func() { registry.Unregister(querythrottlerpb.ThrottlingStrategy_ADMISSION_CONTROL) })
+
+	qt := &QueryThrottler{
+		tabletConfig:   &tabletenv.TabletConfig{},
+		poolCapacities: map[tabletenv.PoolType]func() int{tabletenv.PoolTypeOltpRead: func() int { return 4 }},
+	}
+
+	strategy := qt.selectThrottlingStrategy(&querythrottlerpb.Config{Enabled: true, Strategy: querythrottlerpb.ThrottlingStrategy_ADMISSION_CONTROL})
+
+	require.Same(t, fac.built, strategy, "config selecting ADMISSION_CONTROL must build via the registered factory")
+	_, ok := fac.deps.PoolCapacities[tabletenv.PoolTypeOltpRead]
+	assert.True(t, ok, "pool capacities must be threaded into Deps")
+}

--- a/go/vt/vttablet/tabletserver/querythrottler/query_throttler.go
+++ b/go/vt/vttablet/tabletserver/querythrottler/query_throttler.go
@@ -75,6 +75,7 @@ type QueryThrottler struct {
 	cfg *querythrottlerpb.Config
 	// strategyHandlerInstance is the current throttling strategy handler instance
 	strategyHandlerInstance registry.ThrottlingStrategyHandler
+	poolCapacities          map[tabletenv.PoolType]func() int
 	env                     tabletenv.Env
 	stats                   Stats
 }
@@ -206,6 +207,24 @@ func (qt *QueryThrottler) Throttle(ctx context.Context, tabletType topodatapb.Ta
 
 	// Normal throttling: return an error to reject the query
 	return vterrors.New(vtrpcpb.Code_RESOURCE_EXHAUSTED, decision.Message)
+}
+
+func (qt *QueryThrottler) SetPoolCapacities(capacities map[tabletenv.PoolType]func() int) {
+	qt.mu.Lock()
+	qt.poolCapacities = capacities
+	qt.mu.Unlock()
+}
+
+func (qt *QueryThrottler) AcquireAdmission(ctx context.Context, attrs registry.QueryAttributes, pool tabletenv.PoolType) (func(err error), error) {
+	qt.mu.RLock()
+	strategy := qt.strategyHandlerInstance
+	qt.mu.RUnlock()
+
+	ac, ok := strategy.(registry.AdmissionController)
+	if !ok {
+		return func(error) {}, nil
+	}
+	return ac.Admit(ctx, attrs, pool)
 }
 
 // startSrvKeyspaceWatch starts watching the SrvKeyspace for event-driven config updates.
@@ -347,14 +366,13 @@ func (qt *QueryThrottler) HandleConfigUpdate(srvks *topodatapb.SrvKeyspace, err 
 		return true
 	}
 
-	// No Locking is required because only this function updates the configs of Query Throttler.
 	needsStrategyChange := qt.cfg.GetStrategy() != newCfg.GetStrategy()
 	oldStrategyInstance := qt.strategyHandlerInstance
 
 	var newStrategy registry.ThrottlingStrategyHandler
 	if needsStrategyChange {
 		// Create the new strategy (doesn't need lock)
-		newStrategy = selectThrottlingStrategy(newCfg, qt.throttleClient, qt.tabletConfig)
+		newStrategy = qt.selectThrottlingStrategy(newCfg)
 	}
 
 	// Acquire write lock only for the actual swap operation.
@@ -384,10 +402,12 @@ func (qt *QueryThrottler) HandleConfigUpdate(srvks *topodatapb.SrvKeyspace, err 
 }
 
 // selectThrottlingStrategy returns the appropriate strategy implementation based on the config.
-func selectThrottlingStrategy(cfg *querythrottlerpb.Config, client *throttle.Client, tabletConfig *tabletenv.TabletConfig) registry.ThrottlingStrategyHandler {
+func (qt *QueryThrottler) selectThrottlingStrategy(cfg *querythrottlerpb.Config) registry.ThrottlingStrategyHandler {
 	deps := registry.Deps{
-		ThrottleClient: client,
-		TabletConfig:   tabletConfig,
+		ThrottleClient: qt.throttleClient,
+		TabletConfig:   qt.tabletConfig,
+		Env:            qt.env,
+		PoolCapacities: qt.poolCapacities,
 	}
 	return registry.CreateStrategy(cfg, deps)
 }

--- a/go/vt/vttablet/tabletserver/querythrottler/query_throttler_test.go
+++ b/go/vt/vttablet/tabletserver/querythrottler/query_throttler_test.go
@@ -65,7 +65,8 @@ func TestSelectThrottlingStrategy(t *testing.T) {
 				QueryThrottlerConfigRefreshInterval: 10 * time.Millisecond,
 			}
 
-			strategy := selectThrottlingStrategy(&querythrottlerpb.Config{Enabled: true, Strategy: tt.giveThrottlingStrategy}, mockClient, config)
+			qt := &QueryThrottler{throttleClient: mockClient, tabletConfig: config}
+			strategy := qt.selectThrottlingStrategy(&querythrottlerpb.Config{Enabled: true, Strategy: tt.giveThrottlingStrategy})
 
 			require.IsType(t, tt.expectedType, strategy)
 		})

--- a/go/vt/vttablet/tabletserver/querythrottler/registry/registry.go
+++ b/go/vt/vttablet/tabletserver/querythrottler/registry/registry.go
@@ -43,6 +43,12 @@ func Register(name querythrottlerpb.ThrottlingStrategy, factory StrategyFactory)
 	log.Info(fmt.Sprintf("Registered throttling strategy: %s", name))
 }
 
+func Unregister(name querythrottlerpb.ThrottlingStrategy) {
+	mu.Lock()
+	defer mu.Unlock()
+	delete(factories, name)
+}
+
 // Get retrieves a strategy factory by name.
 // Returns the factory and true if found, nil and false otherwise.
 func Get(name querythrottlerpb.ThrottlingStrategy) (StrategyFactory, bool) {

--- a/go/vt/vttablet/tabletserver/querythrottler/registry/throttling_handler.go
+++ b/go/vt/vttablet/tabletserver/querythrottler/registry/throttling_handler.go
@@ -22,6 +22,7 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )
 
 // ThrottlingStrategyHandler defines the interface for throttling strategies
@@ -46,4 +47,8 @@ type ThrottlingStrategyHandler interface {
 
 	// GetStrategyName returns the name of the strategy.
 	GetStrategyName() string
+}
+
+type AdmissionController interface {
+	Admit(ctx context.Context, attrs QueryAttributes, pool tabletenv.PoolType) (release func(err error), err error)
 }

--- a/go/vt/vttablet/tabletserver/querythrottler/registry/types.go
+++ b/go/vt/vttablet/tabletserver/querythrottler/registry/types.go
@@ -30,6 +30,12 @@ type QueryAttributes struct {
 
 	// Priority contains the priority of the query (0-100, where 0 is highest priority).
 	Priority int
+
+	// AppExecutionContextID identifies the application-level request or async job that issued the query.
+	AppExecutionContextID string
+
+	// SchemaQualifiers holds the schema qualifiers of the query's tables, to exempt system-schema traffic from shedding.
+	SchemaQualifiers []string
 }
 
 // ThrottleDecision represents the result of evaluating whether a query should be throttled.
@@ -67,6 +73,8 @@ type StrategyConfig interface {
 type Deps struct {
 	ThrottleClient *throttle.Client
 	TabletConfig   *tabletenv.TabletConfig
+	Env            tabletenv.Env
+	PoolCapacities map[tabletenv.PoolType]func() int
 }
 
 // StrategyFactory creates a new strategy instance with the given dependencies and configuration.

--- a/go/vt/vttablet/tabletserver/stateful_connection.go
+++ b/go/vt/vttablet/tabletserver/stateful_connection.go
@@ -174,13 +174,8 @@ func (sc *StatefulConnection) ReleaseString(reason string) {
 	if sc.dbConn == nil {
 		return
 	}
-	// Release any admission-control slot this connection holds. This is the
-	// universal teardown funnel: every conn lifecycle (Commit/Rollback via
-	// txComplete, but also the transaction killer, shutdown, taint, and
-	// renew-failure paths that call Release directly and bypass txComplete) passes
-	// through here. txComplete also invokes AdmissionRelease, but the underlying
-	// release is idempotent, so a slot held by a conn torn down without txComplete
-	// is still freed here instead of leaking until the pool's capacity is exhausted.
+	// Universal teardown funnel: frees any admission slot even on paths that bypass
+	// txComplete (killer, shutdown, taint, renew-failure). Release is idempotent.
 	if sc.txProps != nil && sc.txProps.AdmissionRelease != nil {
 		sc.txProps.AdmissionRelease()
 	}

--- a/go/vt/vttablet/tabletserver/stateful_connection.go
+++ b/go/vt/vttablet/tabletserver/stateful_connection.go
@@ -174,6 +174,16 @@ func (sc *StatefulConnection) ReleaseString(reason string) {
 	if sc.dbConn == nil {
 		return
 	}
+	// Release any admission-control slot this connection holds. This is the
+	// universal teardown funnel: every conn lifecycle (Commit/Rollback via
+	// txComplete, but also the transaction killer, shutdown, taint, and
+	// renew-failure paths that call Release directly and bypass txComplete) passes
+	// through here. txComplete also invokes AdmissionRelease, but the underlying
+	// release is idempotent, so a slot held by a conn torn down without txComplete
+	// is still freed here instead of leaking until the pool's capacity is exhausted.
+	if sc.txProps != nil && sc.txProps.AdmissionRelease != nil {
+		sc.txProps.AdmissionRelease()
+	}
 	if sc.pool != nil {
 		sc.pool.unregister(sc.ConnID, reason)
 	}

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -444,6 +444,14 @@ func (cfg *TabletConfig) UnmarshalJSON(data []byte) (err error) {
 	return nil
 }
 
+type PoolType int
+
+const (
+	PoolTypeOltpRead PoolType = iota
+	PoolTypeOlapRead
+	PoolTypeTx
+)
+
 // ConnPoolConfig contains the config for a conn pool.
 type ConnPoolConfig struct {
 	Size               int           `json:"size,omitempty"`

--- a/go/vt/vttablet/tabletserver/tabletenv/stats.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/stats.go
@@ -49,10 +49,6 @@ type Stats struct {
 
 	QueryTimingsByTabletType *servenv.TimingsWrapper // Query timings split by current tablet type
 
-	// QueryTimingsByErrorCode splits query timings by result vterrors code (e.g.
-	// OK for successful queries, RESOURCE_EXHAUSTED for load-shed rejections), so
-	// successful-request latency percentiles can be measured in isolation from
-	// fast-failing shed requests.
 	QueryTimingsByErrorCode *servenv.TimingsWrapper
 
 	// Atomic Transactions

--- a/go/vt/vttablet/tabletserver/tabletenv/stats.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/stats.go
@@ -49,6 +49,12 @@ type Stats struct {
 
 	QueryTimingsByTabletType *servenv.TimingsWrapper // Query timings split by current tablet type
 
+	// QueryTimingsByErrorCode splits query timings by result vterrors code (e.g.
+	// OK for successful queries, RESOURCE_EXHAUSTED for load-shed rejections), so
+	// successful-request latency percentiles can be measured in isolation from
+	// fast-failing shed requests.
+	QueryTimingsByErrorCode *servenv.TimingsWrapper
+
 	// Atomic Transactions
 	Unresolved         *stats.GaugesWithSingleLabel
 	CommitPreparedFail *stats.CountersWithSingleLabel
@@ -101,6 +107,8 @@ func NewStats(exporter *servenv.Exporter) *Stats {
 		UserReservedTimesNs:     exporter.NewCountersWithSingleLabel("UserReservedTimesNs", "Total reserved connection latency for each CallerID", "CallerID"),
 
 		QueryTimingsByTabletType: exporter.NewTimings("QueryTimingsByTabletType", "Query timings broken down by active tablet type", "TabletType"),
+
+		QueryTimingsByErrorCode: exporter.NewTimings("QueryTimingsByErrorCode", "Query timings broken down by result error code (OK for successful queries)", "ErrorCode"),
 
 		Unresolved:         exporter.NewGaugesWithSingleLabel("UnresolvedTransaction", "Current unresolved transactions", "ManagerType"),
 		CommitPreparedFail: exporter.NewCountersWithSingleLabel("CommitPreparedFail", "failed prepared transactions commit", "FailureType"),

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -1947,13 +1947,6 @@ func (tsv *TabletServer) convertAndLogError(ctx context.Context, sql string, bin
 	}
 
 	logMethod := log.Error
-	// skipQueryString suppresses building the (expensive) query+bindvars string
-	// for the log message. RESOURCE_EXHAUSTED is a high-volume, expected outcome
-	// under load shedding / pool exhaustion, and its log is rate-limited
-	// (logPoolFull) anyway — so formatting the SQL and prototext-marshalling every
-	// bind variable per rejection is wasted work that dominates CPU exactly when
-	// the tablet is already overloaded. The returned client error is unaffected;
-	// only the throttled log line omits the query detail.
 	skipQueryString := false
 	// Suppress or demote some errors in logs.
 	switch errCode {
@@ -1994,21 +1987,12 @@ func (tsv *TabletServer) convertAndLogError(ctx context.Context, sql string, bin
 			}
 		}
 	} else if skipQueryString {
-		// High-volume, rate-limited error (RESOURCE_EXHAUSTED, e.g. load shed):
-		// return the (typically pre-built) error as-is. Avoids a per-error
-		// vterrors.Errorf, which captures a stack trace (runtime.Callers) and
-		// allocates — pure overhead on the shed path, and at saturation the single
-		// largest stack-capture site since most requests are being rejected. Any
-		// callerID goes only into the (rate-limited) log line, not the returned
-		// error, so no stack-capturing re-wrap is needed even when a caller is set.
 		if logMethod != nil {
 			message = fmt.Sprintf("%v%s", err, callerID)
 		}
 	} else {
 		err = vterrors.Errorf(errCode, "%v%s", err.Error(), callerID)
 		if logMethod != nil {
-			// For high-volume, rate-limited errors (RESOURCE_EXHAUSTED) skip the
-			// expensive query+bindvars stringification; log just the error.
 			if skipQueryString {
 				message = fmt.Sprintf("%v", err)
 			} else {

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -201,6 +201,7 @@ func NewTabletServer(ctx context.Context, env *vtenv.Environment, name string, c
 	tsv.qe = NewQueryEngine(tsv, tsv.se)
 	tsv.txThrottler = txthrottler.NewTxThrottler(tsv, topoServer)
 	tsv.te = NewTxEngine(tsv, tsv.hs.sendUnresolvedTransactionSignal)
+	tsv.wireAdmissionControl()
 	tsv.messager = messager.NewEngine(tsv, tsv.se, tsv.vstreamer)
 
 	tsv.tableGC = gc.NewTableGC(tsv, topoServer, tsv.lagThrottler)
@@ -629,7 +630,11 @@ func (tsv *TabletServer) begin(
 }
 
 func (tsv *TabletServer) getPriorityFromOptions(options *querypb.ExecuteOptions) int {
-	priority := tsv.config.TxThrottlerDefaultPriority
+	return priorityFromOptions(options, tsv.config.TxThrottlerDefaultPriority)
+}
+
+func priorityFromOptions(options *querypb.ExecuteOptions, defaultPriority int) int {
+	priority := defaultPriority
 	if options == nil {
 		return priority
 	}
@@ -648,6 +653,23 @@ func (tsv *TabletServer) getPriorityFromOptions(options *querypb.ExecuteOptions)
 	}
 
 	return optionsPriority
+}
+
+func (tsv *TabletServer) wireAdmissionControl() {
+	tsv.queryThrottler.SetPoolCapacities(map[tabletenv.PoolType]func() int{
+		tabletenv.PoolTypeOltpRead: liveCapacity(func() int { return int(tsv.qe.conns.Capacity()) }, tsv.config.OltpReadPool.Size),
+		tabletenv.PoolTypeTx:       liveCapacity(tsv.te.txPool.scp.Capacity, tsv.config.TxPool.Size),
+	})
+	tsv.te.txPool.admitter = tsv.queryThrottler
+}
+
+func liveCapacity(live func() int, configured int) func() int {
+	return func() int {
+		if c := live(); c > 0 {
+			return c
+		}
+		return configured
+	}
 }
 
 // resolveTargetType returns the appropriate target tablet type for a
@@ -1925,12 +1947,21 @@ func (tsv *TabletServer) convertAndLogError(ctx context.Context, sql string, bin
 	}
 
 	logMethod := log.Error
+	// skipQueryString suppresses building the (expensive) query+bindvars string
+	// for the log message. RESOURCE_EXHAUSTED is a high-volume, expected outcome
+	// under load shedding / pool exhaustion, and its log is rate-limited
+	// (logPoolFull) anyway — so formatting the SQL and prototext-marshalling every
+	// bind variable per rejection is wasted work that dominates CPU exactly when
+	// the tablet is already overloaded. The returned client error is unaffected;
+	// only the throttled log line omits the query detail.
+	skipQueryString := false
 	// Suppress or demote some errors in logs.
 	switch errCode {
 	case vtrpcpb.Code_FAILED_PRECONDITION, vtrpcpb.Code_ALREADY_EXISTS:
 		logMethod = nil
 	case vtrpcpb.Code_RESOURCE_EXHAUSTED:
 		logMethod = func(msg string, _ ...slog.Attr) { logPoolFull.Errorf("%s", msg) }
+		skipQueryString = true
 	case vtrpcpb.Code_ABORTED:
 		logMethod = log.Warn
 	case vtrpcpb.Code_INVALID_ARGUMENT, vtrpcpb.Code_DEADLINE_EXCEEDED:
@@ -1962,10 +1993,27 @@ func (tsv *TabletServer) convertAndLogError(ctx context.Context, sql string, bin
 				message = fmt.Sprintf("%s (errno %d) (sqlstate %s)%s: %s", sqlErr.Message, errnum, sqlState, callerID, queryAsString(sql, bindVariables, tsv.Config().SanitizeLogMessages, true, tsv.env.Parser()))
 			}
 		}
+	} else if skipQueryString {
+		// High-volume, rate-limited error (RESOURCE_EXHAUSTED, e.g. load shed):
+		// return the (typically pre-built) error as-is. Avoids a per-error
+		// vterrors.Errorf, which captures a stack trace (runtime.Callers) and
+		// allocates — pure overhead on the shed path, and at saturation the single
+		// largest stack-capture site since most requests are being rejected. Any
+		// callerID goes only into the (rate-limited) log line, not the returned
+		// error, so no stack-capturing re-wrap is needed even when a caller is set.
+		if logMethod != nil {
+			message = fmt.Sprintf("%v%s", err, callerID)
+		}
 	} else {
 		err = vterrors.Errorf(errCode, "%v%s", err.Error(), callerID)
 		if logMethod != nil {
-			message = fmt.Sprintf("%v: %v", err, queryAsString(sql, bindVariables, tsv.Config().SanitizeLogMessages, true, tsv.env.Parser()))
+			// For high-volume, rate-limited errors (RESOURCE_EXHAUSTED) skip the
+			// expensive query+bindvars stringification; log just the error.
+			if skipQueryString {
+				message = fmt.Sprintf("%v", err)
+			} else {
+				message = fmt.Sprintf("%v: %v", err, queryAsString(sql, bindVariables, tsv.Config().SanitizeLogMessages, true, tsv.env.Parser()))
+			}
 		}
 	}
 

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -2784,3 +2784,52 @@ func addTabletServerSupportedQueries(db *fakesqldb.DB) {
 		}},
 	})
 }
+
+func TestPriorityFromOptions(t *testing.T) {
+	const defaultPriority = 100
+
+	tests := []struct {
+		name    string
+		options *querypb.ExecuteOptions
+		want    int
+	}{
+		{
+			name:    "nil options uses default",
+			options: nil,
+			want:    defaultPriority,
+		},
+		{
+			name:    "empty priority string uses default",
+			options: &querypb.ExecuteOptions{Priority: ""},
+			want:    defaultPriority,
+		},
+		{
+			name:    "valid priority is parsed",
+			options: &querypb.ExecuteOptions{Priority: "0"},
+			want:    0,
+		},
+		{
+			name:    "valid mid-range priority is parsed",
+			options: &querypb.ExecuteOptions{Priority: "30"},
+			want:    30,
+		},
+		{
+			name:    "non-numeric priority falls back to default",
+			options: &querypb.ExecuteOptions{Priority: "not-a-number"},
+			want:    defaultPriority,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, priorityFromOptions(tt.options, defaultPriority))
+		})
+	}
+}
+
+func TestLiveCapacity(t *testing.T) {
+	assert.Equal(t, 5, liveCapacity(func() int { return 5 }, 10)(),
+		"a live pool capacity should be used as-is")
+	assert.Equal(t, 10, liveCapacity(func() int { return 0 }, 10)(),
+		"capacity 0 (pool not open) should fall back to the configured size")
+}

--- a/go/vt/vttablet/tabletserver/tx/api.go
+++ b/go/vt/vttablet/tabletserver/tx/api.go
@@ -58,9 +58,6 @@ type (
 
 		Stats *servenv.TimingsWrapper
 
-		// AdmissionRelease releases the admission-control slot this transaction
-		// holds on the tx pool, if any. It is invoked when the transaction
-		// completes so the slot is freed exactly once.
 		AdmissionRelease func()
 	}
 

--- a/go/vt/vttablet/tabletserver/tx/api.go
+++ b/go/vt/vttablet/tabletserver/tx/api.go
@@ -57,6 +57,11 @@ type (
 		LogToFile       bool
 
 		Stats *servenv.TimingsWrapper
+
+		// AdmissionRelease releases the admission-control slot this transaction
+		// holds on the tx pool, if any. It is invoked when the transaction
+		// completes so the slot is freed exactly once.
+		AdmissionRelease func()
 	}
 
 	// Query contains the query and involved tables executed inside transaction.

--- a/go/vt/vttablet/tabletserver/tx_pool.go
+++ b/go/vt/vttablet/tabletserver/tx_pool.go
@@ -32,6 +32,7 @@ import (
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/querythrottler/registry"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tx"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/txlimiter"
@@ -65,14 +66,19 @@ type (
 	// concern itself with a connections life cycle. The two exceptions are Begin, which creates a new StatefulConnection,
 	// and RollbackAndRelease, which does a Release after doing the rollback.
 	TxPool struct {
-		env     tabletenv.Env
-		scp     *StatefulConnectionPool
-		ticks   *timer.Timer
-		limiter txlimiter.TxLimiter
+		env      tabletenv.Env
+		scp      *StatefulConnectionPool
+		ticks    *timer.Timer
+		limiter  txlimiter.TxLimiter
+		admitter txAdmitter
 
 		logMu   sync.Mutex
 		lastLog time.Time
 		txStats *servenv.TimingsWrapper
+	}
+
+	txAdmitter interface {
+		AcquireAdmission(ctx context.Context, attrs registry.QueryAttributes, pool tabletenv.PoolType) (func(err error), error)
 	}
 )
 
@@ -236,6 +242,7 @@ func (tp *TxPool) Begin(ctx context.Context, options *querypb.ExecuteOptions, re
 
 	var conn *StatefulConnection
 	var err error
+	var admissionRelease func()
 	if reservedID != 0 {
 		conn, err = tp.scp.GetAndLock(reservedID, "start transaction on reserve conn")
 		if err != nil {
@@ -250,12 +257,30 @@ func (tp *TxPool) Begin(ctx context.Context, options *querypb.ExecuteOptions, re
 		if !tp.limiter.Get(immediateCaller, effectiveCaller) {
 			return nil, "", "", vterrors.Errorf(vtrpcpb.Code_RESOURCE_EXHAUSTED, "per-user transaction pool connection limit exceeded")
 		}
+
+		if tp.admitter != nil {
+			attrs := registry.QueryAttributes{
+				WorkloadName:          options.GetWorkloadName(),
+				Priority:              priorityFromOptions(options, tp.env.Config().TxThrottlerDefaultPriority),
+				AppExecutionContextID: options.GetAppExecutionContextId(),
+			}
+			release, admitErr := tp.admitter.AcquireAdmission(ctx, attrs, tabletenv.PoolTypeTx)
+			if admitErr != nil {
+				tp.limiter.Release(immediateCaller, effectiveCaller)
+				return nil, "", "", errDMLAdmissionRejected
+			}
+			admissionRelease = func() { release(nil) }
+		}
+
 		conn, err = tp.createConn(ctx, options, setting)
 		defer func() {
 			if err != nil {
 				// The transaction limiter frees transactions on rollback or commit. If we fail to create the transaction,
 				// release immediately since there will be no rollback or commit.
 				tp.limiter.Release(immediateCaller, effectiveCaller)
+				if admissionRelease != nil {
+					admissionRelease()
+				}
 			}
 		}()
 	}
@@ -273,6 +298,7 @@ func (tp *TxPool) Begin(ctx context.Context, options *querypb.ExecuteOptions, re
 	if setting != nil {
 		conn.TxProperties().RecordQueryDetail(setting.ApplyQuery(), nil)
 	}
+	conn.TxProperties().AdmissionRelease = admissionRelease
 	return conn, sql, sessionStateChanges, nil
 }
 
@@ -458,6 +484,9 @@ func (tp *TxPool) LogActive() {
 
 func (tp *TxPool) txComplete(conn *StatefulConnection, reason tx.ReleaseReason) {
 	conn.LogTransaction(reason)
+	if release := conn.TxProperties().AdmissionRelease; release != nil {
+		release()
+	}
 	tp.limiter.Release(conn.TxProperties().ImmediateCaller, conn.TxProperties().EffectiveCaller)
 	conn.CleanTxState()
 }

--- a/proto/query.proto
+++ b/proto/query.proto
@@ -387,11 +387,7 @@ message ExecuteOptions {
   // where the goal is to warm the buffer pool, not to retrieve data.
   bool no_result = 21;
 
-  // app_execution_context_id identifies the logical request or job that issued
-  // this query. An admission-control strategy may use it to detect fan-out from
-  // a single caller (e.g., an async helper issuing N queries against the same
-  // shard) and apply per-context fairness. When empty, admission control still
-  // applies but without the per-context grouping.
+  // app_execution_context_id identifies the logical request or job that issued this query.
   string app_execution_context_id = 22;
 }
 

--- a/proto/query.proto
+++ b/proto/query.proto
@@ -386,6 +386,13 @@ message ExecuteOptions {
   // currently honored by StreamExecute. This is useful for warming reads
   // where the goal is to warm the buffer pool, not to retrieve data.
   bool no_result = 21;
+
+  // app_execution_context_id identifies the logical request or job that issued
+  // this query. An admission-control strategy may use it to detect fan-out from
+  // a single caller (e.g., an async helper issuing N queries against the same
+  // shard) and apply per-context fairness. When empty, admission control still
+  // applies but without the per-context grouping.
+  string app_execution_context_id = 22;
 }
 
 // Field describes a single column returned by a query

--- a/proto/querythrottler.proto
+++ b/proto/querythrottler.proto
@@ -8,6 +8,7 @@ option go_package = "vitess.io/vitess/go/vt/proto/querythrottler";
 enum ThrottlingStrategy {
   UNKNOWN = 0;
   TABLET_THROTTLER = 1;
+  ADMISSION_CONTROL = 2;
 }
 
 // Config defines the runtime configuration for the IncomingQueryThrottler

--- a/web/vtadmin/src/proto/vtadmin.d.ts
+++ b/web/vtadmin/src/proto/vtadmin.d.ts
@@ -21082,7 +21082,8 @@ export namespace querythrottler {
     /** ThrottlingStrategy enum. */
     enum ThrottlingStrategy {
         UNKNOWN = 0,
-        TABLET_THROTTLER = 1
+        TABLET_THROTTLER = 1,
+        ADMISSION_CONTROL = 2
     }
 
     /** Properties of a Config. */
@@ -43324,6 +43325,9 @@ export namespace query {
 
         /** ExecuteOptions no_result */
         no_result?: (boolean|null);
+
+        /** ExecuteOptions app_execution_context_id */
+        app_execution_context_id?: (string|null);
     }
 
     /** Represents an ExecuteOptions. */
@@ -43385,6 +43389,9 @@ export namespace query {
 
         /** ExecuteOptions no_result. */
         public no_result: boolean;
+
+        /** ExecuteOptions app_execution_context_id. */
+        public app_execution_context_id: string;
 
         /** ExecuteOptions timeout. */
         public timeout?: "authoritative_timeout";

--- a/web/vtadmin/src/proto/vtadmin.js
+++ b/web/vtadmin/src/proto/vtadmin.js
@@ -1,5 +1,5 @@
 /*eslint-disable block-scoped-var, id-length, no-control-regex, no-magic-numbers, no-prototype-builtins, no-redeclare, no-shadow, no-var, sort-vars*/
-import * as $protobuf from "protobufjs/minimal";
+import $protobuf from "protobufjs/minimal.js";
 
 // Common aliases
 const $Reader = $protobuf.Reader, $Writer = $protobuf.Writer, $util = $protobuf.util;
@@ -54819,11 +54819,13 @@ export const querythrottler = $root.querythrottler = (() => {
      * @enum {number}
      * @property {number} UNKNOWN=0 UNKNOWN value
      * @property {number} TABLET_THROTTLER=1 TABLET_THROTTLER value
+     * @property {number} ADMISSION_CONTROL=2 ADMISSION_CONTROL value
      */
     querythrottler.ThrottlingStrategy = (function() {
         const valuesById = {}, values = Object.create(valuesById);
         values[valuesById[0] = "UNKNOWN"] = 0;
         values[valuesById[1] = "TABLET_THROTTLER"] = 1;
+        values[valuesById[2] = "ADMISSION_CONTROL"] = 2;
         return values;
     })();
 
@@ -55048,6 +55050,7 @@ export const querythrottler = $root.querythrottler = (() => {
                     return "strategy: enum value expected";
                 case 0:
                 case 1:
+                case 2:
                     break;
                 }
             if (message.tablet_strategy_config != null && message.hasOwnProperty("tablet_strategy_config")) {
@@ -55095,6 +55098,10 @@ export const querythrottler = $root.querythrottler = (() => {
                 case "TABLET_THROTTLER":
                 case 1:
                     message.strategy = 1;
+                    break;
+                case "ADMISSION_CONTROL":
+                case 2:
+                    message.strategy = 2;
                     break;
                 }
             if (object.tablet_strategy_config != null) {
@@ -116870,6 +116877,7 @@ export const query = $root.query = (() => {
          * @property {boolean|null} [in_dml_execution] ExecuteOptions in_dml_execution
          * @property {number|Long|null} [transaction_timeout] ExecuteOptions transaction_timeout
          * @property {boolean|null} [no_result] ExecuteOptions no_result
+         * @property {string|null} [app_execution_context_id] ExecuteOptions app_execution_context_id
          */
 
         /**
@@ -117024,6 +117032,14 @@ export const query = $root.query = (() => {
          */
         ExecuteOptions.prototype.no_result = false;
 
+        /**
+         * ExecuteOptions app_execution_context_id.
+         * @member {string} app_execution_context_id
+         * @memberof query.ExecuteOptions
+         * @instance
+         */
+        ExecuteOptions.prototype.app_execution_context_id = "";
+
         // OneOf field names bound to virtual getters and setters
         let $oneOfFields;
 
@@ -117106,6 +117122,8 @@ export const query = $root.query = (() => {
                 writer.uint32(/* id 20, wireType 0 =*/160).int64(message.transaction_timeout);
             if (message.no_result != null && Object.hasOwnProperty.call(message, "no_result"))
                 writer.uint32(/* id 21, wireType 0 =*/168).bool(message.no_result);
+            if (message.app_execution_context_id != null && Object.hasOwnProperty.call(message, "app_execution_context_id"))
+                writer.uint32(/* id 22, wireType 2 =*/178).string(message.app_execution_context_id);
             if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
                 for (let i = 0; i < message.$unknowns.length; ++i)
                     writer.raw(message.$unknowns[i]);
@@ -117309,6 +117327,15 @@ export const query = $root.query = (() => {
                             delete message.no_result;
                         continue;
                     }
+                case 22: {
+                        if (u !== 2)
+                            break;
+                        if ((v = reader.string()).length)
+                            message.app_execution_context_id = v;
+                        else
+                            delete message.app_execution_context_id;
+                        continue;
+                    }
                 }
                 reader.skipType(u, q, tag);
                 $util.makeProp(message, "$unknowns", false);
@@ -117457,6 +117484,9 @@ export const query = $root.query = (() => {
             if (message.no_result != null && message.hasOwnProperty("no_result"))
                 if (typeof message.no_result !== "boolean")
                     return "no_result: boolean expected";
+            if (message.app_execution_context_id != null && message.hasOwnProperty("app_execution_context_id"))
+                if (!$util.isString(message.app_execution_context_id))
+                    return "app_execution_context_id: string expected";
             return null;
         };
 
@@ -117702,6 +117732,9 @@ export const query = $root.query = (() => {
             if (object.no_result != null)
                 if (object.no_result)
                     message.no_result = Boolean(object.no_result);
+            if (object.app_execution_context_id != null)
+                if (typeof object.app_execution_context_id !== "string" || object.app_execution_context_id.length)
+                    message.app_execution_context_id = String(object.app_execution_context_id);
             return message;
         };
 
@@ -117739,6 +117772,7 @@ export const query = $root.query = (() => {
                 object.fetch_last_insert_id = false;
                 object.in_dml_execution = false;
                 object.no_result = false;
+                object.app_execution_context_id = "";
             }
             if (message.included_fields != null && message.hasOwnProperty("included_fields"))
                 object.included_fields = options.enums === String ? $root.query.ExecuteOptions.IncludedFields[message.included_fields] === undefined ? message.included_fields : $root.query.ExecuteOptions.IncludedFields[message.included_fields] : message.included_fields;
@@ -117792,6 +117826,8 @@ export const query = $root.query = (() => {
             }
             if (message.no_result != null && message.hasOwnProperty("no_result"))
                 object.no_result = message.no_result;
+            if (message.app_execution_context_id != null && message.hasOwnProperty("app_execution_context_id"))
+                object.app_execution_context_id = message.app_execution_context_id;
             return object;
         };
 


### PR DESCRIPTION
### Background / Why?

The `querythrottler` framework today supports only predicate-style strategies: a strategy inspects a query, returns an allow/throttle decision, and its involvement ends there. That shape can't express admission control that must hold a resource for the *lifetime* of a query or transaction — e.g. a concurrency limiter that grants a connection-pool slot on acquire and releases it on completion. This PR adds the generic extension points such a strategy needs, without shipping any concrete strategy.

The core addition is a two-phase `AdmissionController` interface (`Admit(...) (release func(err error), err error)`) that `QueryThrottler.AcquireAdmission(...)` invokes from the execution path. When no `AdmissionController` is registered it returns a no-op release, so existing deployments see no behavioral change. The call is wired into both the query path (`getConn` now returns a release the callers defer) and the transaction path (`TxPool.Begin` acquires for `PoolTypeTx` and stores the release on `tx.Properties`), and release is funneled through `StatefulConnection.ReleaseString` so every teardown path — commit, rollback, the transaction killer, shutdown, taint, renew-failure — frees the slot exactly once. Controllers also receive `Deps.PoolCapacities` and a new `AppExecutionContextID`/`SchemaQualifiers` on `QueryAttributes` to reason about pool pressure and caller identity.

### Testing

new unit tests covering the no-op-when-unregistered path, routing to a registered controller, rejection propagation, and pool-capacity threading through strategy construction.

AI disclosure: Claude Code assisted with development. Every line of code was either written by or carefully reviewed by me :)
