### PR TITLE
ERS: skip SetReplicationSource on tablets taking a backup

### DIFF
--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -600,7 +600,13 @@ func (erp *EmergencyReparenter) reparentReplicas(
 		switch {
 		case alias == topoproto.TabletAliasString(newPrimaryTablet.Alias):
 			continue
-		case !opts.IgnoreReplicas.Has(alias):
+		case opts.IgnoreReplicas.Has(alias):
+			continue
+		default:
+			if status, ok := statusMap[alias]; ok && isTabletBackingUp(status) {
+				log.Infof("skipping SetReplicationSource on %v because it is taking a backup", alias)
+				continue
+			}
 			replWg.Add(1)
 			numReplicas++
 			go handleReplica(alias, ti)

--- a/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
@@ -3559,6 +3559,73 @@ func TestEmergencyReparenter_reparentReplicas(t *testing.T) {
 			shouldErr:        true,
 			errShouldContain: "failed to promote zone1-0000000100 to primary: primary-elect tablet zone1-0000000100 failed to be upgraded to primary: context deadline exceeded",
 		},
+		{
+			name:                 "skips tablets taking backup",
+			emergencyReparentOps: EmergencyReparentOptions{IgnoreReplicas: sets.New[string]()},
+			tmc: &testutil.TabletManagerClient{
+				PopulateReparentJournalResults: map[string]error{
+					"zone1-0000000100": nil,
+				},
+				PromoteReplicaResults: map[string]struct {
+					Result string
+					Error  error
+				}{
+					"zone1-0000000100": {
+						Error: nil,
+					},
+				},
+				SetReplicationSourceResults: map[string]error{
+					"zone1-0000000101": nil,
+				},
+			},
+			newPrimaryTabletAlias: "zone1-0000000100",
+			tabletMap: map[string]*topo.TabletInfo{
+				"zone1-0000000100": {
+					Tablet: &topodatapb.Tablet{
+						Alias: &topodatapb.TabletAlias{
+							Cell: "zone1",
+							Uid:  100,
+						},
+						Hostname: "primary-elect",
+					},
+				},
+				"zone1-0000000101": {
+					Tablet: &topodatapb.Tablet{
+						Alias: &topodatapb.TabletAlias{
+							Cell: "zone1",
+							Uid:  101,
+						},
+					},
+				},
+				"zone1-0000000102": {
+					Tablet: &topodatapb.Tablet{
+						Alias: &topodatapb.TabletAlias{
+							Cell: "zone1",
+							Uid:  102,
+						},
+						Hostname: "backup-tablet",
+					},
+				},
+			},
+			statusMap: map[string]*replicationdatapb.StopReplicationStatus{
+				"zone1-0000000101": {
+					Before: &replicationdatapb.Status{
+						IoState:  int32(replication.ReplicationStateRunning),
+						SqlState: int32(replication.ReplicationStateRunning),
+					},
+				},
+				"zone1-0000000102": {
+					After: &replicationdatapb.Status{
+						IoState:      int32(replication.ReplicationStateStopped),
+						SqlState:     int32(replication.ReplicationStateRunning),
+						BackupRunning: true,
+					},
+				},
+			},
+			keyspace:  "testkeyspace",
+			shard:     "-",
+			shouldErr: false,
+		},
 	}
 
 	durability, _ := policy.GetDurabilityPolicy(policy.DurabilityNone)

--- a/go/vt/vtctl/reparentutil/replication.go
+++ b/go/vt/vtctl/reparentutil/replication.go
@@ -196,6 +196,19 @@ func ReplicaWasRunning(stopStatus *replicationdatapb.StopReplicationStatus) (boo
 		(replStatus.SQLState == replication.ReplicationStateRunning), nil
 }
 
+func isTabletBackingUp(stopStatus *replicationdatapb.StopReplicationStatus) bool {
+	if stopStatus == nil {
+		return false
+	}
+	if stopStatus.After != nil {
+		return stopStatus.After.BackupRunning
+	}
+	if stopStatus.Before != nil {
+		return stopStatus.Before.BackupRunning
+	}
+	return false
+}
+
 // SetReplicationSource is used to set the replication source on the specified
 // tablet to the current shard primary (if available). It also figures out if
 // the tablet should be sending semi-sync ACKs or not and passes that to the


### PR DESCRIPTION
## What's this?

During ERS, skip `SetReplicationSource` on tablets that are actively taking a backup.

## Why?

When a mysqlshell logical backup is running, MySQL Shell holds `LOCK INSTANCE FOR BACKUP` for the duration of the dump. If the old primary dies while a backup is in progress:

1. IO thread on the backup tablet stops (connection refused to dead primary)
2. SQL thread is still running (applying remaining relay logs)
3. ERS sees SQL is healthy → sets `wasReplicating=true` → passes `stopReplicationBefore=true`
4. `SetReplicationSource` tries to execute `STOP REPLICA` (all threads) at MySQL level
5. `STOP REPLICA` hangs because `LOCK INSTANCE FOR BACKUP` blocks stopping the SQL thread
6. Context times out, ERS moves on (only needs one replica to succeed)
7. Backup tablet left with IO thread stopped for the remainder of the backup

## How it works

ERS already collects `BackupRunning` state from each tablet during `StopReplicationAndGetStatus`. This change uses that information to skip `SetReplicationSource` on tablets that report a backup in progress. VTOrc or the backup's own completion logic will re-point replication after the backup finishes and the lock is released.

## Test plan
- [x] Added test case `TestEmergencyReparenter_reparentReplicas/skips_tablets_taking_backup`
- [x] All existing ERS tests pass
- [x] Full `reparentutil` test suite passes

---
_Most of this was written by Claude Code - I provided direction and root cause analysis._