### PR TITLE
Move Snake load-shedding into `smartconnpool` itself

### DIFF
--- a/go/pools/smartconnpool/connection.go
+++ b/go/pools/smartconnpool/connection.go
@@ -19,6 +19,8 @@ package smartconnpool
 import (
 	"context"
 	"sync/atomic"
+
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/loadshed"
 )
 
 type Connection interface {
@@ -35,15 +37,33 @@ type Pooled[C Connection] struct {
 	timeCreated timestamp
 	timeUsed    timestamp
 	pool        *ConnPool[C]
+	snakeUnlock *loadshed.SafeUnlock
 
 	Conn C
 }
 
+func NewUnpooled[C Connection](conn C) *Pooled[C] {
+	return &Pooled[C]{Conn: conn}
+}
+
+func (dbc *Pooled[C]) SetSnakeUnlock(unlock *loadshed.SafeUnlock) {
+	dbc.snakeUnlock = unlock
+}
+
+func (dbc *Pooled[C]) releaseSnakeUnlock() {
+	if dbc.snakeUnlock != nil {
+		_ = dbc.snakeUnlock.Release()
+		dbc.snakeUnlock = nil
+	}
+}
+
 func (dbc *Pooled[C]) Close() {
+	dbc.releaseSnakeUnlock()
 	dbc.Conn.Close()
 }
 
 func (dbc *Pooled[C]) Recycle() {
+	dbc.releaseSnakeUnlock()
 	switch {
 	case dbc.pool == nil:
 		dbc.Conn.Close()
@@ -58,6 +78,7 @@ func (dbc *Pooled[C]) Taint() {
 	if dbc.pool == nil {
 		return
 	}
+	dbc.releaseSnakeUnlock()
 	dbc.pool.put(nil)
 	dbc.pool = nil
 }

--- a/go/pools/smartconnpool/pool.go
+++ b/go/pools/smartconnpool/pool.go
@@ -28,6 +28,7 @@ import (
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/vterrors"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/loadshed"
 )
 
 var (
@@ -42,6 +43,8 @@ var (
 
 	// ErrPoolWaiterCapReached is returned when the waiter cap has been reached
 	ErrPoolWaiterCapReached = vterrors.New(vtrpcpb.Code_RESOURCE_EXHAUSTED, "connection pool waiter cap reached")
+
+	ErrPoolLoadShed = vterrors.New(vtrpcpb.Code_RESOURCE_EXHAUSTED, "connection pool load shed")
 
 	// PoolCloseTimeout is how long to wait for all connections to be returned to the pool during close
 	PoolCloseTimeout = 10 * time.Second
@@ -95,8 +98,10 @@ func (m *Metrics) WaiterCapRejected() int64 {
 	return m.waiterCapRejected.Load()
 }
 
-type Connector[C Connection] func(ctx context.Context) (C, error)
-type RefreshCheck func() (bool, error)
+type (
+	Connector[C Connection] func(ctx context.Context) (C, error)
+	RefreshCheck            func() (bool, error)
+)
 
 type Config[C Connection] struct {
 	Capacity        int64
@@ -106,6 +111,8 @@ type Config[C Connection] struct {
 	RefreshInterval time.Duration
 	MaxWaiters      uint
 	LogWait         func(time.Time)
+	Snake           *loadshed.Snake
+	DefaultPriority float64
 }
 
 // stackMask is the number of connection setting stacks minus one;
@@ -161,7 +168,9 @@ type ConnPool[C Connection] struct {
 		logWait func(time.Time)
 		// maxWaiters is the maximum number of clients that can be waiting for a connection;
 		// 0 means unlimited
-		maxWaiters uint
+		maxWaiters      uint
+		snake           *loadshed.Snake
+		defaultPriority float64
 	}
 
 	Metrics Metrics
@@ -179,6 +188,8 @@ func NewPool[C Connection](config *Config[C]) *ConnPool[C] {
 	pool.config.refreshInterval.Store(config.RefreshInterval.Nanoseconds())
 	pool.config.logWait = config.LogWait
 	pool.config.maxWaiters = config.MaxWaiters
+	pool.config.snake = config.Snake
+	pool.config.defaultPriority = config.DefaultPriority
 	pool.wait.init()
 	pool.wait.onWait = func() {
 		pool.Metrics.waitCount.Add(1)
@@ -346,6 +357,19 @@ func (pool *ConnPool[C]) Capacity() int64 {
 	return pool.capacity.Load()
 }
 
+func (pool *ConnPool[C]) SetSnake(snake *loadshed.Snake, defaultPriority float64) {
+	pool.config.snake = snake
+	pool.config.defaultPriority = defaultPriority
+}
+
+func (pool *ConnPool[C]) Snake() *loadshed.Snake {
+	return pool.config.snake
+}
+
+func (pool *ConnPool[C]) DefaultPriority() float64 {
+	return pool.config.defaultPriority
+}
+
 // MaxCapacity returns the maximum value to which Capacity can be set via ConnPool.SetCapacity
 func (pool *ConnPool[C]) MaxCapacity() int64 {
 	return pool.config.maxCapacity
@@ -406,22 +430,53 @@ func (pool *ConnPool[C]) recordWaitDuration(start time.Time) {
 // is returned, or until the given ctx is cancelled.
 // The connection must be returned to the pool once it's not needed by calling Pooled.Recycle
 func (pool *ConnPool[C]) Get(ctx context.Context, setting *Setting) (*Pooled[C], error) {
+	return pool.GetWithPriority(ctx, setting, pool.config.defaultPriority)
+}
+
+func (pool *ConnPool[C]) GetWithPriority(ctx context.Context, setting *Setting, priority float64) (*Pooled[C], error) {
 	if ctx.Err() != nil {
 		return nil, ErrCtxTimeout
 	}
 	if pool.capacity.Load() == 0 {
 		return nil, ErrConnPoolClosed
 	}
-	if setting == nil {
-		return pool.get(ctx)
+
+	var unlock *loadshed.SafeUnlock
+	if pool.config.snake != nil {
+		var err error
+		unlock, err = pool.config.snake.Acquire(ctx, priority)
+		if err != nil {
+			return nil, ErrPoolLoadShed
+		}
 	}
-	return pool.getWithSetting(ctx, setting)
+
+	var conn *Pooled[C]
+	var err error
+	if setting == nil {
+		conn, err = pool.get(ctx)
+	} else {
+		conn, err = pool.getWithSetting(ctx, setting)
+	}
+	if err != nil {
+		if unlock != nil {
+			_ = unlock.Release(err)
+		}
+		return nil, err
+	}
+
+	conn.snakeUnlock = unlock
+	return conn, nil
 }
 
 // put returns a connection to the pool. This is a private API.
 // Return connections to the pool by calling Pooled.Recycle
 func (pool *ConnPool[C]) put(conn *Pooled[C]) {
 	pool.borrowed.Add(-1)
+
+	if conn != nil && conn.snakeUnlock != nil {
+		_ = conn.snakeUnlock.Release()
+		conn.snakeUnlock = nil
+	}
 
 	if conn == nil {
 		var err error

--- a/go/pools/smartconnpool/snake_gate_test.go
+++ b/go/pools/smartconnpool/snake_gate_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package smartconnpool
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/loadshed"
+)
+
+func newTestSnake(t *testing.T, capacity int) *loadshed.Snake {
+	t.Helper()
+	return loadshed.NewSnake(loadshed.SnakeConfig{
+		Name: "test",
+		CoDel: loadshed.CoDelConfig{
+			IntervalNs:     func() int64 { return int64(time.Second) },
+			TargetNs:       func() int64 { return int64(time.Second) },
+			Exponent:       func() float64 { return 1.0 },
+			MinDropDelayNs: func() int64 { return 100 },
+		},
+		Capacity:            func() int { return capacity },
+		LoadsheddingAllowed: func() bool { return true },
+	})
+}
+
+func TestSnakeGate_FastPathIsGated(t *testing.T) {
+	var state TestState
+	snake := newTestSnake(t, 1)
+
+	p := NewPool(&Config[*TestConn]{
+		Capacity: 10,
+		Snake:    snake,
+	}).Open(newConnector(&state), nil)
+	defer p.Close()
+
+	ctx := context.Background()
+
+	held, err := p.GetWithPriority(ctx, nil, 0)
+	require.NoError(t, err)
+
+	// The physical pool still has 9 idle connections available, but Snake's
+	// own capacity (1) is exhausted — a fresh acquire must be gated (blocked
+	// in Snake's queue) even though the underlying pool would grant it
+	// immediately on the fast path. A short-lived context stands in for "this
+	// acquire never gets in while the slot is held" without waiting for
+	// CoDel's real shed timing.
+	shortCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	defer cancel()
+	_, err = p.GetWithPriority(shortCtx, nil, 0)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrPoolLoadShed), "expected ErrPoolLoadShed, got %v", err)
+
+	held.Recycle()
+}
+
+func TestSnakeGate_RecycleFreesSlot(t *testing.T) {
+	var state TestState
+	snake := newTestSnake(t, 1)
+
+	p := NewPool(&Config[*TestConn]{
+		Capacity: 10,
+		Snake:    snake,
+	}).Open(newConnector(&state), nil)
+	defer p.Close()
+
+	ctx := context.Background()
+
+	held, err := p.GetWithPriority(ctx, nil, 0)
+	require.NoError(t, err)
+
+	shortCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	defer cancel()
+	_, err = p.GetWithPriority(shortCtx, nil, 0)
+	require.Error(t, err, "should be gated while the only slot is held")
+
+	held.Recycle()
+
+	held2, err := p.GetWithPriority(ctx, nil, 0)
+	require.NoError(t, err, "slot should be free after Recycle")
+	held2.Recycle()
+}
+
+func TestSnakeGate_PlainGetIsGated(t *testing.T) {
+	var state TestState
+	snake := newTestSnake(t, 1)
+
+	p := NewPool(&Config[*TestConn]{
+		Capacity:        10,
+		Snake:           snake,
+		DefaultPriority: 0,
+	}).Open(newConnector(&state), nil)
+	defer p.Close()
+
+	ctx := context.Background()
+
+	held, err := snake.Acquire(ctx, 0)
+	require.NoError(t, err)
+
+	// Plain Get must not bypass the gate: exhausting Snake's capacity via a
+	// side-channel Acquire must still block/shed a plain Get call.
+	shortCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	defer cancel()
+	_, err = p.Get(shortCtx, nil)
+	require.Error(t, err, "plain Get must be gated identically to GetWithPriority")
+
+	require.NoError(t, held.Release())
+
+	conn, err := p.Get(ctx, nil)
+	require.NoError(t, err, "plain Get should succeed once the slot is free")
+	conn.Recycle()
+}
+
+func TestSnakeGate_UndroppableNeverShed(t *testing.T) {
+	var state TestState
+	snake := newTestSnake(t, 1)
+
+	p := NewPool(&Config[*TestConn]{
+		Capacity: 10,
+		Snake:    snake,
+	}).Open(newConnector(&state), nil)
+	defer p.Close()
+
+	ctx := context.Background()
+
+	held, err := p.GetWithPriority(ctx, nil, 0)
+	require.NoError(t, err)
+
+	holdersBefore := snake.Stats().HolderCount
+
+	// An undroppable caller must never be shed, even though the gate's only
+	// slot is held — it queues instead of failing immediately. Use a short
+	// deadline so a regression (permanently gated/blocked) fails the test
+	// instead of hanging.
+	shortCtx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() {
+		u, err := p.GetWithPriority(context.Background(), nil, loadshed.PriorityUndroppable)
+		if err == nil {
+			u.Recycle()
+		}
+		errCh <- err
+	}()
+
+	select {
+	case <-shortCtx.Done():
+	case <-errCh:
+		t.Fatal("undroppable acquire should still be queued, not resolved yet")
+	}
+	assert.Equal(t, holdersBefore, snake.Stats().HolderCount, "undroppable caller should be queued, not granted, while the slot is held")
+
+	held.Recycle()
+
+	select {
+	case err := <-errCh:
+		assert.NoError(t, err, "undroppable request must never be shed")
+	case <-time.After(2 * time.Second):
+		t.Fatal("undroppable acquire never resolved after the slot freed")
+	}
+}

--- a/go/vt/vttablet/tabletserver/connpool/pool.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool.go
@@ -31,6 +31,7 @@ import (
 	"vitess.io/vitess/go/vt/dbconnpool"
 	"vitess.io/vitess/go/vt/mysqlctl"
 	"vitess.io/vitess/go/vt/servenv"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/loadshed"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )
 
@@ -118,15 +119,32 @@ func (cp *Pool) Close() {
 // Get returns a connection.
 // You must call Recycle on DBConn once done.
 func (cp *Pool) Get(ctx context.Context, setting *smartconnpool.Setting) (*PooledConn, error) {
+	return cp.GetWithPriority(ctx, setting, cp.ConnPool.DefaultPriority())
+}
+
+func (cp *Pool) GetWithPriority(ctx context.Context, setting *smartconnpool.Setting, priority float64) (*PooledConn, error) {
 	span, ctx := trace.NewSpan(ctx, "Pool.Get")
 	defer span.Finish()
 
 	if cp.isCallerIDAppDebug(ctx) {
+		var unlock *loadshed.SafeUnlock
+		if snake := cp.Snake(); snake != nil {
+			var err error
+			unlock, err = snake.Acquire(ctx, priority)
+			if err != nil {
+				return nil, smartconnpool.ErrPoolLoadShed
+			}
+		}
 		conn, err := NewConn(ctx, cp.appDebugParams, cp.dbaPool, setting, cp.env)
 		if err != nil {
+			if unlock != nil {
+				_ = unlock.Release(err)
+			}
 			return nil, err
 		}
-		return &smartconnpool.Pooled[*Conn]{Conn: conn}, nil
+		pooled := smartconnpool.NewUnpooled[*Conn](conn)
+		pooled.SetSnakeUnlock(unlock)
+		return pooled, nil
 	}
 	span.Annotate("capacity", cp.Capacity())
 	span.Annotate("in_use", cp.InUse())
@@ -140,7 +158,7 @@ func (cp *Pool) Get(ctx context.Context, setting *smartconnpool.Setting) (*Poole
 	}
 
 	start := time.Now()
-	conn, err := cp.ConnPool.Get(ctx, setting)
+	conn, err := cp.ConnPool.GetWithPriority(ctx, setting, priority)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vttablet/tabletserver/connpool/pool_test.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool_test.go
@@ -30,6 +30,7 @@ import (
 	"vitess.io/vitess/go/vt/callerid"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/vtenv"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/loadshed"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )
 
@@ -115,6 +116,45 @@ func TestConnPoolGetAppDebug(t *testing.T) {
 	if !dbConn.Conn.IsClosed() {
 		t.Fatalf("db conn should be closed after recycle")
 	}
+}
+
+func TestConnPoolGetAppDebug_GatedButUndroppable(t *testing.T) {
+	db := fakesqldb.New(t)
+	debugConn := dbconfigs.New(db.ConnParamsWithUname("debugUsername"))
+	ctx := context.Background()
+	im := callerid.NewImmediateCallerID("debugUsername")
+	ecid := callerid.NewEffectiveCallerID("p", "c", "sc")
+	ctx = callerid.NewContext(ctx, ecid, im)
+	defer db.Close()
+	connPool := newPool()
+	snake := loadshed.NewSnake(loadshed.SnakeConfig{
+		Name: "test",
+		CoDel: loadshed.CoDelConfig{
+			IntervalNs:     func() int64 { return int64(time.Second) },
+			TargetNs:       func() int64 { return int64(time.Second) },
+			Exponent:       func() float64 { return 1.0 },
+			MinDropDelayNs: func() int64 { return 100 },
+		},
+		Capacity:            func() int { return 1 },
+		LoadsheddingAllowed: func() bool { return true },
+	})
+	connPool.SetSnake(snake, 0)
+	params := dbconfigs.New(db.ConnParams())
+	connPool.Open(params, params, debugConn)
+	defer connPool.Close()
+
+	// The appDebug path must go through the same Snake gate as everyone else
+	// (tracked as a holder) rather than bypassing it entirely, as it did
+	// before this integration existed.
+	assert.Equal(t, 0, snake.Stats().HolderCount)
+
+	dbConn, err := connPool.Get(ctx, nil)
+	require.NoError(t, err, "appDebug connections must never be shed")
+	require.NotNil(t, dbConn)
+	assert.Equal(t, 1, snake.Stats().HolderCount, "appDebug acquisition should be tracked as a Snake holder")
+	dbConn.Recycle()
+	assert.True(t, dbConn.Conn.IsClosed(), "db conn should be closed after recycle")
+	assert.Equal(t, 0, snake.Stats().HolderCount, "recycling the appDebug conn should release its Snake slot")
 }
 
 func TestConnPoolSetCapacity(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/loadshed/snake.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake.go
@@ -144,14 +144,9 @@ func (s *Snake) hasCapacity() bool {
 // is dropped by CoDel, or the context is cancelled. The returned SafeUnlock
 // must be released via defer unlock.Release().
 //
-// An empty valveID is valid: such requests bypass the per-valve fairness
-// layer but still pass through the CoDel gate. Callers should pass the valve
-// ID through unconditionally rather than gating Acquire on a non-empty ID,
-// which would silently exclude all unkeyed traffic from load shedding.
-//
 // The priority ordering convention is that lower-valued priorities indicate
 // less important requests. Lower values are shed first.
-func (s *Snake) Acquire(ctx context.Context, valveID string, priority float64) (*SafeUnlock, error) {
+func (s *Snake) Acquire(ctx context.Context, priority float64) (*SafeUnlock, error) {
 	priority = s.priority(priority)
 
 	if s.acquireByPriority != nil {
@@ -159,10 +154,7 @@ func (s *Snake) Acquire(ctx context.Context, valveID string, priority float64) (
 	}
 
 	s.mu.Lock()
-	req := s.q.lockedEnqueue(valveID, priority)
-	if valveID != "" {
-		s.lockedObserveValveDepth(valveID)
-	}
+	req := s.q.lockedEnqueue("", priority)
 
 	if s.hasCapacity() && req.codelqElem != nil {
 		s.lockedGrant(req)

--- a/go/vt/vttablet/tabletserver/loadshed/snake_bench_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_bench_test.go
@@ -33,21 +33,7 @@ func BenchmarkSnake_Uncontended(b *testing.B) {
 
 	b.ResetTimer()
 	for range b.N {
-		u, err := s.Acquire(ctx, "", 0)
-		if err != nil {
-			b.Fatal(err)
-		}
-		u.Release()
-	}
-}
-
-func BenchmarkSnake_Uncontended_WithValveID(b *testing.B) {
-	s := NewSnake(defaultSnakeConfig())
-	ctx := context.Background()
-
-	b.ResetTimer()
-	for range b.N {
-		u, err := s.Acquire(ctx, "valve-1", 0)
+		u, err := s.Acquire(ctx, 0)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -67,69 +53,13 @@ func BenchmarkSnake_Contended(b *testing.B) {
 			b.ResetTimer()
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
-					u, err := s.Acquire(ctx, "", 0)
+					u, err := s.Acquire(ctx, 0)
 					if err != nil {
 						continue
 					}
 					u.Release()
 				}
 			})
-		})
-	}
-}
-
-// --- Valve overhead: measure cost of valve bookkeeping vs. direct entry ---
-
-func BenchmarkSnake_ValveOverhead(b *testing.B) {
-	b.Run("NoValve", func(b *testing.B) {
-		s := NewSnake(defaultSnakeConfig())
-		ctx := context.Background()
-
-		b.ResetTimer()
-		for range b.N {
-			u, err := s.Acquire(ctx, "", 0)
-			if err != nil {
-				b.Fatal(err)
-			}
-			u.Release()
-		}
-	})
-
-	b.Run("WithValve", func(b *testing.B) {
-		s := NewSnake(defaultSnakeConfig())
-		ctx := context.Background()
-
-		b.ResetTimer()
-		for range b.N {
-			u, err := s.Acquire(ctx, "single-id", 0)
-			if err != nil {
-				b.Fatal(err)
-			}
-			u.Release()
-		}
-	})
-}
-
-// --- Valve ID scaling: many distinct valve IDs ---
-
-func BenchmarkSnake_ValveIDScaling(b *testing.B) {
-	for _, numIDs := range []int{1, 10, 100, 1000} {
-		b.Run(fmt.Sprintf("IDs%d", numIDs), func(b *testing.B) {
-			s := NewSnake(defaultSnakeConfig())
-			ctx := context.Background()
-			ids := make([]string, numIDs)
-			for i := range numIDs {
-				ids[i] = fmt.Sprintf("valve-%d", i)
-			}
-
-			b.ResetTimer()
-			for i := range b.N {
-				u, err := s.Acquire(ctx, ids[i%numIDs], 0)
-				if err != nil {
-					b.Fatal(err)
-				}
-				u.Release()
-			}
 		})
 	}
 }
@@ -149,7 +79,7 @@ func BenchmarkSnake_GOMAXPROCS(b *testing.B) {
 			b.ResetTimer()
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
-					u, err := s.Acquire(ctx, "", 0)
+					u, err := s.Acquire(ctx, 0)
 					if err != nil {
 						continue
 					}
@@ -257,22 +187,7 @@ func BenchmarkSnake_Allocs_Uncontended(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for range b.N {
-		u, err := s.Acquire(ctx, "", 0)
-		if err != nil {
-			b.Fatal(err)
-		}
-		u.Release()
-	}
-}
-
-func BenchmarkSnake_Allocs_WithValve(b *testing.B) {
-	s := NewSnake(defaultSnakeConfig())
-	ctx := context.Background()
-
-	b.ReportAllocs()
-	b.ResetTimer()
-	for range b.N {
-		u, err := s.Acquire(ctx, "valve-1", 0)
+		u, err := s.Acquire(ctx, 0)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -295,7 +210,7 @@ func BenchmarkSnake_Allocs_Contended(b *testing.B) {
 		go func() {
 			defer wg.Done()
 			for range opsPerWorker {
-				u, err := s.Acquire(ctx, "", 0)
+				u, err := s.Acquire(ctx, 0)
 				if err != nil {
 					continue
 				}
@@ -304,29 +219,6 @@ func BenchmarkSnake_Allocs_Contended(b *testing.B) {
 		}()
 	}
 	wg.Wait()
-}
-
-// --- Throughput under contention (ops/sec) ---
-
-func BenchmarkSnake_Throughput_SelfContention(b *testing.B) {
-	for _, parallelism := range []int{2, 4, 8} {
-		b.Run(fmt.Sprintf("SameID_P%d", parallelism), func(b *testing.B) {
-			s := NewSnake(defaultSnakeConfig())
-			ctx := context.Background()
-
-			b.SetParallelism(parallelism / runtime.GOMAXPROCS(0))
-			b.ResetTimer()
-			b.RunParallel(func(pb *testing.PB) {
-				for pb.Next() {
-					u, err := s.Acquire(ctx, "shared-id", 0)
-					if err != nil {
-						continue
-					}
-					u.Release()
-				}
-			})
-		})
-	}
 }
 
 // --- N-holder: multi-slot throughput ---
@@ -343,7 +235,7 @@ func BenchmarkSnake_NHolder_Throughput(b *testing.B) {
 			b.ResetTimer()
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
-					u, err := s.Acquire(ctx, "", 0)
+					u, err := s.Acquire(ctx, 0)
 					if err != nil {
 						continue
 					}
@@ -366,7 +258,7 @@ func BenchmarkSnake_NHolder_Uncontended(b *testing.B) {
 
 			b.ResetTimer()
 			for range b.N {
-				u, err := s.Acquire(ctx, "", 0)
+				u, err := s.Acquire(ctx, 0)
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -390,40 +282,7 @@ func BenchmarkSnake_NHolder_Saturated(b *testing.B) {
 			b.ResetTimer()
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
-					u, err := s.Acquire(ctx, "", 0)
-					if err != nil {
-						continue
-					}
-					u.Release()
-				}
-			})
-		})
-	}
-}
-
-// --- N-holder: valve + multi-slot (self-contention across multiple slots) ---
-
-func BenchmarkSnake_NHolder_WithValve(b *testing.B) {
-	for _, capacity := range []int{1, 4, 8} {
-		b.Run(fmt.Sprintf("Cap%d", capacity), func(b *testing.B) {
-			cfg := defaultSnakeConfig()
-			cfg.Capacity = func() int { return capacity }
-			s := NewSnake(cfg)
-			ctx := context.Background()
-
-			ids := make([]string, 4)
-			for i := range ids {
-				ids[i] = fmt.Sprintf("valve-%d", i)
-			}
-
-			b.SetParallelism(capacity * 2 / runtime.GOMAXPROCS(0))
-			b.ResetTimer()
-			var counter atomic.Int64
-			b.RunParallel(func(pb *testing.PB) {
-				idx := int(counter.Add(1) - 1)
-				id := ids[idx%len(ids)]
-				for pb.Next() {
-					u, err := s.Acquire(ctx, id, 0)
+					u, err := s.Acquire(ctx, 0)
 					if err != nil {
 						continue
 					}
@@ -447,7 +306,7 @@ func BenchmarkSnake_NHolder_Allocs(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			for range b.N {
-				u, err := s.Acquire(ctx, "", 0)
+				u, err := s.Acquire(ctx, 0)
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -536,24 +395,7 @@ func BenchmarkSnake_HighContention(b *testing.B) {
 				cfg.Capacity = hugeCapacity
 				s := NewSnake(cfg)
 				runPooledContention(b, level, func() {
-					u, err := s.Acquire(ctx, "", 0)
-					if err != nil {
-						return
-					}
-					u.Release()
-				})
-			})
-		}
-	})
-
-	b.Run("FastPath_WithValve", func(b *testing.B) {
-		for _, level := range contentionLevels {
-			b.Run(fmt.Sprintf("C%d", level), func(b *testing.B) {
-				cfg := defaultSnakeConfig()
-				cfg.Capacity = hugeCapacity
-				s := NewSnake(cfg)
-				runPooledContention(b, level, func() {
-					u, err := s.Acquire(ctx, "shared-valve", 0)
+					u, err := s.Acquire(ctx, 0)
 					if err != nil {
 						return
 					}
@@ -571,7 +413,7 @@ func BenchmarkSnake_HighContention(b *testing.B) {
 				// CoDel; either way the mutex is the serialization point.
 				s := NewSnake(defaultSnakeConfig())
 				runPooledContention(b, level, func() {
-					u, err := s.Acquire(ctx, "", 0)
+					u, err := s.Acquire(ctx, 0)
 					if err != nil {
 						// Dropped by CoDel under load; count the attempt and
 						// move on, matching the existing contended benchmark.

--- a/go/vt/vttablet/tabletserver/loadshed/snake_nholder_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_nholder_test.go
@@ -39,7 +39,7 @@ func TestSnake_NHolder_ConcurrentGrants(t *testing.T) {
 
 			unlocks := make([]*SafeUnlock, cap)
 			for i := range cap {
-				u, err := s.Acquire(t.Context(), "", 0)
+				u, err := s.Acquire(t.Context(), 0)
 				require.NoError(t, err, "acquire %d should succeed (capacity=%d)", i, cap)
 				unlocks[i] = u
 			}
@@ -63,14 +63,14 @@ func TestSnake_NHolder_BlocksAtCapacity(t *testing.T) {
 
 	unlocks := make([]*SafeUnlock, 3)
 	for i := range 3 {
-		u, err := s.Acquire(t.Context(), "", 0)
+		u, err := s.Acquire(t.Context(), 0)
 		require.NoError(t, err)
 		unlocks[i] = u
 	}
 
 	acquired := make(chan struct{})
 	go func() {
-		u, err := s.Acquire(t.Context(), "", 0)
+		u, err := s.Acquire(t.Context(), 0)
 		if err == nil {
 			close(acquired)
 			u.Release()
@@ -112,7 +112,7 @@ func TestSnake_NHolder_ParallelThroughput(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for range opsPerWorker {
-				u, err := s.Acquire(t.Context(), "", 0)
+				u, err := s.Acquire(t.Context(), 0)
 				if err != nil {
 					continue
 				}
@@ -145,12 +145,12 @@ func TestSnake_NHolder_DynamicCapacityIncrease(t *testing.T) {
 	cfg.Capacity = func() int { return int(cap.Load()) }
 	s := NewSnake(cfg)
 
-	u1, err := s.Acquire(t.Context(), "", 0)
+	u1, err := s.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 
 	acquired := make(chan struct{})
 	go func() {
-		u, err := s.Acquire(t.Context(), "", 0)
+		u, err := s.Acquire(t.Context(), 0)
 		if err == nil {
 			close(acquired)
 			u.Release()
@@ -185,7 +185,7 @@ func TestSnake_NHolder_DynamicCapacityDecrease(t *testing.T) {
 
 	unlocks := make([]*SafeUnlock, 4)
 	for i := range 4 {
-		u, err := s.Acquire(t.Context(), "", 0)
+		u, err := s.Acquire(t.Context(), 0)
 		require.NoError(t, err)
 		unlocks[i] = u
 	}
@@ -195,7 +195,7 @@ func TestSnake_NHolder_DynamicCapacityDecrease(t *testing.T) {
 
 	acquired := make(chan struct{})
 	go func() {
-		u, err := s.Acquire(t.Context(), "", 0)
+		u, err := s.Acquire(t.Context(), 0)
 		if err == nil {
 			close(acquired)
 			u.Release()
@@ -222,53 +222,6 @@ func TestSnake_NHolder_DynamicCapacityDecrease(t *testing.T) {
 	unlocks[3].Release()
 }
 
-// --- N-holder: valve serialization with multiple slots ---
-
-func TestSnake_NHolder_ValveSerialization(t *testing.T) {
-	cfg := defaultSnakeConfig()
-	cfg.Capacity = func() int { return 3 }
-	s := NewSnake(cfg)
-
-	u1, err := s.Acquire(t.Context(), "valve-a", 0)
-	require.NoError(t, err)
-	u2, err := s.Acquire(t.Context(), "valve-b", 0)
-	require.NoError(t, err)
-	u3, err := s.Acquire(t.Context(), "valve-c", 0)
-	require.NoError(t, err)
-	assert.Equal(t, 3, s.nGranted())
-
-	results := make(chan string, 6)
-	var wg sync.WaitGroup
-	for _, id := range []string{"valve-a", "valve-b", "valve-c"} {
-		for range 2 {
-			vid := id
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				u, err := s.Acquire(t.Context(), vid, 0)
-				if err == nil {
-					results <- vid
-					u.Release()
-				}
-			}()
-		}
-	}
-
-	time.Sleep(10 * time.Millisecond)
-	u1.Release()
-	u2.Release()
-	u3.Release()
-	wg.Wait()
-	close(results)
-
-	var count int
-	for range results {
-		count++
-	}
-	assert.Equal(t, 6, count, "all valve-serialized requests should complete")
-	assert.Equal(t, 0, s.nGranted())
-}
-
 // --- N-holder: NGranted accuracy under concurrency ---
 
 func TestSnake_NHolder_NGrantedAccuracy(t *testing.T) {
@@ -284,7 +237,7 @@ func TestSnake_NHolder_NGrantedAccuracy(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			u, err := s.Acquire(t.Context(), "", 0)
+			u, err := s.Acquire(t.Context(), 0)
 			if err != nil {
 				return
 			}
@@ -308,15 +261,15 @@ func TestSnake_NHolder_ContextCancelFreesSlot(t *testing.T) {
 	s := NewSnake(cfg)
 
 	ctx1, cancel1 := context.WithCancel(t.Context())
-	u1, err := s.Acquire(ctx1, "", 0)
+	u1, err := s.Acquire(ctx1, 0)
 	require.NoError(t, err)
 
-	u2, err := s.Acquire(t.Context(), "", 0)
+	u2, err := s.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 
 	waiterDone := make(chan error, 1)
 	go func() {
-		u, err := s.Acquire(t.Context(), "", 0)
+		u, err := s.Acquire(t.Context(), 0)
 		if err == nil {
 			u.Release()
 		}
@@ -350,7 +303,7 @@ func TestSnake_NHolder_ReleaseCallbacks(t *testing.T) {
 
 	unlocks := make([]*SafeUnlock, 3)
 	for i := range 3 {
-		u, err := s.Acquire(t.Context(), "", 0)
+		u, err := s.Acquire(t.Context(), 0)
 		require.NoError(t, err)
 		unlocks[i] = u
 	}
@@ -362,86 +315,7 @@ func TestSnake_NHolder_ReleaseCallbacks(t *testing.T) {
 	assert.Equal(t, int64(3), count.Load(), "release callback should fire for each holder")
 }
 
-// --- N-holder: valve invariant under sufficient capacity ---
-
-func TestSnake_NHolder_ValveInvariant_AllGranted(t *testing.T) {
-	const capacity = 10
-	const M = 5
-
-	cfg := defaultSnakeConfig()
-	cfg.Capacity = func() int { return capacity }
-	s := NewSnake(cfg)
-
-	unlocks := make([]*SafeUnlock, M)
-	for i := range M {
-		ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
-		u, err := s.Acquire(ctx, "foo", 0)
-		cancel()
-		require.NoError(t, err, "request %d should be granted (capacity=%d, holders=%d)", i, capacity, i)
-		unlocks[i] = u
-	}
-
-	assert.Equal(t, M, s.nGranted(), "all %d requests should be granted concurrently", M)
-
-	for _, u := range unlocks {
-		u.Release()
-	}
-	assert.Equal(t, 0, s.nGranted())
-}
-
-// --- N-holder: valve invariant under exhausted capacity ---
-
-func TestSnake_NHolder_ValveInvariant_CapacityExhausted(t *testing.T) {
-	const capacity = 3
-
-	cfg := defaultSnakeConfig()
-	cfg.Capacity = func() int { return capacity }
-	s := NewSnake(cfg)
-
-	unlocks := make([]*SafeUnlock, capacity)
-	for i := range capacity {
-		ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
-		u, err := s.Acquire(ctx, "foo", 0)
-		cancel()
-		require.NoError(t, err, "request %d should be granted", i)
-		unlocks[i] = u
-	}
-	assert.Equal(t, capacity, s.nGranted())
-
-	blocked := make(chan struct{})
-	granted := make(chan *SafeUnlock, 1)
-	go func() {
-		close(blocked)
-		u, err := s.Acquire(context.Background(), "foo", 0)
-		if err == nil {
-			granted <- u
-		}
-	}()
-	<-blocked
-	time.Sleep(10 * time.Millisecond)
-
-	s.mu.Lock()
-	droppable, hasDroppable := s.q.droppablePerValve["foo"]
-	s.mu.Unlock()
-	assert.True(t, hasDroppable, "nonempty valve must have a droppable representative")
-	assert.NotNil(t, droppable)
-
-	unlocks[0].Release()
-
-	select {
-	case u := <-granted:
-		assert.Equal(t, capacity, s.nGranted())
-		u.Release()
-	case <-time.After(2 * time.Second):
-		t.Fatal("blocked request should have been granted after release")
-	}
-
-	for i := 1; i < capacity; i++ {
-		unlocks[i].Release()
-	}
-}
-
-// --- N-holder: memory cleanup with multi-slot ---
+// --- N-holder: memory cleanup ---
 
 func TestSnake_NHolder_MemoryCleanup(t *testing.T) {
 	cfg := defaultSnakeConfig()
@@ -451,7 +325,7 @@ func TestSnake_NHolder_MemoryCleanup(t *testing.T) {
 	for range 500 {
 		unlocks := make([]*SafeUnlock, 5)
 		for i := range 5 {
-			u, err := s.Acquire(t.Context(), fmt.Sprintf("id-%d", i), 0)
+			u, err := s.Acquire(t.Context(), 0)
 			require.NoError(t, err)
 			unlocks[i] = u
 		}

--- a/go/vt/vttablet/tabletserver/loadshed/snake_overload_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_overload_test.go
@@ -18,7 +18,6 @@ package loadshed
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -38,7 +37,7 @@ func TestSnake_Overload_RecoveryToHealthy(t *testing.T) {
 	s := NewSnake(cfg)
 
 	// Phase 1: overload — hold lock for a long time with waiters
-	unlock, err := s.Acquire(t.Context(), "", 0)
+	unlock, err := s.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 
 	var wg sync.WaitGroup
@@ -46,7 +45,7 @@ func TestSnake_Overload_RecoveryToHealthy(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			u, err := s.Acquire(t.Context(), "", 0)
+			u, err := s.Acquire(t.Context(), 0)
 			if err == nil {
 				u.Release()
 			}
@@ -66,7 +65,7 @@ func TestSnake_Overload_RecoveryToHealthy(t *testing.T) {
 	// Phase 3: verify function — uncontended acquires should succeed immediately
 	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
 	defer cancel()
-	u, err := s.Acquire(ctx, "", 0)
+	u, err := s.Acquire(ctx, 0)
 	require.NoError(t, err, "post-recovery acquire should succeed quickly")
 	u.Release()
 }
@@ -76,7 +75,7 @@ func TestSnake_Overload_RecoveryToHealthy(t *testing.T) {
 func TestSnake_Overload_HolderKeepsQueueNonEmpty(t *testing.T) {
 	s := NewSnake(defaultSnakeConfig())
 
-	unlock, err := s.Acquire(t.Context(), "", 0)
+	unlock, err := s.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 
 	// The holder stays at the head — queue length should be 1 even though
@@ -99,7 +98,7 @@ func TestSnake_Overload_HolderKeepsQueueNonEmpty(t *testing.T) {
 func TestSnake_Overload_MassCancel(t *testing.T) {
 	s := NewSnake(defaultSnakeConfig())
 
-	unlock, err := s.Acquire(t.Context(), "mass-cancel", 0)
+	unlock, err := s.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 
 	const n = 30
@@ -115,7 +114,7 @@ func TestSnake_Overload_MassCancel(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			u, err := s.Acquire(ctxs[idx], "mass-cancel", 0)
+			u, err := s.Acquire(ctxs[idx], 0)
 			if err == nil {
 				u.Release()
 			}
@@ -143,7 +142,7 @@ func TestSnake_Overload_MassCancel(t *testing.T) {
 	assert.True(t, s.isIdle())
 
 	// Verify the lock is still usable
-	u, err := s.Acquire(t.Context(), "mass-cancel", 0)
+	u, err := s.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 	u.Release()
 }
@@ -195,7 +194,7 @@ func TestSnake_Overload_DropOnlyDroppable(t *testing.T) {
 		cfg.LoadsheddingAllowed = func() bool { return true }
 		s := NewSnake(cfg)
 
-		unlock, err := s.Acquire(t.Context(), "", 0)
+		unlock, err := s.Acquire(t.Context(), 0)
 		require.NoError(t, err)
 
 		var wg sync.WaitGroup
@@ -204,7 +203,7 @@ func TestSnake_Overload_DropOnlyDroppable(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				u, err := s.Acquire(t.Context(), "", 0)
+				u, err := s.Acquire(t.Context(), 0)
 				if err != nil {
 					dropped.Add(1)
 					return
@@ -228,7 +227,7 @@ func TestSnake_Overload_DropOnlyDroppable(t *testing.T) {
 		cfg.LoadsheddingAllowed = func() bool { return false }
 		s := NewSnake(cfg)
 
-		unlock, err := s.Acquire(t.Context(), "", 0)
+		unlock, err := s.Acquire(t.Context(), 0)
 		require.NoError(t, err)
 
 		var wg sync.WaitGroup
@@ -237,7 +236,7 @@ func TestSnake_Overload_DropOnlyDroppable(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				u, err := s.Acquire(t.Context(), "", 0)
+				u, err := s.Acquire(t.Context(), 0)
 				if err != nil {
 					dropped.Add(1)
 					return
@@ -304,67 +303,6 @@ func TestCoDelQueue_SuccessiveDrops_IncrementCount(t *testing.T) {
 	assert.Greater(t, 10-q.lockedLen(), 0, "some requests should have been dropped")
 }
 
-// --- Self-contention: many IDs under overload, only cross-ID contention gets dropped ---
-
-func TestSnake_Overload_SelfContention_CrossIDDrops(t *testing.T) {
-	cfg := defaultSnakeConfig()
-	cfg.CoDel.IntervalNs = func() int64 { return 5_000_000 }   // 5ms
-	cfg.CoDel.TargetNs = func() int64 { return 500_000 }       // 0.5ms
-	cfg.CoDel.MinDropDelayNs = func() int64 { return 100_000 } // 0.1ms
-	s := NewSnake(cfg)
-
-	// Hold the lock
-	unlock, err := s.Acquire(t.Context(), "holder", 0)
-	require.NoError(t, err)
-
-	const numIDs = 10
-	const perID = 5
-
-	var wg sync.WaitGroup
-	type result struct {
-		granted int64
-		dropped int64
-		valveID string
-	}
-	results := make([]result, numIDs)
-
-	for id := range numIDs {
-		results[id].valveID = fmt.Sprintf("overload-id%d", id)
-		for range perID {
-			idx := id
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				u, err := s.Acquire(t.Context(), results[idx].valveID, 0)
-				if err != nil {
-					atomic.AddInt64(&results[idx].dropped, 1)
-					return
-				}
-				atomic.AddInt64(&results[idx].granted, 1)
-				u.Release()
-			}()
-		}
-	}
-
-	// Hold long enough for CoDel to enter dropping state
-	time.Sleep(150 * time.Millisecond)
-	unlock.Release()
-	wg.Wait()
-
-	totalGranted := int64(0)
-	totalDropped := int64(0)
-	for _, r := range results {
-		totalGranted += r.granted
-		totalDropped += r.dropped
-		assert.Equal(t, int64(perID), r.granted+r.dropped,
-			"valve %s: granted+dropped should equal perID", r.valveID)
-	}
-
-	assert.Greater(t, totalDropped, int64(0),
-		"cross-ID contention should cause some drops")
-	assert.Equal(t, int64(numIDs*perID), totalGranted+totalDropped)
-}
-
 // --- Memory steady-state: clean baseline after many cycles ---
 
 func TestSnake_Memory_CleanBaseline(t *testing.T) {
@@ -372,7 +310,7 @@ func TestSnake_Memory_CleanBaseline(t *testing.T) {
 
 	// Run many acquire/release cycles
 	for range 1000 {
-		u, err := s.Acquire(t.Context(), "cycle-id", 0)
+		u, err := s.Acquire(t.Context(), 0)
 		require.NoError(t, err)
 		u.Release()
 	}
@@ -383,30 +321,7 @@ func TestSnake_Memory_CleanBaseline(t *testing.T) {
 
 	assert.Empty(t, s.holders, "holders map should be empty after all releases")
 	assert.Equal(t, 0, s.q.lockedLen(), "queue should be empty")
-	assert.Empty(t, s.q.valves, "valves map should be empty")
-	assert.Empty(t, s.q.outstandingCounts, "outstandingCounts map should be empty")
-	assert.Empty(t, s.q.droppablePerValve, "droppablePerValve map should be empty")
 	assert.False(t, s.q.codelq.dropping, "CoDel should not be in dropping state")
-}
-
-// --- Memory: many distinct valve IDs map cleanup ---
-
-func TestSnake_Memory_ManyDistinctValveIDs_Cleanup(t *testing.T) {
-	s := NewSnake(defaultSnakeConfig())
-
-	// Use many distinct valve IDs
-	for i := range 500 {
-		u, err := s.Acquire(t.Context(), fmt.Sprintf("distinct-%d", i), 0)
-		require.NoError(t, err)
-		u.Release()
-	}
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	assert.Empty(t, s.q.valves, "valves should be empty after all releases")
-	assert.Empty(t, s.q.outstandingCounts, "outstandingCounts should be empty after all releases")
-	assert.Empty(t, s.q.droppablePerValve, "droppablePerValve should be empty after all releases")
 }
 
 // --- CoDel state transition: healthy → unhealthy → healthy ---
@@ -422,7 +337,7 @@ func TestSnake_Memory_CoDelStateTransition(t *testing.T) {
 	assert.True(t, s.IsHealthy())
 
 	// Create overload
-	unlock, err := s.Acquire(t.Context(), "", 0)
+	unlock, err := s.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 
 	var wg sync.WaitGroup
@@ -430,7 +345,7 @@ func TestSnake_Memory_CoDelStateTransition(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			u, err := s.Acquire(t.Context(), "", 0)
+			u, err := s.Acquire(t.Context(), 0)
 			if err == nil {
 				u.Release()
 			}
@@ -450,7 +365,7 @@ func TestSnake_Memory_CoDelStateTransition(t *testing.T) {
 	}, 2*time.Second, 10*time.Millisecond, "should recover to healthy after overload resolves")
 
 	// And still usable
-	u, err := s.Acquire(t.Context(), "", 0)
+	u, err := s.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 	u.Release()
 }
@@ -467,7 +382,7 @@ func TestSnake_Overload_GrantStall_ShedsDuringStall(t *testing.T) {
 	// Acquire the only slot (capacity defaults to 1). Once granted, this
 	// holder becomes undroppable and never releases — a stuck in-flight query
 	// that pins the semaphore.
-	holder, err := s.Acquire(t.Context(), "", 0)
+	holder, err := s.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 
 	// Enqueue droppable waiters that can never be granted (capacity pinned)
@@ -482,7 +397,7 @@ func TestSnake_Overload_GrantStall_ShedsDuringStall(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			u, err := s.Acquire(ctx, "", 0)
+			u, err := s.Acquire(ctx, 0)
 			if err != nil {
 				dropped.Add(1)
 				return
@@ -515,7 +430,7 @@ func TestSnake_Overload_GrantStall_ShedsDuringStall(t *testing.T) {
 func TestSnake_NoPanicOnConcurrentCancel(t *testing.T) {
 	s := NewSnake(defaultSnakeConfig())
 
-	unlock, err := s.Acquire(t.Context(), "no-panic", 0)
+	unlock, err := s.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 
 	const n = 50
@@ -527,7 +442,7 @@ func TestSnake_NoPanicOnConcurrentCancel(t *testing.T) {
 			defer wg.Done()
 			ctx, cancel := context.WithTimeout(t.Context(), 2*time.Millisecond)
 			defer cancel()
-			u, err := s.Acquire(ctx, "no-panic", 0)
+			u, err := s.Acquire(ctx, 0)
 			if err == nil {
 				u.Release()
 			}

--- a/go/vt/vttablet/tabletserver/loadshed/snake_race_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_race_test.go
@@ -47,7 +47,7 @@ func TestSnake_CancelVsGrant_Race(t *testing.T) {
 	for range iterations {
 		s := newTestSnake(cfg)
 
-		unlockA, err := s.Acquire(t.Context(), "", 0)
+		unlockA, err := s.Acquire(t.Context(), 0)
 		require.NoError(t, err)
 
 		ctx, cancel := context.WithCancel(t.Context())
@@ -60,7 +60,7 @@ func TestSnake_CancelVsGrant_Race(t *testing.T) {
 
 		go func() {
 			defer wg.Done()
-			unlockB, acquireErr = s.Acquire(ctx, "", 0)
+			unlockB, acquireErr = s.Acquire(ctx, 0)
 		}()
 
 		runtime.Gosched()
@@ -83,7 +83,7 @@ func TestSnake_CancelVsGrant_Race(t *testing.T) {
 
 			// Verify lock is still usable.
 			ctx2, cancel2 := context.WithTimeout(t.Context(), 10*time.Millisecond)
-			unlockC, err2 := s.Acquire(ctx2, "", 0)
+			unlockC, err2 := s.Acquire(ctx2, 0)
 			cancel2()
 			if assert.NoError(t, err2, "lock must remain acquirable") {
 				unlockC.Release()

--- a/go/vt/vttablet/tabletserver/loadshed/snake_stats_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_stats_test.go
@@ -118,7 +118,7 @@ func TestPublishStats_ShedCountTracksDrops(t *testing.T) {
 	// Hold every slot, then pile on contending acquires so CoDel drops some.
 	var unlocks []*SafeUnlock
 	for range 4 {
-		u, err := s.Acquire(t.Context(), "", 0)
+		u, err := s.Acquire(t.Context(), 0)
 		require.NoError(t, err)
 		unlocks = append(unlocks, u)
 	}
@@ -126,7 +126,7 @@ func TestPublishStats_ShedCountTracksDrops(t *testing.T) {
 	errCh := make(chan error, contenders)
 	for range contenders {
 		go func() {
-			_, err := s.Acquire(t.Context(), "", 0)
+			_, err := s.Acquire(t.Context(), 0)
 			errCh <- err
 		}()
 	}
@@ -158,7 +158,7 @@ func TestPublishStats_ShedCountIgnoresContextCancellation(t *testing.T) {
 	shedGauge := exp.counters["SnakeOltpReadShedCount"]
 
 	// Occupy the only slot so the next acquire must wait.
-	unlock, err := s.Acquire(t.Context(), "", 0)
+	unlock, err := s.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 	defer unlock.Release()
 
@@ -166,7 +166,7 @@ func TestPublishStats_ShedCountIgnoresContextCancellation(t *testing.T) {
 	// the caller giving up — not a gate shed — so it must not be counted.
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
-	_, err = s.Acquire(ctx, "", 0)
+	_, err = s.Acquire(ctx, 0)
 	require.Error(t, err)
 
 	assert.Equal(t, int64(0), shedGauge(), "context cancellation must not count as a shed")
@@ -183,7 +183,7 @@ func TestPublishStats_SojournRecordsGrant(t *testing.T) {
 	assert.Equal(t, int64(0), hist.Count(), "no grants before any acquire")
 
 	// A granted request records exactly one sojourn observation.
-	unlock, err := s.Acquire(t.Context(), "", 0)
+	unlock, err := s.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), hist.Count(), "one grant should record one sojourn observation")
 	assert.GreaterOrEqual(t, hist.Total(), int64(0), "sojourn total should be a non-negative duration")
@@ -200,7 +200,7 @@ func TestPublishStats_SojournBucketing(t *testing.T) {
 
 	// A fast, uncontended grant lands in one of the low buckets: well under the
 	// 1ms cutoff. Assert nothing landed at or above the 5ms (5e6) cutoff.
-	unlock, err := s.Acquire(t.Context(), "", 0)
+	unlock, err := s.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 	require.NoError(t, unlock.Release())
 
@@ -223,7 +223,7 @@ func TestNewSnake_DistributionMetricsInitializedBeforePublish(t *testing.T) {
 	require.NotNil(t, s.interval)
 	require.NotNil(t, s.dropCount)
 
-	unlock, err := s.Acquire(t.Context(), "", 0)
+	unlock, err := s.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 	// The detached histograms accumulate even before PublishStats swaps in the
 	// exporter-registered instances.
@@ -247,7 +247,7 @@ func TestPublishStats_QueueAndHolderHistogramsRecord(t *testing.T) {
 
 	// A grant observes both: the enqueue records queue length, the holder insert
 	// records holder count.
-	unlock, err := s.Acquire(t.Context(), "", 0)
+	unlock, err := s.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 	assert.Positive(t, queueLen.Count(), "enqueue should record a queue-length observation")
 	assert.Positive(t, holderCount.Count(), "grant should record a holder-count observation")
@@ -259,69 +259,6 @@ func TestPublishStats_QueueAndHolderHistogramsRecord(t *testing.T) {
 	require.NoError(t, unlock.Release())
 	assert.Greater(t, queueLen.Count(), beforeQueue, "release should record another queue-length observation")
 	assert.Greater(t, holderCount.Count(), beforeHolder, "release should record another holder-count observation")
-}
-
-func TestPublishStats_ValveDepthHistogramRecords(t *testing.T) {
-	// Fast CoDel timing so that at teardown the queued valve entries are shed
-	// promptly (the drop fires on the control-law interval). The default 1s
-	// interval would not drain them within the teardown window — the depth
-	// observations under test are unaffected by the timing.
-	cfg := defaultSnakeConfig() // capacity 1
-	cfg.CoDel.IntervalNs = func() int64 { return 1_000 }
-	cfg.CoDel.TargetNs = func() int64 { return 1 }
-	cfg.CoDel.MinDropDelayNs = func() int64 { return 1 }
-	s := newTestSnake(cfg)
-	exp := newFakeExporter()
-	PublishStats(exp, "SnakeOltpRead", s)
-
-	valveDepth := exp.histograms["SnakeOltpReadValveDepthObserved"]
-	require.NotNil(t, valveDepth)
-	assert.Equal(t, int64(0), valveDepth.Count(), "no observations before any acquire")
-
-	// Occupy the single slot with an empty-valve acquire. This also covers the
-	// exclusion rule: an empty valve ID bypasses the valve and is not observed.
-	holder, err := s.Acquire(t.Context(), "", 0)
-	require.NoError(t, err)
-	assert.Equal(t, int64(0), valveDepth.Count(), "empty valve ID should not record a valve-depth observation")
-
-	// With the slot occupied, a valve-keyed acquire cannot be granted, so it
-	// waits in the CoDel queue as valve "v"'s droppable representative. Its
-	// enqueue records depth 0 (nothing stacked behind it yet). The observation
-	// is synchronous inside Acquire before it blocks, so wait for the count.
-	// Cancelable context so any queued entry left below keepDroppableFloor (never
-	// shed) can be released at teardown rather than hanging.
-	ctx, cancel := context.WithCancel(t.Context())
-	errCh := make(chan error, 2)
-	go func() {
-		_, err := s.Acquire(ctx, "v", 0)
-		errCh <- err
-	}()
-	assert.Eventually(t, func() bool { return valveDepth.Count() == 1 }, 2*time.Second, time.Millisecond,
-		"valve-keyed representative enqueue should record a depth observation")
-	assert.Equal(t, int64(0), valveDepth.Total(), "first valve entry becomes the representative, depth 0")
-
-	// A second acquire on the same valve ID stacks behind the representative
-	// and records depth 1.
-	go func() {
-		_, err := s.Acquire(ctx, "v", 0)
-		errCh <- err
-	}()
-	assert.Eventually(t, func() bool { return valveDepth.Count() == 2 }, 2*time.Second, time.Millisecond,
-		"stacked valve entry should record a second depth observation")
-	assert.Equal(t, int64(1), valveDepth.Total(), "second same-valve entry stacks at depth 1")
-
-	// Release the holder and cancel the context so the queued "v" entries drain
-	// (granted, or shed, or cancelled if kept below the floor) and the goroutines
-	// return. This is teardown; the depth observations above are the assertions.
-	require.NoError(t, holder.Release())
-	cancel()
-	for range 2 {
-		select {
-		case <-errCh:
-		case <-time.After(2 * time.Second):
-			t.Fatal("queued goroutine did not return")
-		}
-	}
 }
 
 func TestPublishStats_DroppableAndIntervalHistogramsRecordUnderLoad(t *testing.T) {
@@ -349,7 +286,7 @@ func TestPublishStats_DroppableAndIntervalHistogramsRecordUnderLoad(t *testing.T
 	// timer fires (recording interval and drop-count observations).
 	var unlocks []*SafeUnlock
 	for range 4 {
-		u, err := s.Acquire(t.Context(), "", 0)
+		u, err := s.Acquire(t.Context(), 0)
 		require.NoError(t, err)
 		unlocks = append(unlocks, u)
 	}
@@ -357,7 +294,7 @@ func TestPublishStats_DroppableAndIntervalHistogramsRecordUnderLoad(t *testing.T
 	errCh := make(chan error, contenders)
 	for range contenders {
 		go func() {
-			_, err := s.Acquire(t.Context(), "", 0)
+			_, err := s.Acquire(t.Context(), 0)
 			errCh <- err
 		}()
 	}
@@ -422,7 +359,7 @@ func TestPublishStats_DroppingNanosAdvancesDuringEpisode(t *testing.T) {
 	// Drive a dropping episode: hold every slot and pile on contenders.
 	var unlocks []*SafeUnlock
 	for range 4 {
-		u, err := s.Acquire(t.Context(), "", 0)
+		u, err := s.Acquire(t.Context(), 0)
 		require.NoError(t, err)
 		unlocks = append(unlocks, u)
 	}
@@ -430,7 +367,7 @@ func TestPublishStats_DroppingNanosAdvancesDuringEpisode(t *testing.T) {
 	errCh := make(chan error, contenders)
 	for range contenders {
 		go func() {
-			_, err := s.Acquire(t.Context(), "", 0)
+			_, err := s.Acquire(t.Context(), 0)
 			errCh <- err
 		}()
 	}

--- a/go/vt/vttablet/tabletserver/loadshed/snake_stress_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_stress_test.go
@@ -18,7 +18,6 @@ package loadshed
 
 import (
 	"context"
-	"fmt"
 	"math/rand/v2"
 	"runtime"
 	"sync"
@@ -43,7 +42,7 @@ func TestSnake_Stress_HighContention(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			u, err := s.Acquire(t.Context(), "", 0)
+			u, err := s.Acquire(t.Context(), 0)
 			if err != nil {
 				return
 			}
@@ -74,7 +73,7 @@ func TestSnake_Stress_HighContention_TriggerGated(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			u, err := s.Acquire(t.Context(), "", 0)
+			u, err := s.Acquire(t.Context(), 0)
 			if err != nil {
 				dropped.Add(1)
 				return
@@ -110,7 +109,7 @@ func TestSnake_Stress_ContextCancellation(t *testing.T) {
 				time.Duration(1+rand.IntN(5))*time.Millisecond)
 			defer cancel()
 
-			u, err := s.Acquire(ctx, "", 0)
+			u, err := s.Acquire(ctx, 0)
 			if err != nil {
 				cancelled.Add(1)
 				return
@@ -143,7 +142,7 @@ func TestSnake_Stress_MixedPriorities(t *testing.T) {
 	undroppableCfg.LoadsheddingAllowed = func() bool { return false }
 	undroppableSnake := NewSnake(undroppableCfg)
 
-	unlock, err := droppableSnake.Acquire(t.Context(), "", 0)
+	unlock, err := droppableSnake.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 
 	var wg sync.WaitGroup
@@ -153,7 +152,7 @@ func TestSnake_Stress_MixedPriorities(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			u, err := droppableSnake.Acquire(t.Context(), "", 0)
+			u, err := droppableSnake.Acquire(t.Context(), 0)
 			if err != nil {
 				droppableFailed.Add(1)
 				return
@@ -170,7 +169,7 @@ func TestSnake_Stress_MixedPriorities(t *testing.T) {
 	assert.Equal(t, int64(50), droppableSuccess.Load()+droppableFailed.Load())
 	assert.True(t, droppableSnake.isIdle())
 
-	unlock2, err := undroppableSnake.Acquire(t.Context(), "", 0)
+	unlock2, err := undroppableSnake.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 
 	var undroppableSuccess atomic.Int64
@@ -178,7 +177,7 @@ func TestSnake_Stress_MixedPriorities(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			u, err := undroppableSnake.Acquire(t.Context(), "", 0)
+			u, err := undroppableSnake.Acquire(t.Context(), 0)
 			if err != nil {
 				return
 			}
@@ -195,320 +194,6 @@ func TestSnake_Stress_MixedPriorities(t *testing.T) {
 	assert.True(t, undroppableSnake.isIdle())
 }
 
-// --- Self-contention ---
-
-func TestSnake_Stress_SelfContention_MutualExclusion(t *testing.T) {
-	s := NewSnake(defaultSnakeConfig())
-
-	var wg sync.WaitGroup
-	var globalHeld atomic.Int32
-	var globalMax atomic.Int32
-	var completed atomic.Int64
-
-	type perID struct {
-		held atomic.Int32
-		max  atomic.Int32
-	}
-	ids := make([]*perID, 10)
-	for i := range ids {
-		ids[i] = &perID{}
-	}
-
-	for id := range 10 {
-		for range 10 {
-			cid := fmt.Sprintf("id%d", id)
-			pid := ids[id]
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				u, err := s.Acquire(t.Context(), cid, 0)
-				if err != nil {
-					return
-				}
-
-				gv := globalHeld.Add(1)
-				if gv > globalMax.Load() {
-					globalMax.Store(gv)
-				}
-				pv := pid.held.Add(1)
-				if pv > pid.max.Load() {
-					pid.max.Store(pv)
-				}
-
-				time.Sleep(time.Duration(1+rand.IntN(5)) * time.Millisecond)
-
-				pid.held.Add(-1)
-				globalHeld.Add(-1)
-				u.Release()
-				completed.Add(1)
-			}()
-		}
-	}
-
-	wg.Wait()
-	assert.Equal(t, int64(100), completed.Load())
-	assert.LessOrEqual(t, globalMax.Load(), int32(1), "mutual exclusion violated")
-	for id, pid := range ids {
-		assert.LessOrEqual(t, pid.max.Load(), int32(1),
-			"contention ID %d had concurrent holders", id)
-	}
-	assert.True(t, s.isIdle())
-}
-
-func TestSnake_Stress_SelfContention_ValveSerializationOrder(t *testing.T) {
-	s := NewSnake(defaultSnakeConfig())
-
-	unlock, err := s.Acquire(t.Context(), "order-test", 0)
-	require.NoError(t, err)
-
-	const n = 20
-	var mu sync.Mutex
-	var order []int
-	var wg sync.WaitGroup
-
-	for i := range n {
-		time.Sleep(2 * time.Millisecond)
-		idx := i
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			u, err := s.Acquire(t.Context(), "order-test", 0)
-			if err != nil {
-				return
-			}
-			mu.Lock()
-			order = append(order, idx)
-			mu.Unlock()
-			u.Release()
-		}()
-	}
-
-	time.Sleep(50 * time.Millisecond)
-	unlock.Release()
-	wg.Wait()
-
-	expected := make([]int, n)
-	for i := range n {
-		expected[i] = i
-	}
-	assert.Equal(t, expected, order, "valve should preserve FIFO order within contention ID")
-	assert.True(t, s.isIdle())
-}
-
-func TestSnake_Stress_SelfContention_DropPromotionChain(t *testing.T) {
-	cfg := defaultSnakeConfig()
-	cfg.CoDel.IntervalNs = func() int64 { return 1_000 }     // 1us
-	cfg.CoDel.TargetNs = func() int64 { return 1 }           // 1ns
-	cfg.CoDel.MinDropDelayNs = func() int64 { return 1_000 } // 1us
-	s := NewSnake(cfg)
-
-	unlock, err := s.Acquire(t.Context(), "holder", 0)
-	require.NoError(t, err)
-
-	const numIDs = 5
-	const perID = 10
-	type result struct {
-		id      int
-		granted bool
-	}
-	results := make(chan result, numIDs*perID)
-
-	var wg sync.WaitGroup
-	for id := range numIDs {
-		for range perID {
-			cid := fmt.Sprintf("drop-id%d", id)
-			idx := id
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				u, err := s.Acquire(t.Context(), cid, 0)
-				if err != nil {
-					results <- result{id: idx, granted: false}
-					return
-				}
-				time.Sleep(time.Duration(1+rand.IntN(3)) * time.Millisecond)
-				u.Release()
-				results <- result{id: idx, granted: true}
-			}()
-		}
-	}
-
-	time.Sleep(100 * time.Millisecond)
-	unlock.Release()
-	wg.Wait()
-	close(results)
-
-	granted := make([]int, numIDs)
-	dropped := make([]int, numIDs)
-	for r := range results {
-		if r.granted {
-			granted[r.id]++
-		} else {
-			dropped[r.id]++
-		}
-	}
-
-	for id := range numIDs {
-		total := granted[id] + dropped[id]
-		assert.Equal(t, perID, total,
-			"contention ID %d: granted(%d) + dropped(%d) != total(%d)",
-			id, granted[id], dropped[id], perID)
-	}
-	assert.True(t, s.isIdle())
-}
-
-func TestSnake_Stress_SelfContention_CancelInValve(t *testing.T) {
-	s := NewSnake(defaultSnakeConfig())
-
-	unlock, err := s.Acquire(t.Context(), "cancel-test", 0)
-	require.NoError(t, err)
-
-	const n = 20
-	ctxs := make([]context.Context, n)
-	cancels := make([]context.CancelFunc, n)
-	results := make([]chan error, n)
-
-	var wg sync.WaitGroup
-	for i := range n {
-		ctxs[i], cancels[i] = context.WithCancel(t.Context())
-		results[i] = make(chan error, 1)
-		idx := i
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			u, err := s.Acquire(ctxs[idx], "cancel-test", 0)
-			if err != nil {
-				results[idx] <- err
-				return
-			}
-			time.Sleep(time.Millisecond)
-			u.Release()
-			results[idx] <- nil
-		}()
-		time.Sleep(2 * time.Millisecond)
-	}
-
-	time.Sleep(20 * time.Millisecond)
-
-	for i := 0; i < n; i += 2 {
-		cancels[i]()
-	}
-
-	time.Sleep(20 * time.Millisecond)
-	unlock.Release()
-	wg.Wait()
-
-	for i := range n {
-		select {
-		case err := <-results[i]:
-			if i%2 == 0 {
-				assert.ErrorIs(t, err, context.Canceled,
-					"waiter %d should have been cancelled", i)
-			} else {
-				assert.NoError(t, err,
-					"waiter %d should have been granted", i)
-			}
-		case <-time.After(30 * time.Second):
-			t.Fatalf("waiter %d did not return", i)
-		}
-	}
-	assert.True(t, s.isIdle())
-}
-
-func TestSnake_Stress_SelfContention_MixedCancelDropGrant(t *testing.T) {
-	cfg := defaultSnakeConfig()
-	cfg.CoDel.IntervalNs = func() int64 { return 5_000_000 }   // 5ms
-	cfg.CoDel.TargetNs = func() int64 { return 500_000 }       // 0.5ms
-	cfg.CoDel.MinDropDelayNs = func() int64 { return 100_000 } // 0.1ms
-	s := NewSnake(cfg)
-
-	const numIDs = 5
-	const perID = 8
-	const total = numIDs * perID
-
-	var granted, dropped, cancelled atomic.Int64
-	var wg sync.WaitGroup
-
-	for id := range numIDs {
-		for range perID {
-			cid := fmt.Sprintf("mix-id%d", id)
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				timeout := time.Duration(1+rand.IntN(20)) * time.Millisecond
-				ctx, cancel := context.WithTimeout(t.Context(), timeout)
-				defer cancel()
-
-				u, err := s.Acquire(ctx, cid, 0)
-				if err != nil {
-					if ctx.Err() != nil {
-						cancelled.Add(1)
-					} else {
-						dropped.Add(1)
-					}
-					return
-				}
-				time.Sleep(time.Duration(1+rand.IntN(5)) * time.Millisecond)
-				u.Release()
-				granted.Add(1)
-			}()
-		}
-	}
-
-	wg.Wait()
-
-	g, d, c := granted.Load(), dropped.Load(), cancelled.Load()
-	assert.Equal(t, int64(total), g+d+c,
-		"granted(%d) + dropped(%d) + cancelled(%d) != total(%d)", g, d, c, total)
-	assert.True(t, s.isIdle())
-}
-
-func TestSnake_Stress_SelfContention_HighConcurrency_Sustained(t *testing.T) {
-	s := NewSnake(defaultSnakeConfig())
-
-	const numIDs = 5
-	const goroutinesPerID = 4
-	deadline := time.Now().Add(500 * time.Millisecond)
-
-	var globalHeld atomic.Int32
-	var globalMax atomic.Int32
-	var totalAcquires atomic.Int64
-	var wg sync.WaitGroup
-
-	for id := range numIDs {
-		for range goroutinesPerID {
-			cid := fmt.Sprintf("sustained-id%d", id)
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				for time.Now().Before(deadline) {
-					u, err := s.Acquire(t.Context(), cid, 0)
-					if err != nil {
-						continue
-					}
-
-					v := globalHeld.Add(1)
-					if v > globalMax.Load() {
-						globalMax.Store(v)
-					}
-
-					time.Sleep(time.Duration(500+rand.IntN(1500)) * time.Microsecond)
-
-					globalHeld.Add(-1)
-					u.Release()
-					totalAcquires.Add(1)
-				}
-			}()
-		}
-	}
-
-	wg.Wait()
-	assert.LessOrEqual(t, globalMax.Load(), int32(1), "mutual exclusion violated")
-	assert.Greater(t, totalAcquires.Load(), int64(50),
-		"too few acquires — test may not be exercising contention")
-	assert.True(t, s.isIdle())
-}
-
 // --- Rapid acquire/release ---
 
 func TestSnake_Stress_RapidAcquireRelease(t *testing.T) {
@@ -520,7 +205,7 @@ func TestSnake_Stress_RapidAcquireRelease(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for range 100 {
-				u, err := s.Acquire(t.Context(), "", 0)
+				u, err := s.Acquire(t.Context(), 0)
 				if err != nil {
 					continue
 				}
@@ -549,7 +234,7 @@ func TestSnake_Stress_CancelAndGrant_Race(t *testing.T) {
 				cancel()
 			}()
 
-			u, err := s.Acquire(ctx, "", 0)
+			u, err := s.Acquire(ctx, 0)
 			if err == nil {
 				time.Sleep(100 * time.Microsecond)
 				u.Release()
@@ -570,7 +255,7 @@ func TestSnake_Stress_DropTimerAndCancel_Race(t *testing.T) {
 	cfg.CoDel.MinDropDelayNs = func() int64 { return 1_000 } // 1us
 	s := NewSnake(cfg)
 
-	unlock, err := s.Acquire(t.Context(), "", 0)
+	unlock, err := s.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 
 	var wg sync.WaitGroup
@@ -581,7 +266,7 @@ func TestSnake_Stress_DropTimerAndCancel_Race(t *testing.T) {
 			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Millisecond)
 			defer cancel()
 
-			u, err := s.Acquire(ctx, "", 0)
+			u, err := s.Acquire(ctx, 0)
 			if err == nil {
 				u.Release()
 			}
@@ -592,35 +277,6 @@ func TestSnake_Stress_DropTimerAndCancel_Race(t *testing.T) {
 	unlock.Release()
 	wg.Wait()
 
-	assert.True(t, s.isIdle())
-}
-
-// --- Self-contention with drops ---
-
-func TestSnake_Stress_SelfContention_WithDrops(t *testing.T) {
-	cfg := defaultSnakeConfig()
-	cfg.CoDel.IntervalNs = func() int64 { return 10_000_000 }  // 10ms
-	cfg.CoDel.TargetNs = func() int64 { return 1_000_000 }     // 1ms
-	cfg.CoDel.MinDropDelayNs = func() int64 { return 100_000 } // 0.1ms
-	s := NewSnake(cfg)
-
-	var wg sync.WaitGroup
-
-	for i := range 30 {
-		cid := fmt.Sprintf("id%d", i%5)
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			u, err := s.Acquire(t.Context(), cid, 0)
-			if err != nil {
-				return
-			}
-			time.Sleep(time.Duration(1+rand.IntN(5)) * time.Millisecond)
-			u.Release()
-		}()
-	}
-
-	wg.Wait()
 	assert.True(t, s.isIdle())
 }
 
@@ -638,7 +294,7 @@ func TestSnake_Stress_GoroutineLeakDetector(t *testing.T) {
 			defer wg.Done()
 			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
 			defer cancel()
-			u, err := s.Acquire(ctx, "", 0)
+			u, err := s.Acquire(ctx, 0)
 			if err == nil {
 				time.Sleep(time.Millisecond)
 				u.Release()
@@ -671,7 +327,7 @@ func TestSnake_Stress_NoStarvation(t *testing.T) {
 			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 			defer cancel()
 
-			u, err := s.Acquire(ctx, "", 0)
+			u, err := s.Acquire(ctx, 0)
 			if err != nil {
 				return
 			}
@@ -690,42 +346,4 @@ func TestSnake_Stress_NoStarvation(t *testing.T) {
 		}
 	}
 	assert.Equal(t, 100, acquired, "some goroutines were starved")
-}
-
-// --- Promotion during cancel ---
-
-func TestSnake_Stress_PromotionDuringCancel(t *testing.T) {
-	s := NewSnake(defaultSnakeConfig())
-
-	unlock, err := s.Acquire(t.Context(), "id1", 0)
-	require.NoError(t, err)
-
-	var wg sync.WaitGroup
-
-	ctxs := make([]context.CancelFunc, 20)
-	for i := range 20 {
-		var ctx context.Context
-		ctx, ctxs[i] = context.WithCancel(t.Context())
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			u, err := s.Acquire(ctx, "id1", 0)
-			if err == nil {
-				time.Sleep(time.Millisecond)
-				u.Release()
-			}
-		}()
-	}
-
-	time.Sleep(10 * time.Millisecond)
-
-	for i := 0; i < 20; i += 2 {
-		ctxs[i]()
-	}
-
-	time.Sleep(10 * time.Millisecond)
-	unlock.Release()
-	wg.Wait()
-
-	assert.True(t, s.isIdle())
 }

--- a/go/vt/vttablet/tabletserver/loadshed/snake_syncshed_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_syncshed_test.go
@@ -44,7 +44,7 @@ func TestSnake_SyncShedOnRelease(t *testing.T) {
 	s.q.codelq.nowNs = now.Load // queue uses defaultClock otherwise — keep clocks consistent
 
 	// Grant the single slot to a holder we control.
-	holder, err := s.Acquire(t.Context(), "", 0)
+	holder, err := s.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 
 	// Enqueue several droppable waiters directly into the queue and force the

--- a/go/vt/vttablet/tabletserver/loadshed/snake_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_test.go
@@ -63,7 +63,7 @@ func TestSnake_AcquireRelease_Basic(t *testing.T) {
 
 	assert.True(t, s.isIdle())
 
-	unlock, err := s.Acquire(t.Context(), "", 0)
+	unlock, err := s.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 	assert.False(t, s.isIdle())
 
@@ -76,7 +76,7 @@ func TestSnake_AcquireRelease_Sequential(t *testing.T) {
 	s := newTestSnake(defaultSnakeConfig())
 
 	for range 10 {
-		unlock, err := s.Acquire(t.Context(), "", 0)
+		unlock, err := s.Acquire(t.Context(), 0)
 		require.NoError(t, err)
 		assert.False(t, s.isIdle())
 
@@ -98,7 +98,7 @@ func TestSnake_MutualExclusion(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			unlock, err := s.Acquire(t.Context(), "", 0)
+			unlock, err := s.Acquire(t.Context(), 0)
 			if err != nil {
 				return
 			}
@@ -120,7 +120,7 @@ func TestSnake_MutualExclusion(t *testing.T) {
 func TestSnake_FIFO_Order(t *testing.T) {
 	s := newTestSnake(defaultSnakeConfig())
 
-	unlock1, err := s.Acquire(t.Context(), "", 0)
+	unlock1, err := s.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 
 	var mu sync.Mutex
@@ -133,7 +133,7 @@ func TestSnake_FIFO_Order(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			u, err := s.Acquire(t.Context(), "", 0)
+			u, err := s.Acquire(t.Context(), 0)
 			if err != nil {
 				return
 			}
@@ -157,12 +157,12 @@ func TestSnake_FIFO_Order(t *testing.T) {
 func TestSnake_ReleaseWakesNext(t *testing.T) {
 	s := newTestSnake(defaultSnakeConfig())
 
-	unlock1, err := s.Acquire(t.Context(), "", 0)
+	unlock1, err := s.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 
 	acquired := make(chan struct{})
 	go func() {
-		u, err := s.Acquire(t.Context(), "", 0)
+		u, err := s.Acquire(t.Context(), 0)
 		if err == nil {
 			close(acquired)
 			u.Release()
@@ -189,14 +189,14 @@ func TestSnake_ReleaseWakesNext(t *testing.T) {
 func TestSnake_ContextCancellation(t *testing.T) {
 	s := newTestSnake(defaultSnakeConfig())
 
-	unlock, err := s.Acquire(t.Context(), "", 0)
+	unlock, err := s.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(t.Context())
 
 	errCh := make(chan error, 1)
 	go func() {
-		_, err := s.Acquire(ctx, "", 0)
+		_, err := s.Acquire(ctx, 0)
 		errCh <- err
 	}()
 
@@ -218,13 +218,13 @@ func TestSnake_ContextCancellation(t *testing.T) {
 func TestSnake_ContextTimeout(t *testing.T) {
 	s := newTestSnake(defaultSnakeConfig())
 
-	unlock, err := s.Acquire(t.Context(), "", 0)
+	unlock, err := s.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
 	defer cancel()
 
-	_, err = s.Acquire(ctx, "", 0)
+	_, err = s.Acquire(ctx, 0)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 
 	unlock.Release()
@@ -235,14 +235,14 @@ func TestSnake_ContextTimeout(t *testing.T) {
 func TestSnake_ContextCancel_RaceWithGrant(t *testing.T) {
 	s := newTestSnake(defaultSnakeConfig())
 
-	unlock1, err := s.Acquire(t.Context(), "", 0)
+	unlock1, err := s.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(t.Context())
 
 	waiter2Done := make(chan error, 1)
 	go func() {
-		u, err := s.Acquire(ctx, "", 0)
+		u, err := s.Acquire(ctx, 0)
 		if err == nil {
 			u.Release()
 		}
@@ -251,7 +251,7 @@ func TestSnake_ContextCancel_RaceWithGrant(t *testing.T) {
 
 	waiter3Done := make(chan struct{})
 	go func() {
-		u, err := s.Acquire(t.Context(), "", 0)
+		u, err := s.Acquire(t.Context(), 0)
 		if err == nil {
 			u.Release()
 		}
@@ -278,71 +278,6 @@ func TestSnake_ContextCancel_RaceWithGrant(t *testing.T) {
 	assert.True(t, s.isIdle())
 }
 
-// --- Self-contention ---
-
-func TestSnake_SelfContention_Serialized(t *testing.T) {
-	s := newTestSnake(defaultSnakeConfig())
-
-	unlock1, err := s.Acquire(t.Context(), "id1", 0)
-	require.NoError(t, err)
-
-	var mu sync.Mutex
-	var order []int
-
-	var wg sync.WaitGroup
-	for i := range 3 {
-		time.Sleep(2 * time.Millisecond)
-		idx := i
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			u, err := s.Acquire(t.Context(), "id1", 0)
-			if err != nil {
-				return
-			}
-			mu.Lock()
-			order = append(order, idx)
-			mu.Unlock()
-			u.Release()
-		}()
-	}
-
-	time.Sleep(20 * time.Millisecond)
-	unlock1.Release()
-	wg.Wait()
-
-	assert.Equal(t, []int{0, 1, 2}, order)
-}
-
-func TestSnake_SelfContention_DifferentIDs_Independent(t *testing.T) {
-	s := newTestSnake(defaultSnakeConfig())
-
-	unlock1, err := s.Acquire(t.Context(), "", 0)
-	require.NoError(t, err)
-
-	acquired := make(chan struct{}, 2)
-	var wg sync.WaitGroup
-	for i := range 2 {
-		valveID := string(rune('a' + i))
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			u, err := s.Acquire(t.Context(), valveID, 0)
-			if err != nil {
-				return
-			}
-			acquired <- struct{}{}
-			u.Release()
-		}()
-	}
-
-	time.Sleep(10 * time.Millisecond)
-	unlock1.Release()
-	wg.Wait()
-
-	assert.Equal(t, 2, len(acquired))
-}
-
 // --- CoDel drop ---
 
 func TestSnake_DroppedRequest(t *testing.T) {
@@ -359,7 +294,7 @@ func TestSnake_DroppedRequest(t *testing.T) {
 
 	var unlocks []*SafeUnlock
 	for range 4 {
-		u, err := s.Acquire(t.Context(), "", 0)
+		u, err := s.Acquire(t.Context(), 0)
 		require.NoError(t, err)
 		unlocks = append(unlocks, u)
 	}
@@ -367,7 +302,7 @@ func TestSnake_DroppedRequest(t *testing.T) {
 	errCh := make(chan error, contenders)
 	for range contenders {
 		go func() {
-			_, err := s.Acquire(t.Context(), "", 0)
+			_, err := s.Acquire(t.Context(), 0)
 			errCh <- err
 		}()
 	}
@@ -394,51 +329,12 @@ func TestSnake_DroppedRequest(t *testing.T) {
 	assert.Greater(t, dropped, 0, "CoDel should have dropped some requests")
 }
 
-func TestSnake_SelfContention_NoDrop(t *testing.T) {
-	// Valve serialization: 3 same-ID requests serialize through the valve so only
-	// ONE droppable entry is in the CoDel queue at a time. With a target well above
-	// the per-holder execution time (~1ms), each promoted entry's sojourn is below
-	// target, keeping CoDel in healthy state and preventing drops.
-	cfg := defaultSnakeConfig()
-	cfg.CoDel.IntervalNs = func() int64 { return 100_000_000 }   // 100ms
-	cfg.CoDel.TargetNs = func() int64 { return 10_000_000 }      // 10ms
-	cfg.CoDel.MinDropDelayNs = func() int64 { return 1_000_000 } // 1ms
-	s := newTestSnake(cfg)
-
-	unlock, err := s.Acquire(t.Context(), "same-id", 0)
-	require.NoError(t, err)
-
-	results := make(chan error, 3)
-	for range 3 {
-		go func() {
-			u, err := s.Acquire(t.Context(), "same-id", 0)
-			if err == nil {
-				time.Sleep(1 * time.Millisecond)
-				u.Release()
-			}
-			results <- err
-		}()
-	}
-
-	time.Sleep(5 * time.Millisecond)
-	unlock.Release()
-
-	for range 3 {
-		select {
-		case err := <-results:
-			assert.NoError(t, err, "same valve ID should not be dropped")
-		case <-time.After(2 * time.Second):
-			t.Fatal("goroutine did not return")
-		}
-	}
-}
-
 // --- SafeUnlock ---
 
 func TestSnake_SafeUnlock_DoubleRelease(t *testing.T) {
 	s := newTestSnake(defaultSnakeConfig())
 
-	unlock, err := s.Acquire(t.Context(), "", 0)
+	unlock, err := s.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 
 	err = unlock.Release()
@@ -451,12 +347,12 @@ func TestSnake_SafeUnlock_DoubleRelease(t *testing.T) {
 func TestSnake_SafeUnlock_StaleNonce(t *testing.T) {
 	s := newTestSnake(defaultSnakeConfig())
 
-	unlock1, err := s.Acquire(t.Context(), "", 0)
+	unlock1, err := s.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 
 	acquired := make(chan *SafeUnlock, 1)
 	go func() {
-		u, err := s.Acquire(t.Context(), "", 0)
+		u, err := s.Acquire(t.Context(), 0)
 		if err == nil {
 			acquired <- u
 		}
@@ -488,7 +384,7 @@ func TestSnake_ReleaseCallbacks_Executed(t *testing.T) {
 	}
 	s := newTestSnake(cfg)
 
-	unlock, err := s.Acquire(t.Context(), "", 0)
+	unlock, err := s.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 
 	unlock.Release()
@@ -503,7 +399,7 @@ func TestSnake_ReleaseCallbacks_ReceiveError(t *testing.T) {
 	}
 	s := newTestSnake(cfg)
 
-	unlock, err := s.Acquire(t.Context(), "", 0)
+	unlock, err := s.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 
 	myErr := errors.New("test error")
@@ -528,7 +424,7 @@ func TestSnake_ReleaseCallbacks_NilOnNormalRelease(t *testing.T) {
 	}
 	s := newTestSnake(cfg)
 
-	unlock, err := s.Acquire(t.Context(), "", 0)
+	unlock, err := s.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 
 	unlock.Release()
@@ -545,7 +441,7 @@ func TestSnake_ReleaseCallbacks_PanicRecovery(t *testing.T) {
 	}
 	s := newTestSnake(cfg)
 
-	unlock, err := s.Acquire(t.Context(), "", 0)
+	unlock, err := s.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 
 	err = unlock.Release()
@@ -561,7 +457,7 @@ func TestSnake_ReleaseCallbacks_NoDeadlock(t *testing.T) {
 	}
 	s := newTestSnake(cfg)
 
-	unlock, err := s.Acquire(t.Context(), "", 0)
+	unlock, err := s.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 
 	done := make(chan struct{})
@@ -585,7 +481,7 @@ func TestSnake_IsIdle_IsHealthy(t *testing.T) {
 	assert.True(t, s.isIdle())
 	assert.True(t, s.IsHealthy())
 
-	unlock, err := s.Acquire(t.Context(), "", 0)
+	unlock, err := s.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 
 	assert.False(t, s.isIdle())
@@ -600,19 +496,19 @@ func TestSnake_IsIdle_IsHealthy(t *testing.T) {
 func TestSnake_CancelInCoDelQueue(t *testing.T) {
 	s := newTestSnake(defaultSnakeConfig())
 
-	unlock1, err := s.Acquire(t.Context(), "", 0)
+	unlock1, err := s.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 
 	ctx2, cancel2 := context.WithCancel(t.Context())
 	waiter2Done := make(chan error, 1)
 	go func() {
-		_, err := s.Acquire(ctx2, "", 0)
+		_, err := s.Acquire(ctx2, 0)
 		waiter2Done <- err
 	}()
 
 	waiter3Done := make(chan struct{})
 	go func() {
-		u, err := s.Acquire(t.Context(), "", 0)
+		u, err := s.Acquire(t.Context(), 0)
 		if err == nil {
 			close(waiter3Done)
 			u.Release()
@@ -639,70 +535,6 @@ func TestSnake_CancelInCoDelQueue(t *testing.T) {
 	}
 }
 
-// --- Cancel in valve ---
-
-func TestSnake_CancelInValve(t *testing.T) {
-	s := newTestSnake(defaultSnakeConfig())
-
-	unlock1, err := s.Acquire(t.Context(), "id1", 0)
-	require.NoError(t, err)
-
-	ctx3, cancel3 := context.WithCancel(t.Context())
-
-	waiter2Done := make(chan struct{})
-	go func() {
-		u, err := s.Acquire(t.Context(), "id1", 0)
-		if err == nil {
-			u.Release()
-		}
-		close(waiter2Done)
-	}()
-
-	time.Sleep(5 * time.Millisecond)
-
-	waiter3Done := make(chan error, 1)
-	go func() {
-		_, err := s.Acquire(ctx3, "id1", 0)
-		waiter3Done <- err
-	}()
-
-	time.Sleep(5 * time.Millisecond)
-
-	waiter4Done := make(chan struct{})
-	go func() {
-		u, err := s.Acquire(t.Context(), "id1", 0)
-		if err == nil {
-			u.Release()
-		}
-		close(waiter4Done)
-	}()
-
-	time.Sleep(5 * time.Millisecond)
-
-	cancel3()
-
-	select {
-	case err := <-waiter3Done:
-		assert.ErrorIs(t, err, context.Canceled)
-	case <-time.After(1 * time.Second):
-		t.Fatal("waiter3 cancel did not return")
-	}
-
-	unlock1.Release()
-
-	select {
-	case <-waiter2Done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("waiter2 did not complete")
-	}
-
-	select {
-	case <-waiter4Done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("waiter4 did not complete")
-	}
-}
-
 // --- Undroppable ---
 
 func TestSnake_Undroppable_NeverDropped(t *testing.T) {
@@ -713,13 +545,13 @@ func TestSnake_Undroppable_NeverDropped(t *testing.T) {
 	cfg.LoadsheddingAllowed = func() bool { return false }
 	s := newTestSnake(cfg)
 
-	unlock, err := s.Acquire(t.Context(), "", 0)
+	unlock, err := s.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 
 	results := make(chan error, 5)
 	for range 5 {
 		go func() {
-			u, err := s.Acquire(t.Context(), "", 0)
+			u, err := s.Acquire(t.Context(), 0)
 			if err == nil {
 				u.Release()
 			}
@@ -758,7 +590,7 @@ func TestSnake_AcquireError_Custom(t *testing.T) {
 
 	var unlocks []*SafeUnlock
 	for range 4 {
-		u, err := s.Acquire(t.Context(), "", 0)
+		u, err := s.Acquire(t.Context(), 0)
 		require.NoError(t, err)
 		unlocks = append(unlocks, u)
 	}
@@ -766,7 +598,7 @@ func TestSnake_AcquireError_Custom(t *testing.T) {
 	errCh := make(chan error, contenders)
 	for range contenders {
 		go func() {
-			_, err := s.Acquire(t.Context(), "", 0)
+			_, err := s.Acquire(t.Context(), 0)
 			errCh <- err
 		}()
 	}
@@ -795,48 +627,12 @@ func TestSnake_AcquireError_Custom(t *testing.T) {
 	}
 }
 
-// --- Self-contention: exceptions during hold ---
-
-func TestSnake_SelfContention_WithExceptions(t *testing.T) {
-	s := newTestSnake(defaultSnakeConfig())
-
-	var mu sync.Mutex
-	var order []int
-
-	unlock1, err := s.Acquire(t.Context(), "id1", 0)
-	require.NoError(t, err)
-
-	var wg sync.WaitGroup
-	for i := 2; i <= 4; i++ {
-		time.Sleep(2 * time.Millisecond)
-		idx := i
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			u, err := s.Acquire(t.Context(), "id1", 0)
-			if err != nil {
-				return
-			}
-			mu.Lock()
-			order = append(order, idx)
-			mu.Unlock()
-			u.Release(errors.New("simulated error"))
-		}()
-	}
-
-	time.Sleep(20 * time.Millisecond)
-	unlock1.Release(errors.New("first error"))
-	wg.Wait()
-
-	assert.Equal(t, []int{2, 3, 4}, order, "all waiters should complete despite errors")
-}
-
 // --- NewSnake (default clock) ---
 
 func TestNewSnake_DefaultClock(t *testing.T) {
 	s := NewSnake(defaultSnakeConfig())
 
-	unlock, err := s.Acquire(t.Context(), "", 0)
+	unlock, err := s.Acquire(t.Context(), 0)
 	require.NoError(t, err)
 	assert.False(t, s.isIdle())
 

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -124,11 +124,15 @@ func isValid(planType planbuilder.PlanType, hasReservedCon bool, hasSysSettings 
 
 // _______________________________________________
 
-type PlanCacheKey = theine.StringKey
-type PlanCache = theine.Store[PlanCacheKey, *TabletPlan]
+type (
+	PlanCacheKey = theine.StringKey
+	PlanCache    = theine.Store[PlanCacheKey, *TabletPlan]
+)
 
-type SettingsCacheKey = theine.StringKey
-type SettingsCache = theine.Store[SettingsCacheKey, *smartconnpool.Setting]
+type (
+	SettingsCacheKey = theine.StringKey
+	SettingsCache    = theine.Store[SettingsCacheKey, *smartconnpool.Setting]
+)
 
 type currentSchema struct {
 	tables map[string]*schema.Table
@@ -224,7 +228,7 @@ func NewQueryEngine(env tabletenv.Env, se *schema.Engine) *QueryEngine {
 	// cache for connection settings: default to 1/4th of the size for the query cache and do
 	// not use a doorkeeper because custom connection settings are rarely one-off and we always
 	// want to cache them
-	var settingsCacheMemory = config.QueryCacheMemory / 4
+	settingsCacheMemory := config.QueryCacheMemory / 4
 	qe.settings = theine.NewStore[SettingsCacheKey, *smartconnpool.Setting](settingsCacheMemory, false)
 
 	qe.schema.Store(&currentSchema{
@@ -270,6 +274,7 @@ func NewQueryEngine(env tabletenv.Env, se *schema.Engine) *QueryEngine {
 			LoadsheddingAllowed: func() bool { return true },
 		})
 		loadshed.PublishStats(env.Exporter(), "SnakeOltpRead", qe.snake)
+		qe.conns.SetSnake(qe.snake, snakePriorityFromOptions(nil, config.TxThrottlerDefaultPriority))
 	}
 
 	qe.strictTableACL = config.StrictTableACL
@@ -362,7 +367,7 @@ func (qe *QueryEngine) Open() error {
 
 	qe.conns.Open(config.DB.AppWithDB(), config.DB.DbaWithDB(), config.DB.AppDebugWithDB())
 
-	conn, err := qe.conns.Get(tabletenv.LocalContext(), nil)
+	conn, err := qe.conns.GetWithPriority(tabletenv.LocalContext(), nil, loadshed.PriorityUndroppable)
 	if err != nil {
 		qe.conns.Close()
 		return err
@@ -455,7 +460,6 @@ func (qe *QueryEngine) getStreamPlan(curSchema *currentSchema, sql string) (*Tab
 	}
 
 	splan, err := planbuilder.BuildStreaming(statement, curSchema.tables)
-
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -257,7 +257,6 @@ func (qre *QueryExecutor) execAutocommit(f func(conn *StatefulConnection) (*sqlt
 	}
 
 	conn, _, _, err := qre.tsv.te.txPool.Begin(qre.ctx, qre.options, false, 0, qre.setting)
-
 	if err != nil {
 		return nil, err
 	}
@@ -583,7 +582,8 @@ func (qre *QueryExecutor) execDDL(conn *StatefulConnection) (result *sqltypes.Re
 	}
 
 	if conn == nil {
-		conn, err = qre.tsv.te.txPool.createConn(qre.ctx, qre.options, qre.setting)
+		snakePriority := snakePriorityFromOptions(qre.options, qre.tsv.config.TxThrottlerDefaultPriority)
+		conn, err = qre.tsv.te.txPool.createConn(qre.ctx, qre.options, qre.setting, snakePriority)
 		if err != nil {
 			return nil, err
 		}
@@ -829,31 +829,16 @@ func (qre *QueryExecutor) getConn() (*connpool.PooledConn, func(), error) {
 		qre.logStats.WaitingForConnection += time.Since(start)
 	}(time.Now())
 
-	snake := qre.tsv.qe.snake
-	if snake != nil {
-		valveID := qre.options.GetLoadshedValveId()
-		// Translate the Vitess proto priority (0 = most important) into Snake's
-		// convention (higher priority shed last). Queries against a configured
-		// schema (e.g. performance_schema health checks) are marked undroppable
-		// instead, so they are never shed.
-		snakePriority := snakePriorityFromOptions(qre.options, qre.tsv.config.TxThrottlerDefaultPriority)
-		if matchesUndroppableSchema(qre.plan.SchemaQualifiers, qre.tsv.Config().LoadshedUndroppableSchemas) {
-			snakePriority = loadshed.PriorityUndroppable
-		}
-		unlock, err := snake.Acquire(ctx, valveID, snakePriority)
-		if err != nil {
-			return nil, nil, errLoadShed
-		}
-		conn, err := qre.tsv.qe.conns.Get(ctx, qre.setting)
-		if err != nil {
-			unlock.Release()
-			return nil, nil, err
-		}
-		return conn, func() { unlock.Release() }, nil
+	snakePriority := snakePriorityFromOptions(qre.options, qre.tsv.config.TxThrottlerDefaultPriority)
+	if matchesUndroppableSchema(qre.plan.SchemaQualifiers, qre.tsv.Config().LoadshedUndroppableSchemas) {
+		snakePriority = loadshed.PriorityUndroppable
 	}
 
-	conn, err := qre.tsv.qe.conns.Get(ctx, qre.setting)
+	conn, err := qre.tsv.qe.conns.GetWithPriority(ctx, qre.setting, snakePriority)
 	if err != nil {
+		if errors.Is(err, smartconnpool.ErrPoolLoadShed) {
+			return nil, nil, errLoadShed
+		}
 		return nil, nil, err
 	}
 	return conn, func() {}, nil

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -95,229 +95,230 @@ func TestQueryExecutorPlans(t *testing.T) {
 		outsideTxErr bool
 		// TxThrottler allows the test case to override the transaction throttler
 		txThrottler txthrottler.TxThrottler
-	}{{
-		input: "select * from t",
-		dbResponses: []dbResponse{{
-			query:  "select * from t limit 10001",
-			result: selectResult,
-		}},
-		resultWant: selectResult,
-		planWant:   "Select",
-		logWant:    "select * from t limit 10001",
-		inTxWant:   "select * from t limit 10001",
-	}, {
-		input: "select * from t limit 1",
-		dbResponses: []dbResponse{{
-			query:  "select * from t limit 1",
-			result: selectResult,
-		}},
-		resultWant: selectResult,
-		planWant:   "Select",
-		logWant:    "select * from t limit 1",
-		inTxWant:   "select * from t limit 1",
-	}, {
-		input: "show engines",
-		dbResponses: []dbResponse{{
-			query:  "show engines",
-			result: dmlResult,
-		}},
-		resultWant: dmlResult,
-		planWant:   "Show",
-		logWant:    "show engines",
-	}, {
-		input: "repair t",
-		dbResponses: []dbResponse{{
-			query:  "repair t",
-			result: dmlResult,
-		}},
-		resultWant: dmlResult,
-		planWant:   "OtherAdmin",
-		logWant:    "repair t",
-	}, {
-		input: "insert into test_table(a) values(1)",
-		dbResponses: []dbResponse{{
-			query:  "insert into test_table(a) values (1)",
-			result: dmlResult,
-		}},
-		resultWant: dmlResult,
-		planWant:   "Insert",
-		logWant:    "insert into test_table(a) values (1)",
-	}, {
-		input: "replace into test_table(a) values(1)",
-		dbResponses: []dbResponse{{
-			query:  "replace into test_table(a) values (1)",
-			result: dmlResult,
-		}},
-		resultWant: dmlResult,
-		planWant:   "Insert",
-		logWant:    "replace into test_table(a) values (1)",
-	}, {
-		input: "update test_table set a=1",
-		dbResponses: []dbResponse{{
-			query:  "update test_table set a = 1 limit 10001",
-			result: dmlResult,
-		}},
-		resultWant: dmlResult,
-		planWant:   "UpdateLimit",
-		// The UpdateLimit query will not use autocommit because
-		// it needs to roll back on failure.
-		logWant:  "begin; update test_table set a = 1 limit 10001; commit",
-		inTxWant: "update test_table set a = 1 limit 10001",
-	}, {
-		input:       "select a, b from test_table",
-		passThrough: true,
-		inDMLExec:   true,
-		dbResponses: []dbResponse{{
-			query:  "select a, b from test_table",
-			result: selectResult,
-		}},
-		resultWant:   selectResult,
-		planWant:     "SelectNoLimit",
-		logWant:      "select a, b from test_table",
-		outsideTxErr: true,
-		errorWant:    "[BUG] SelectNoLimit unexpected plan type",
-	}, {
-		input:       "update test_table set a=1",
-		passThrough: true,
-		dbResponses: []dbResponse{{
-			query:  "update test_table set a = 1",
-			result: dmlResult,
-		}},
-		resultWant: dmlResult,
-		planWant:   "Update",
-		logWant:    "update test_table set a = 1",
-	}, {
-		input: "delete from test_table",
-		dbResponses: []dbResponse{{
-			query:  "delete from test_table limit 10001",
-			result: dmlResult,
-		}},
-		resultWant: dmlResult,
-		planWant:   "DeleteLimit",
-		// The DeleteLimit query will not use autocommit because
-		// it needs to roll back on failure.
-		logWant:  "begin; delete from test_table limit 10001; commit",
-		inTxWant: "delete from test_table limit 10001",
-	}, {
-		input:       "delete from test_table",
-		passThrough: true,
-		dbResponses: []dbResponse{{
-			query:  "delete from test_table",
-			result: dmlResult,
-		}},
-		resultWant: dmlResult,
-		planWant:   "Delete",
-		logWant:    "delete from test_table",
-	}, {
-		input: "alter table test_table add zipcode int",
-		dbResponses: []dbResponse{{
-			query:  "alter table test_table add column zipcode int",
-			result: dmlResult,
-		}},
-		resultWant:  dmlResult,
-		planWant:    "DDL",
-		logWant:     "alter table test_table add column zipcode int",
-		onlyInTxErr: true,
-		errorWant:   "DDL statement executed inside a transaction",
-	}, {
-		input: "savepoint a",
-		dbResponses: []dbResponse{{
-			query:  "savepoint a",
-			result: emptyResult,
-		}},
-		resultWant: emptyResult,
-		planWant:   "Savepoint",
-		logWant:    "savepoint a",
-		inTxWant:   "savepoint a",
-	}, {
-		input: "create index a on user(id)",
-		dbResponses: []dbResponse{{
-			query:  "alter table `user` add key a (id)",
-			result: emptyResult,
-		}},
-		resultWant:  emptyResult,
-		planWant:    "DDL",
-		logWant:     "alter table `user` add key a (id)",
-		inTxWant:    "alter table `user` add key a (id)",
-		onlyInTxErr: true,
-		errorWant:   "DDL statement executed inside a transaction",
-	}, {
-		input: "create index a on user(id1 + id2)",
-		dbResponses: []dbResponse{{
-			query:  "create index a on user(id1 + id2)",
-			result: emptyResult,
-		}},
-		resultWant:  emptyResult,
-		planWant:    "DDL",
-		logWant:     "create index a on user(id1 + id2)",
-		inTxWant:    "create index a on user(id1 + id2)",
-		onlyInTxErr: true,
-		errorWant:   "DDL statement executed inside a transaction",
-	}, {
-		input: "ROLLBACK work to SAVEPOINT a",
-		dbResponses: []dbResponse{{
-			query:  "ROLLBACK work to SAVEPOINT a",
-			result: emptyResult,
-		}},
-		resultWant: emptyResult,
-		planWant:   "RollbackSavepoint",
-		logWant:    "ROLLBACK work to SAVEPOINT a",
-		inTxWant:   "ROLLBACK work to SAVEPOINT a",
-	}, {
-		input: "RELEASE savepoint a",
-		dbResponses: []dbResponse{{
-			query:  "RELEASE savepoint a",
-			result: emptyResult,
-		}},
-		resultWant: emptyResult,
-		planWant:   "Release",
-		logWant:    "RELEASE savepoint a",
-		inTxWant:   "RELEASE savepoint a",
-	}, {
-		input: "show create database db_name",
-		dbResponses: []dbResponse{{
-			query:  "show create database ks",
-			result: emptyResult,
-		}},
-		resultWant: emptyResult,
-		planWant:   "Show",
-		logWant:    "show create database ks",
-	}, {
-		input: "show create database mysql",
-		dbResponses: []dbResponse{{
-			query:  "show create database mysql",
-			result: emptyResult,
-		}},
-		resultWant: emptyResult,
-		planWant:   "Show",
-		logWant:    "show create database mysql",
-	}, {
-		input: "show create table mysql.user",
-		dbResponses: []dbResponse{{
-			query:  "show create table mysql.`user`",
-			result: emptyResult,
-		}},
-		resultWant: emptyResult,
-		planWant:   "Show",
-		logWant:    "show create table mysql.`user`",
-	}, {
-		input: "update test_table set a=1",
-		dbResponses: []dbResponse{{
-			query:  "update test_table set a = 1 limit 10001",
-			result: dmlResult,
-		}},
-		errorWant:   "Transaction throttled",
-		txThrottler: &mockTxThrottler{true},
-	}, {
-		input:       "update test_table set a=1",
-		passThrough: true,
-		dbResponses: []dbResponse{{
-			query:  "update test_table set a = 1 limit 10001",
-			result: dmlResult,
-		}},
-		errorWant:   "Transaction throttled",
-		txThrottler: &mockTxThrottler{true},
-	},
+	}{
+		{
+			input: "select * from t",
+			dbResponses: []dbResponse{{
+				query:  "select * from t limit 10001",
+				result: selectResult,
+			}},
+			resultWant: selectResult,
+			planWant:   "Select",
+			logWant:    "select * from t limit 10001",
+			inTxWant:   "select * from t limit 10001",
+		}, {
+			input: "select * from t limit 1",
+			dbResponses: []dbResponse{{
+				query:  "select * from t limit 1",
+				result: selectResult,
+			}},
+			resultWant: selectResult,
+			planWant:   "Select",
+			logWant:    "select * from t limit 1",
+			inTxWant:   "select * from t limit 1",
+		}, {
+			input: "show engines",
+			dbResponses: []dbResponse{{
+				query:  "show engines",
+				result: dmlResult,
+			}},
+			resultWant: dmlResult,
+			planWant:   "Show",
+			logWant:    "show engines",
+		}, {
+			input: "repair t",
+			dbResponses: []dbResponse{{
+				query:  "repair t",
+				result: dmlResult,
+			}},
+			resultWant: dmlResult,
+			planWant:   "OtherAdmin",
+			logWant:    "repair t",
+		}, {
+			input: "insert into test_table(a) values(1)",
+			dbResponses: []dbResponse{{
+				query:  "insert into test_table(a) values (1)",
+				result: dmlResult,
+			}},
+			resultWant: dmlResult,
+			planWant:   "Insert",
+			logWant:    "insert into test_table(a) values (1)",
+		}, {
+			input: "replace into test_table(a) values(1)",
+			dbResponses: []dbResponse{{
+				query:  "replace into test_table(a) values (1)",
+				result: dmlResult,
+			}},
+			resultWant: dmlResult,
+			planWant:   "Insert",
+			logWant:    "replace into test_table(a) values (1)",
+		}, {
+			input: "update test_table set a=1",
+			dbResponses: []dbResponse{{
+				query:  "update test_table set a = 1 limit 10001",
+				result: dmlResult,
+			}},
+			resultWant: dmlResult,
+			planWant:   "UpdateLimit",
+			// The UpdateLimit query will not use autocommit because
+			// it needs to roll back on failure.
+			logWant:  "begin; update test_table set a = 1 limit 10001; commit",
+			inTxWant: "update test_table set a = 1 limit 10001",
+		}, {
+			input:       "select a, b from test_table",
+			passThrough: true,
+			inDMLExec:   true,
+			dbResponses: []dbResponse{{
+				query:  "select a, b from test_table",
+				result: selectResult,
+			}},
+			resultWant:   selectResult,
+			planWant:     "SelectNoLimit",
+			logWant:      "select a, b from test_table",
+			outsideTxErr: true,
+			errorWant:    "[BUG] SelectNoLimit unexpected plan type",
+		}, {
+			input:       "update test_table set a=1",
+			passThrough: true,
+			dbResponses: []dbResponse{{
+				query:  "update test_table set a = 1",
+				result: dmlResult,
+			}},
+			resultWant: dmlResult,
+			planWant:   "Update",
+			logWant:    "update test_table set a = 1",
+		}, {
+			input: "delete from test_table",
+			dbResponses: []dbResponse{{
+				query:  "delete from test_table limit 10001",
+				result: dmlResult,
+			}},
+			resultWant: dmlResult,
+			planWant:   "DeleteLimit",
+			// The DeleteLimit query will not use autocommit because
+			// it needs to roll back on failure.
+			logWant:  "begin; delete from test_table limit 10001; commit",
+			inTxWant: "delete from test_table limit 10001",
+		}, {
+			input:       "delete from test_table",
+			passThrough: true,
+			dbResponses: []dbResponse{{
+				query:  "delete from test_table",
+				result: dmlResult,
+			}},
+			resultWant: dmlResult,
+			planWant:   "Delete",
+			logWant:    "delete from test_table",
+		}, {
+			input: "alter table test_table add zipcode int",
+			dbResponses: []dbResponse{{
+				query:  "alter table test_table add column zipcode int",
+				result: dmlResult,
+			}},
+			resultWant:  dmlResult,
+			planWant:    "DDL",
+			logWant:     "alter table test_table add column zipcode int",
+			onlyInTxErr: true,
+			errorWant:   "DDL statement executed inside a transaction",
+		}, {
+			input: "savepoint a",
+			dbResponses: []dbResponse{{
+				query:  "savepoint a",
+				result: emptyResult,
+			}},
+			resultWant: emptyResult,
+			planWant:   "Savepoint",
+			logWant:    "savepoint a",
+			inTxWant:   "savepoint a",
+		}, {
+			input: "create index a on user(id)",
+			dbResponses: []dbResponse{{
+				query:  "alter table `user` add key a (id)",
+				result: emptyResult,
+			}},
+			resultWant:  emptyResult,
+			planWant:    "DDL",
+			logWant:     "alter table `user` add key a (id)",
+			inTxWant:    "alter table `user` add key a (id)",
+			onlyInTxErr: true,
+			errorWant:   "DDL statement executed inside a transaction",
+		}, {
+			input: "create index a on user(id1 + id2)",
+			dbResponses: []dbResponse{{
+				query:  "create index a on user(id1 + id2)",
+				result: emptyResult,
+			}},
+			resultWant:  emptyResult,
+			planWant:    "DDL",
+			logWant:     "create index a on user(id1 + id2)",
+			inTxWant:    "create index a on user(id1 + id2)",
+			onlyInTxErr: true,
+			errorWant:   "DDL statement executed inside a transaction",
+		}, {
+			input: "ROLLBACK work to SAVEPOINT a",
+			dbResponses: []dbResponse{{
+				query:  "ROLLBACK work to SAVEPOINT a",
+				result: emptyResult,
+			}},
+			resultWant: emptyResult,
+			planWant:   "RollbackSavepoint",
+			logWant:    "ROLLBACK work to SAVEPOINT a",
+			inTxWant:   "ROLLBACK work to SAVEPOINT a",
+		}, {
+			input: "RELEASE savepoint a",
+			dbResponses: []dbResponse{{
+				query:  "RELEASE savepoint a",
+				result: emptyResult,
+			}},
+			resultWant: emptyResult,
+			planWant:   "Release",
+			logWant:    "RELEASE savepoint a",
+			inTxWant:   "RELEASE savepoint a",
+		}, {
+			input: "show create database db_name",
+			dbResponses: []dbResponse{{
+				query:  "show create database ks",
+				result: emptyResult,
+			}},
+			resultWant: emptyResult,
+			planWant:   "Show",
+			logWant:    "show create database ks",
+		}, {
+			input: "show create database mysql",
+			dbResponses: []dbResponse{{
+				query:  "show create database mysql",
+				result: emptyResult,
+			}},
+			resultWant: emptyResult,
+			planWant:   "Show",
+			logWant:    "show create database mysql",
+		}, {
+			input: "show create table mysql.user",
+			dbResponses: []dbResponse{{
+				query:  "show create table mysql.`user`",
+				result: emptyResult,
+			}},
+			resultWant: emptyResult,
+			planWant:   "Show",
+			logWant:    "show create table mysql.`user`",
+		}, {
+			input: "update test_table set a=1",
+			dbResponses: []dbResponse{{
+				query:  "update test_table set a = 1 limit 10001",
+				result: dmlResult,
+			}},
+			errorWant:   "Transaction throttled",
+			txThrottler: &mockTxThrottler{true},
+		}, {
+			input:       "update test_table set a=1",
+			passThrough: true,
+			dbResponses: []dbResponse{{
+				query:  "update test_table set a = 1 limit 10001",
+				result: dmlResult,
+			}},
+			errorWant:   "Transaction throttled",
+			txThrottler: &mockTxThrottler{true},
+		},
 	}
 	for _, tcase := range testcases {
 		t.Run(tcase.input, func(t *testing.T) {
@@ -1716,9 +1717,7 @@ func TestGetConnWithSnake(t *testing.T) {
 
 	input := "select * from test_table limit 1"
 
-	// With a valve ID set, Snake gate admits the request
 	qre := newTestQueryExecutor(ctx, tsv, input, 0)
-	qre.options = &querypb.ExecuteOptions{LoadshedValveId: "test-request-123"}
 	conn, release, err := qre.getConn()
 	require.NoError(t, err)
 	require.NotNil(t, conn)

--- a/go/vt/vttablet/tabletserver/snake_capacity_test.go
+++ b/go/vt/vttablet/tabletserver/snake_capacity_test.go
@@ -34,7 +34,7 @@ func acquireN(t *testing.T, s *loadshed.Snake, count int) []*loadshed.SafeUnlock
 	t.Helper()
 	unlocks := make([]*loadshed.SafeUnlock, count)
 	for i := range count {
-		u, err := s.Acquire(t.Context(), "", 0)
+		u, err := s.Acquire(t.Context(), 0)
 		require.NoErrorf(t, err, "acquire %d of %d should be granted", i+1, count)
 		unlocks[i] = u
 	}
@@ -46,7 +46,7 @@ func acquireN(t *testing.T, s *loadshed.Snake, count int) []*loadshed.SafeUnlock
 func acquireBlocks(s *loadshed.Snake) bool {
 	granted := make(chan *loadshed.SafeUnlock, 1)
 	go func() {
-		u, err := s.Acquire(context.Background(), "", 0)
+		u, err := s.Acquire(context.Background(), 0)
 		if err == nil {
 			granted <- u
 		}

--- a/go/vt/vttablet/tabletserver/stateful_connection.go
+++ b/go/vt/vttablet/tabletserver/stateful_connection.go
@@ -174,16 +174,6 @@ func (sc *StatefulConnection) ReleaseString(reason string) {
 	if sc.dbConn == nil {
 		return
 	}
-	// Release any load-shed (Snake) slot this connection holds. This is the
-	// universal teardown funnel: every conn lifecycle (Commit/Rollback via
-	// txComplete, but also the transaction killer, shutdown, taint, and
-	// renew-failure paths that call Release directly and bypass txComplete) passes
-	// through here. txComplete also invokes SnakeRelease, but SafeUnlock.Release is
-	// idempotent, so a slot held by a conn torn down without txComplete is still
-	// freed here instead of leaking until the gate's capacity is exhausted.
-	if sc.txProps != nil && sc.txProps.SnakeRelease != nil {
-		sc.txProps.SnakeRelease()
-	}
 	if sc.pool != nil {
 		sc.pool.unregister(sc.ConnID, reason)
 	}

--- a/go/vt/vttablet/tabletserver/stateful_connection_pool.go
+++ b/go/vt/vttablet/tabletserver/stateful_connection_pool.go
@@ -171,14 +171,14 @@ func (sf *StatefulConnectionPool) GetAndLock(id int64, reason string) (*Stateful
 
 // NewConn creates a new StatefulConnection. It will be created from either the normal pool or
 // the found_rows pool, depending on the options provided
-func (sf *StatefulConnectionPool) NewConn(ctx context.Context, options *querypb.ExecuteOptions, setting *smartconnpool.Setting) (*StatefulConnection, error) {
+func (sf *StatefulConnectionPool) NewConn(ctx context.Context, options *querypb.ExecuteOptions, setting *smartconnpool.Setting, priority float64) (*StatefulConnection, error) {
 	var conn *connpool.PooledConn
 	var err error
 
 	if options.GetClientFoundRows() {
-		conn, err = sf.foundRowsPool.Get(ctx, setting)
+		conn, err = sf.foundRowsPool.GetWithPriority(ctx, setting, priority)
 	} else {
-		conn, err = sf.conns.Get(ctx, setting)
+		conn, err = sf.conns.GetWithPriority(ctx, setting, priority)
 	}
 	if err != nil {
 		return nil, err

--- a/go/vt/vttablet/tabletserver/stateful_connection_pool_test.go
+++ b/go/vt/vttablet/tabletserver/stateful_connection_pool_test.go
@@ -44,11 +44,11 @@ func TestActivePoolClientRowsFound(t *testing.T) {
 	startNormalSize := pool.conns.Available()
 	startFoundRowsSize := pool.foundRowsPool.Available()
 
-	conn1, err := pool.NewConn(ctx, &querypb.ExecuteOptions{}, nil)
+	conn1, err := pool.NewConn(ctx, &querypb.ExecuteOptions{}, nil, 0)
 	require.NoError(t, err)
 	assert.Equal(t, startNormalSize-1, pool.conns.Available(), "default pool not used")
 
-	conn2, err := pool.NewConn(ctx, &querypb.ExecuteOptions{ClientFoundRows: true}, nil)
+	conn2, err := pool.NewConn(ctx, &querypb.ExecuteOptions{ClientFoundRows: true}, nil, 0)
 	require.NoError(t, err)
 	assert.Equal(t, startFoundRowsSize-1, pool.conns.Available(), "foundRows pool not used")
 
@@ -67,15 +67,15 @@ func TestActivePoolForAllTxProps(t *testing.T) {
 	pool := newActivePool()
 	params := dbconfigs.New(db.ConnParams())
 	pool.Open(params, params, params)
-	conn1, err := pool.NewConn(ctx, &querypb.ExecuteOptions{}, nil)
+	conn1, err := pool.NewConn(ctx, &querypb.ExecuteOptions{}, nil, 0)
 	require.NoError(t, err)
 	conn1.txProps = &tx.Properties{}
 
-	conn2, err := pool.NewConn(ctx, &querypb.ExecuteOptions{}, nil)
+	conn2, err := pool.NewConn(ctx, &querypb.ExecuteOptions{}, nil, 0)
 	require.NoError(t, err)
 	// for the second connection, we are not going to set a tx state
 
-	conn3, err := pool.NewConn(ctx, &querypb.ExecuteOptions{}, nil)
+	conn3, err := pool.NewConn(ctx, &querypb.ExecuteOptions{}, nil, 0)
 	require.NoError(t, err)
 	conn3.txProps = &tx.Properties{}
 
@@ -98,20 +98,20 @@ func TestStatefulPoolShutdownNonTx(t *testing.T) {
 	pool.Open(params, params, params)
 
 	// conn1 non-tx, not in use.
-	conn1, err := pool.NewConn(ctx, &querypb.ExecuteOptions{}, nil)
+	conn1, err := pool.NewConn(ctx, &querypb.ExecuteOptions{}, nil, 0)
 	require.NoError(t, err)
 	conn1.Taint(ctx, nil)
 	conn1.Unlock()
 
 	// conn2 tx, not in use.
-	conn2, err := pool.NewConn(ctx, &querypb.ExecuteOptions{}, nil)
+	conn2, err := pool.NewConn(ctx, &querypb.ExecuteOptions{}, nil, 0)
 	require.NoError(t, err)
 	conn2.Taint(ctx, nil)
 	conn2.txProps = &tx.Properties{}
 	conn2.Unlock()
 
 	// conn3 non-tx, in use.
-	conn3, err := pool.NewConn(ctx, &querypb.ExecuteOptions{}, nil)
+	conn3, err := pool.NewConn(ctx, &querypb.ExecuteOptions{}, nil, 0)
 	require.NoError(t, err)
 	conn3.Taint(ctx, nil)
 
@@ -139,13 +139,13 @@ func TestStatefulPoolShutdownAll(t *testing.T) {
 	pool.Open(params, params, params)
 
 	// conn1 not in use
-	conn1, err := pool.NewConn(ctx, &querypb.ExecuteOptions{}, nil)
+	conn1, err := pool.NewConn(ctx, &querypb.ExecuteOptions{}, nil, 0)
 	require.NoError(t, err)
 	conn1.txProps = &tx.Properties{}
 	conn1.Unlock()
 
 	// conn2 in use.
-	conn2, err := pool.NewConn(ctx, &querypb.ExecuteOptions{}, nil)
+	conn2, err := pool.NewConn(ctx, &querypb.ExecuteOptions{}, nil, 0)
 	require.NoError(t, err)
 	conn2.txProps = &tx.Properties{}
 
@@ -175,7 +175,7 @@ func TestExecWithAbortedCtx(t *testing.T) {
 	pool := newActivePool()
 	params := dbconfigs.New(db.ConnParams())
 	pool.Open(params, params, params)
-	conn, err := pool.NewConn(ctx, &querypb.ExecuteOptions{}, nil)
+	conn, err := pool.NewConn(ctx, &querypb.ExecuteOptions{}, nil, 0)
 	require.NoError(t, err)
 	cancel()
 	_, err = conn.Exec(ctx, "", 0, false)
@@ -190,7 +190,7 @@ func TestExecWithDbconnClosed(t *testing.T) {
 	pool := newActivePool()
 	params := dbconfigs.New(db.ConnParams())
 	pool.Open(params, params, params)
-	conn, err := pool.NewConn(ctx, &querypb.ExecuteOptions{}, nil)
+	conn, err := pool.NewConn(ctx, &querypb.ExecuteOptions{}, nil, 0)
 	require.NoError(t, err)
 	conn.Close()
 
@@ -206,7 +206,7 @@ func TestExecWithDbconnClosedHavingTx(t *testing.T) {
 	pool := newActivePool()
 	params := dbconfigs.New(db.ConnParams())
 	pool.Open(params, params, params)
-	conn, err := pool.NewConn(ctx, &querypb.ExecuteOptions{}, nil)
+	conn, err := pool.NewConn(ctx, &querypb.ExecuteOptions{}, nil, 0)
 	require.NoError(t, err)
 	conn.txProps = &tx.Properties{Conclusion: "foobar"}
 	conn.Close()
@@ -223,13 +223,13 @@ func TestFailOnConnectionRegistering(t *testing.T) {
 	pool := newActivePool()
 	params := dbconfigs.New(db.ConnParams())
 	pool.Open(params, params, params)
-	conn, err := pool.NewConn(ctx, &querypb.ExecuteOptions{}, nil)
+	conn, err := pool.NewConn(ctx, &querypb.ExecuteOptions{}, nil, 0)
 	require.NoError(t, err)
 	defer conn.Close()
 
 	pool.lastID.Store(conn.ConnID - 1)
 
-	_, err = pool.NewConn(ctx, &querypb.ExecuteOptions{}, nil)
+	_, err = pool.NewConn(ctx, &querypb.ExecuteOptions{}, nil, 0)
 	require.Error(t, err, "already present")
 }
 

--- a/go/vt/vttablet/tabletserver/tx/api.go
+++ b/go/vt/vttablet/tabletserver/tx/api.go
@@ -57,8 +57,6 @@ type (
 		LogToFile       bool
 
 		Stats *servenv.TimingsWrapper
-
-		SnakeRelease func()
 	}
 
 	// Query contains the query and involved tables executed inside transaction.

--- a/go/vt/vttablet/tabletserver/tx_engine.go
+++ b/go/vt/vttablet/tabletserver/tx_engine.go
@@ -55,7 +55,8 @@ func (state txEngineState) String() string {
 		"NotServing",
 		"Transitioning",
 		"AcceptReadWrite",
-		"AcceptingReadOnly"}
+		"AcceptingReadOnly",
+	}
 
 	if state < NotServing || state > AcceptingReadOnly {
 		return fmt.Sprintf("Unknown - %d", int(state))
@@ -140,6 +141,9 @@ func NewTxEngine(env tabletenv.Env, dxNotifier func()) *TxEngine {
 			LoadsheddingAllowed: func() bool { return true },
 		})
 		loadshed.PublishStats(env.Exporter(), "SnakeDml", te.txPool.snake)
+		defaultPriority := snakePriorityFromOptions(nil, config.TxThrottlerDefaultPriority)
+		te.txPool.scp.conns.SetSnake(te.txPool.snake, defaultPriority)
+		te.txPool.scp.foundRowsPool.SetSnake(te.txPool.snake, defaultPriority)
 	}
 	// We initially allow twoPC (handles vttablet restarts).
 	// We will disallow them for a few reasons -
@@ -706,7 +710,8 @@ func (te *TxEngine) Reserve(ctx context.Context, options *querypb.ExecuteOptions
 
 // Reserve creates a reserved connection and returns the id to it
 func (te *TxEngine) reserve(ctx context.Context, options *querypb.ExecuteOptions, preQueries []string) (*StatefulConnection, error) {
-	conn, err := te.txPool.scp.NewConn(ctx, options, nil)
+	snakePriority := snakePriorityFromOptions(options, te.env.Config().TxThrottlerDefaultPriority)
+	conn, err := te.txPool.scp.NewConn(ctx, options, nil, snakePriority)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vttablet/tabletserver/tx_engine_test.go
+++ b/go/vt/vttablet/tabletserver/tx_engine_test.go
@@ -190,7 +190,6 @@ func TestTxEngineBegin(t *testing.T) {
 		_, _, err = exec()
 		assert.EqualError(t, err, "tx engine can't accept new connections in state NotServing")
 	}
-
 }
 
 func TestTxEngineRenewFails(t *testing.T) {
@@ -212,7 +211,7 @@ func TestTxEngineRenewFails(t *testing.T) {
 	conn.Unlock() // but we keep holding on to it... sneaky....
 
 	// this next bit sets up the scp so our renew will fail
-	conn2, err := te.txPool.scp.NewConn(ctx, options, nil)
+	conn2, err := te.txPool.scp.NewConn(ctx, options, nil, 0)
 	require.NoError(t, err)
 	defer conn2.Release(tx.TxCommit)
 	te.txPool.scp.lastID.Store(conn2.ConnID - 1)
@@ -285,205 +284,365 @@ func changeState(te *TxEngine, state txEngineState) {
 }
 
 func TestWithInnerTests(outerT *testing.T) {
-
 	tests := []TestCase{
 		// Start from RW and test all single hop transitions with and without tx
-		{AcceptingReadAndWrite, []txEngineState{
-			NotServing},
-			NoTx, assertEndStateIs(NotServing)},
+		{
+			AcceptingReadAndWrite,
+			[]txEngineState{
+				NotServing,
+			},
+			NoTx, assertEndStateIs(NotServing),
+		},
 
-		{AcceptingReadAndWrite, []txEngineState{
-			AcceptingReadAndWrite},
-			NoTx, assertEndStateIs(AcceptingReadAndWrite)},
+		{
+			AcceptingReadAndWrite,
+			[]txEngineState{
+				AcceptingReadAndWrite,
+			},
+			NoTx, assertEndStateIs(AcceptingReadAndWrite),
+		},
 
-		{AcceptingReadAndWrite, []txEngineState{
-			AcceptingReadOnly},
-			NoTx, assertEndStateIs(AcceptingReadOnly)},
+		{
+			AcceptingReadAndWrite,
+			[]txEngineState{
+				AcceptingReadOnly,
+			},
+			NoTx, assertEndStateIs(AcceptingReadOnly),
+		},
 
-		{AcceptingReadAndWrite, []txEngineState{
-			NotServing},
-			WriteAccepted, assertEndStateIs(NotServing)},
+		{
+			AcceptingReadAndWrite,
+			[]txEngineState{
+				NotServing,
+			},
+			WriteAccepted, assertEndStateIs(NotServing),
+		},
 
-		{AcceptingReadAndWrite, []txEngineState{
-			AcceptingReadAndWrite},
-			WriteAccepted, assertEndStateIs(AcceptingReadAndWrite)},
+		{
+			AcceptingReadAndWrite,
+			[]txEngineState{
+				AcceptingReadAndWrite,
+			},
+			WriteAccepted, assertEndStateIs(AcceptingReadAndWrite),
+		},
 
-		{AcceptingReadAndWrite, []txEngineState{
-			AcceptingReadOnly},
-			WriteAccepted, assertEndStateIs(AcceptingReadOnly)},
+		{
+			AcceptingReadAndWrite,
+			[]txEngineState{
+				AcceptingReadOnly,
+			},
+			WriteAccepted, assertEndStateIs(AcceptingReadOnly),
+		},
 
-		{AcceptingReadAndWrite, []txEngineState{
-			NotServing},
-			ReadOnlyAccepted, assertEndStateIs(NotServing)},
+		{
+			AcceptingReadAndWrite,
+			[]txEngineState{
+				NotServing,
+			},
+			ReadOnlyAccepted, assertEndStateIs(NotServing),
+		},
 
-		{AcceptingReadAndWrite, []txEngineState{
-			AcceptingReadAndWrite},
-			ReadOnlyAccepted, assertEndStateIs(AcceptingReadAndWrite)},
+		{
+			AcceptingReadAndWrite,
+			[]txEngineState{
+				AcceptingReadAndWrite,
+			},
+			ReadOnlyAccepted, assertEndStateIs(AcceptingReadAndWrite),
+		},
 
-		{AcceptingReadAndWrite, []txEngineState{
-			AcceptingReadOnly},
-			ReadOnlyAccepted, assertEndStateIs(AcceptingReadOnly)},
+		{
+			AcceptingReadAndWrite,
+			[]txEngineState{
+				AcceptingReadOnly,
+			},
+			ReadOnlyAccepted, assertEndStateIs(AcceptingReadOnly),
+		},
 
 		// Start from RW and test all transitions with and without tx, plus a concurrent Stop()
-		{AcceptingReadAndWrite, []txEngineState{
-			NotServing,
-			NotServing},
-			NoTx, assertEndStateIs(NotServing)},
-
-		{AcceptingReadAndWrite, []txEngineState{
+		{
 			AcceptingReadAndWrite,
-			NotServing},
-			NoTx, assertEndStateIs(NotServing)},
+			[]txEngineState{
+				NotServing,
+				NotServing,
+			},
+			NoTx, assertEndStateIs(NotServing),
+		},
 
-		{AcceptingReadAndWrite, []txEngineState{
-			AcceptingReadOnly,
-			NotServing},
-			NoTx, assertEndStateIs(NotServing)},
-
-		{AcceptingReadAndWrite, []txEngineState{
-			NotServing,
-			NotServing},
-			WriteAccepted, assertEndStateIs(NotServing)},
-
-		{AcceptingReadAndWrite, []txEngineState{
+		{
 			AcceptingReadAndWrite,
-			NotServing},
-			WriteAccepted, assertEndStateIs(NotServing)},
+			[]txEngineState{
+				AcceptingReadAndWrite,
+				NotServing,
+			},
+			NoTx, assertEndStateIs(NotServing),
+		},
 
-		{AcceptingReadAndWrite, []txEngineState{
-			AcceptingReadOnly,
-			NotServing},
-			WriteAccepted, assertEndStateIs(NotServing)},
+		{
+			AcceptingReadAndWrite,
+			[]txEngineState{
+				AcceptingReadOnly,
+				NotServing,
+			},
+			NoTx, assertEndStateIs(NotServing),
+		},
+
+		{
+			AcceptingReadAndWrite,
+			[]txEngineState{
+				NotServing,
+				NotServing,
+			},
+			WriteAccepted, assertEndStateIs(NotServing),
+		},
+
+		{
+			AcceptingReadAndWrite,
+			[]txEngineState{
+				AcceptingReadAndWrite,
+				NotServing,
+			},
+			WriteAccepted, assertEndStateIs(NotServing),
+		},
+
+		{
+			AcceptingReadAndWrite,
+			[]txEngineState{
+				AcceptingReadOnly,
+				NotServing,
+			},
+			WriteAccepted, assertEndStateIs(NotServing),
+		},
 
 		// Start from RW and test all transitions with and without tx, plus a concurrent ReadOnly()
-		{AcceptingReadAndWrite, []txEngineState{
-			NotServing,
-			AcceptingReadOnly},
-			NoTx, assertEndStateIs(AcceptingReadOnly)},
-
-		{AcceptingReadAndWrite, []txEngineState{
+		{
 			AcceptingReadAndWrite,
-			AcceptingReadOnly},
-			NoTx, assertEndStateIs(AcceptingReadOnly)},
+			[]txEngineState{
+				NotServing,
+				AcceptingReadOnly,
+			},
+			NoTx, assertEndStateIs(AcceptingReadOnly),
+		},
 
-		{AcceptingReadAndWrite, []txEngineState{
-			AcceptingReadOnly,
-			AcceptingReadOnly},
-			NoTx, assertEndStateIs(AcceptingReadOnly)},
-
-		{AcceptingReadAndWrite, []txEngineState{
-			NotServing,
-			AcceptingReadOnly},
-			WriteAccepted, assertEndStateIs(AcceptingReadOnly)},
-
-		{AcceptingReadAndWrite, []txEngineState{
+		{
 			AcceptingReadAndWrite,
-			AcceptingReadOnly},
-			WriteAccepted, assertEndStateIs(AcceptingReadOnly)},
+			[]txEngineState{
+				AcceptingReadAndWrite,
+				AcceptingReadOnly,
+			},
+			NoTx, assertEndStateIs(AcceptingReadOnly),
+		},
 
-		{AcceptingReadAndWrite, []txEngineState{
-			AcceptingReadOnly,
-			AcceptingReadOnly},
-			WriteAccepted, assertEndStateIs(AcceptingReadOnly)},
+		{
+			AcceptingReadAndWrite,
+			[]txEngineState{
+				AcceptingReadOnly,
+				AcceptingReadOnly,
+			},
+			NoTx, assertEndStateIs(AcceptingReadOnly),
+		},
+
+		{
+			AcceptingReadAndWrite,
+			[]txEngineState{
+				NotServing,
+				AcceptingReadOnly,
+			},
+			WriteAccepted, assertEndStateIs(AcceptingReadOnly),
+		},
+
+		{
+			AcceptingReadAndWrite,
+			[]txEngineState{
+				AcceptingReadAndWrite,
+				AcceptingReadOnly,
+			},
+			WriteAccepted, assertEndStateIs(AcceptingReadOnly),
+		},
+
+		{
+			AcceptingReadAndWrite,
+			[]txEngineState{
+				AcceptingReadOnly,
+				AcceptingReadOnly,
+			},
+			WriteAccepted, assertEndStateIs(AcceptingReadOnly),
+		},
 
 		// Start from RO and test all single hop transitions with and without tx
-		{AcceptingReadOnly, []txEngineState{
-			NotServing},
-			NoTx, assertEndStateIs(NotServing)},
+		{
+			AcceptingReadOnly,
+			[]txEngineState{
+				NotServing,
+			},
+			NoTx, assertEndStateIs(NotServing),
+		},
 
-		{AcceptingReadOnly, []txEngineState{
-			AcceptingReadAndWrite},
-			NoTx, assertEndStateIs(AcceptingReadAndWrite)},
+		{
+			AcceptingReadOnly,
+			[]txEngineState{
+				AcceptingReadAndWrite,
+			},
+			NoTx, assertEndStateIs(AcceptingReadAndWrite),
+		},
 
-		{AcceptingReadOnly, []txEngineState{
-			AcceptingReadOnly},
-			NoTx, assertEndStateIs(AcceptingReadOnly)},
+		{
+			AcceptingReadOnly,
+			[]txEngineState{
+				AcceptingReadOnly,
+			},
+			NoTx, assertEndStateIs(AcceptingReadOnly),
+		},
 
-		{AcceptingReadOnly, []txEngineState{
-			NotServing},
-			WriteRejected, assertEndStateIs(NotServing)},
+		{
+			AcceptingReadOnly,
+			[]txEngineState{
+				NotServing,
+			},
+			WriteRejected, assertEndStateIs(NotServing),
+		},
 
-		{AcceptingReadOnly, []txEngineState{
-			AcceptingReadAndWrite},
-			WriteRejected, assertEndStateIs(AcceptingReadAndWrite)},
+		{
+			AcceptingReadOnly,
+			[]txEngineState{
+				AcceptingReadAndWrite,
+			},
+			WriteRejected, assertEndStateIs(AcceptingReadAndWrite),
+		},
 
-		{AcceptingReadOnly, []txEngineState{
-			AcceptingReadOnly},
-			WriteRejected, assertEndStateIs(AcceptingReadOnly)},
+		{
+			AcceptingReadOnly,
+			[]txEngineState{
+				AcceptingReadOnly,
+			},
+			WriteRejected, assertEndStateIs(AcceptingReadOnly),
+		},
 
 		// Start from RO and test all transitions with and without tx, plus a concurrent Stop()
-		{AcceptingReadOnly, []txEngineState{
-			NotServing,
-			NotServing},
-			NoTx, assertEndStateIs(NotServing)},
-
-		{AcceptingReadOnly, []txEngineState{
-			AcceptingReadAndWrite,
-			NotServing},
-			NoTx, assertEndStateIs(NotServing)},
-
-		{AcceptingReadOnly, []txEngineState{
+		{
 			AcceptingReadOnly,
-			NotServing},
-			NoTx, assertEndStateIs(NotServing)},
+			[]txEngineState{
+				NotServing,
+				NotServing,
+			},
+			NoTx, assertEndStateIs(NotServing),
+		},
 
-		{AcceptingReadOnly, []txEngineState{
-			NotServing,
-			NotServing},
-			WriteRejected, assertEndStateIs(NotServing)},
-
-		{AcceptingReadOnly, []txEngineState{
-			AcceptingReadAndWrite,
-			NotServing},
-			WriteRejected, assertEndStateIs(NotServing)},
-
-		{AcceptingReadOnly, []txEngineState{
+		{
 			AcceptingReadOnly,
-			NotServing},
-			WriteRejected, assertEndStateIs(NotServing)},
+			[]txEngineState{
+				AcceptingReadAndWrite,
+				NotServing,
+			},
+			NoTx, assertEndStateIs(NotServing),
+		},
+
+		{
+			AcceptingReadOnly,
+			[]txEngineState{
+				AcceptingReadOnly,
+				NotServing,
+			},
+			NoTx, assertEndStateIs(NotServing),
+		},
+
+		{
+			AcceptingReadOnly,
+			[]txEngineState{
+				NotServing,
+				NotServing,
+			},
+			WriteRejected, assertEndStateIs(NotServing),
+		},
+
+		{
+			AcceptingReadOnly,
+			[]txEngineState{
+				AcceptingReadAndWrite,
+				NotServing,
+			},
+			WriteRejected, assertEndStateIs(NotServing),
+		},
+
+		{
+			AcceptingReadOnly,
+			[]txEngineState{
+				AcceptingReadOnly,
+				NotServing,
+			},
+			WriteRejected, assertEndStateIs(NotServing),
+		},
 
 		// Start from RO and test all transitions with and without tx, plus a concurrent ReadWrite()
-		{AcceptingReadOnly, []txEngineState{
-			NotServing,
-			AcceptingReadAndWrite},
-			NoTx, assertEndStateIs(AcceptingReadAndWrite)},
-
-		{AcceptingReadOnly, []txEngineState{
-			AcceptingReadAndWrite,
-			AcceptingReadAndWrite},
-			NoTx, assertEndStateIs(AcceptingReadAndWrite)},
-
-		{AcceptingReadOnly, []txEngineState{
+		{
 			AcceptingReadOnly,
-			AcceptingReadAndWrite},
-			NoTx, assertEndStateIs(AcceptingReadAndWrite)},
+			[]txEngineState{
+				NotServing,
+				AcceptingReadAndWrite,
+			},
+			NoTx, assertEndStateIs(AcceptingReadAndWrite),
+		},
 
-		{AcceptingReadOnly, []txEngineState{
-			NotServing,
-			AcceptingReadAndWrite},
-			WriteRejected, assertEndStateIs(AcceptingReadAndWrite)},
-
-		{AcceptingReadOnly, []txEngineState{
-			AcceptingReadAndWrite,
-			AcceptingReadAndWrite},
-			WriteRejected, assertEndStateIs(AcceptingReadAndWrite)},
-
-		{AcceptingReadOnly, []txEngineState{
+		{
 			AcceptingReadOnly,
-			AcceptingReadAndWrite},
-			WriteRejected, assertEndStateIs(AcceptingReadAndWrite)},
+			[]txEngineState{
+				AcceptingReadAndWrite,
+				AcceptingReadAndWrite,
+			},
+			NoTx, assertEndStateIs(AcceptingReadAndWrite),
+		},
+
+		{
+			AcceptingReadOnly,
+			[]txEngineState{
+				AcceptingReadOnly,
+				AcceptingReadAndWrite,
+			},
+			NoTx, assertEndStateIs(AcceptingReadAndWrite),
+		},
+
+		{
+			AcceptingReadOnly,
+			[]txEngineState{
+				NotServing,
+				AcceptingReadAndWrite,
+			},
+			WriteRejected, assertEndStateIs(AcceptingReadAndWrite),
+		},
+
+		{
+			AcceptingReadOnly,
+			[]txEngineState{
+				AcceptingReadAndWrite,
+				AcceptingReadAndWrite,
+			},
+			WriteRejected, assertEndStateIs(AcceptingReadAndWrite),
+		},
+
+		{
+			AcceptingReadOnly,
+			[]txEngineState{
+				AcceptingReadOnly,
+				AcceptingReadAndWrite,
+			},
+			WriteRejected, assertEndStateIs(AcceptingReadAndWrite),
+		},
 
 		// Make sure that all transactions are rejected when we are not serving
-		{NotServing, []txEngineState{},
-			WriteRejected, assertEndStateIs(NotServing)},
+		{
+			NotServing,
+			[]txEngineState{},
+			WriteRejected, assertEndStateIs(NotServing),
+		},
 
-		{NotServing, []txEngineState{},
-			ReadOnlyRejected, assertEndStateIs(NotServing)},
+		{
+			NotServing,
+			[]txEngineState{},
+			ReadOnlyRejected, assertEndStateIs(NotServing),
+		},
 	}
 
 	for _, test := range tests {
 		outerT.Run(test.String(), func(t *testing.T) {
-
 			db := setUpQueryExecutorTest(t)
 			db.AddQuery("set transaction isolation level REPEATABLE READ", &sqltypes.Result{})
 			db.AddQuery("start transaction with consistent snapshot, read only", &sqltypes.Result{})
@@ -561,6 +720,48 @@ func startTx(te *TxEngine, writeTransaction bool) error {
 	}
 	_, _, _, err := te.Begin(context.Background(), 0, nil, options)
 	return err
+}
+
+// TestTxEngineReserve_GatedBySnake is a regression guard for an intentional
+// behavior change in this PR: bare Reserve() (txID == 0) used to bypass Snake
+// entirely, going straight to StatefulConnectionPool.NewConn without ever
+// going through TxPool.Begin's Acquire. Under the "no bypass" design, Reserve
+// now computes a priority and is gated like any other transaction.
+func TestTxEngineReserve_GatedBySnake(t *testing.T) {
+	db := setUpQueryExecutorTest(t)
+	defer db.Close()
+	db.AddQueryPattern(".*", &sqltypes.Result{})
+
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.DB = newDBConfigs(db)
+	cfg.TxPool.Size = 1
+	cfg.LoadshedEnabled = true
+	cfg.LoadshedTarget = 5 * time.Millisecond
+	cfg.LoadshedIntervalRatio = 20
+
+	te := NewTxEngine(tabletenv.NewEnv(vtenv.NewTestEnv(), cfg, "TabletServerTest"), nil)
+	te.AcceptReadOnly()
+
+	require.NotNil(t, te.txPool.snake, "snake should be initialized when LoadshedEnabled=true")
+
+	ctx := context.Background()
+	options := &querypb.ExecuteOptions{}
+
+	// Fill the single slot with a normal transaction.
+	txID, _, _, err := te.Begin(ctx, 0, nil, options)
+	require.NoError(t, err)
+
+	// A bare Reserve() must now be gated by the same shared Snake capacity.
+	shortCtx, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
+	defer cancel()
+	_, err = te.Reserve(shortCtx, options, 0, nil)
+	require.Error(t, err, "Reserve() should be gated while the shared slot is held")
+
+	// Release the transaction and confirm Reserve() succeeds once the slot frees.
+	_, _, err = te.Commit(ctx, txID)
+	require.NoError(t, err)
+	_, err = te.Reserve(ctx, options, 0, nil)
+	require.NoError(t, err, "Reserve() should succeed once the slot is free")
 }
 
 func TestTxEngineFailReserve(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/tx_pool.go
+++ b/go/vt/vttablet/tabletserver/tx_pool.go
@@ -18,6 +18,7 @@ package tabletserver
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync"
 	"time"
@@ -237,7 +238,6 @@ func (tp *TxPool) Begin(ctx context.Context, options *querypb.ExecuteOptions, re
 
 	var conn *StatefulConnection
 	var err error
-	var snakeRelease func()
 	if reservedID != 0 {
 		conn, err = tp.scp.GetAndLock(reservedID, "start transaction on reserve conn")
 		if err != nil {
@@ -253,26 +253,16 @@ func (tp *TxPool) Begin(ctx context.Context, options *querypb.ExecuteOptions, re
 			return nil, "", "", vterrors.Errorf(vtrpcpb.Code_RESOURCE_EXHAUSTED, "per-user transaction pool connection limit exceeded")
 		}
 
-		if tp.snake != nil {
-			valveID := options.GetLoadshedValveId()
-			snakePriority := snakePriorityFromOptions(options, tp.env.Config().TxThrottlerDefaultPriority)
-			unlock, snakeErr := tp.snake.Acquire(ctx, valveID, snakePriority)
-			if snakeErr != nil {
-				tp.limiter.Release(immediateCaller, effectiveCaller)
-				return nil, "", "", errDMLLoadShed
-			}
-			snakeRelease = func() { unlock.Release() }
+		snakePriority := snakePriorityFromOptions(options, tp.env.Config().TxThrottlerDefaultPriority)
+		conn, err = tp.createConn(ctx, options, setting, snakePriority)
+		if err != nil && errors.Is(err, smartconnpool.ErrPoolLoadShed) {
+			err = errDMLLoadShed
 		}
-
-		conn, err = tp.createConn(ctx, options, setting)
 		defer func() {
 			if err != nil {
 				// The transaction limiter frees transactions on rollback or commit. If we fail to create the transaction,
 				// release immediately since there will be no rollback or commit.
 				tp.limiter.Release(immediateCaller, effectiveCaller)
-				if snakeRelease != nil {
-					snakeRelease()
-				}
 			}
 		}()
 	}
@@ -290,7 +280,6 @@ func (tp *TxPool) Begin(ctx context.Context, options *querypb.ExecuteOptions, re
 	if setting != nil {
 		conn.TxProperties().RecordQueryDetail(setting.ApplyQuery(), nil)
 	}
-	conn.TxProperties().SnakeRelease = snakeRelease
 	return conn, sql, sessionStateChanges, nil
 }
 
@@ -305,8 +294,8 @@ func (tp *TxPool) begin(ctx context.Context, options *querypb.ExecuteOptions, re
 	return beginQueries, sessionStateChanges, nil
 }
 
-func (tp *TxPool) createConn(ctx context.Context, options *querypb.ExecuteOptions, setting *smartconnpool.Setting) (*StatefulConnection, error) {
-	conn, err := tp.scp.NewConn(ctx, options, setting)
+func (tp *TxPool) createConn(ctx context.Context, options *querypb.ExecuteOptions, setting *smartconnpool.Setting, priority float64) (*StatefulConnection, error) {
+	conn, err := tp.scp.NewConn(ctx, options, setting, priority)
 	if err != nil {
 		errCode := vterrors.Code(err)
 		switch err {
@@ -463,9 +452,6 @@ func (tp *TxPool) LogActive() {
 
 func (tp *TxPool) txComplete(conn *StatefulConnection, reason tx.ReleaseReason) {
 	conn.LogTransaction(reason)
-	if release := conn.TxProperties().SnakeRelease; release != nil {
-		release()
-	}
 	tp.limiter.Release(conn.TxProperties().ImmediateCaller, conn.TxProperties().EffectiveCaller)
 	conn.CleanTxState()
 }

--- a/go/vt/vttablet/tabletserver/tx_pool_snake_test.go
+++ b/go/vt/vttablet/tabletserver/tx_pool_snake_test.go
@@ -59,6 +59,8 @@ func setupWithSnake(t *testing.T, capacity int) (*fakesqldb.DB, *TxPool, func())
 		Capacity:            func() int { return capacity },
 		LoadsheddingAllowed: func() bool { return true },
 	})
+	txPool.scp.conns.SetSnake(txPool.snake, 0)
+	txPool.scp.foundRowsPool.SetSnake(txPool.snake, 0)
 
 	db := fakesqldb.New(t)
 	db.AddQueryPattern(".*", &sqltypes.Result{})
@@ -76,19 +78,19 @@ func TestTxPoolSnake_BeginAcquiresSlot(t *testing.T) {
 	defer closer()
 
 	ctx := context.Background()
-	opts := &querypb.ExecuteOptions{LoadshedValveId: "req-1"}
 
-	conn, _, _, err := txPool.Begin(ctx, opts, false, 0, nil)
+	conn, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
 	require.NoError(t, err)
-	assert.NotNil(t, conn.TxProperties().SnakeRelease)
+	assert.Equal(t, 1, txPool.snake.Stats().HolderCount)
 	conn.Unlock()
 
-	// Commit releases the snake slot via txComplete.
+	// Commit releases the snake slot via the connection's normal Recycle path.
 	conn2, err := txPool.GetAndLock(conn.ReservedID(), "")
 	require.NoError(t, err)
 	_, err = txPool.Commit(ctx, conn2)
 	require.NoError(t, err)
 	conn2.Release(tx.TxCommit)
+	assert.Equal(t, 0, txPool.snake.Stats().HolderCount)
 }
 
 func TestTxPoolSnake_CommitReleasesSlot(t *testing.T) {
@@ -96,14 +98,13 @@ func TestTxPoolSnake_CommitReleasesSlot(t *testing.T) {
 	defer closer()
 
 	ctx := context.Background()
-	opts := &querypb.ExecuteOptions{LoadshedValveId: "req-1"}
 
 	// Fill the single slot.
-	conn, _, _, err := txPool.Begin(ctx, opts, false, 0, nil)
+	conn, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
 	require.NoError(t, err)
 	conn.Unlock()
 
-	// Second begin with a different ID would block/fail if slot is not released.
+	// Second begin would block/fail if the slot is not released.
 	// Commit the first to free the slot.
 	conn2, err := txPool.GetAndLock(conn.ReservedID(), "")
 	require.NoError(t, err)
@@ -112,7 +113,7 @@ func TestTxPoolSnake_CommitReleasesSlot(t *testing.T) {
 	conn2.Release(tx.TxCommit)
 
 	// Now a new begin should succeed.
-	conn3, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{LoadshedValveId: "req-2"}, false, 0, nil)
+	conn3, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
 	require.NoError(t, err)
 	conn3.Unlock()
 	conn4, err := txPool.GetAndLock(conn3.ReservedID(), "")
@@ -126,9 +127,8 @@ func TestTxPoolSnake_RollbackReleasesSlot(t *testing.T) {
 	defer closer()
 
 	ctx := context.Background()
-	opts := &querypb.ExecuteOptions{LoadshedValveId: "req-1"}
 
-	conn, _, _, err := txPool.Begin(ctx, opts, false, 0, nil)
+	conn, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
 	require.NoError(t, err)
 	conn.Unlock()
 
@@ -138,7 +138,7 @@ func TestTxPoolSnake_RollbackReleasesSlot(t *testing.T) {
 	txPool.RollbackAndRelease(ctx, conn2)
 
 	// Slot is free — new begin should succeed.
-	conn3, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{LoadshedValveId: "req-2"}, false, 0, nil)
+	conn3, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
 	require.NoError(t, err)
 	conn3.Unlock()
 	conn4, err := txPool.GetAndLock(conn3.ReservedID(), "")
@@ -147,34 +147,14 @@ func TestTxPoolSnake_RollbackReleasesSlot(t *testing.T) {
 	conn4.Release(tx.TxCommit)
 }
 
-func TestTxPoolSnake_EmptyValveIDAcquiresSlot(t *testing.T) {
-	_, txPool, closer := setupWithSnake(t, 2)
-	defer closer()
-
-	ctx := context.Background()
-
-	// A request with no valve ID still acquires a Snake slot — it enters the
-	// CoDel queue directly, bypassing only the per-valve fairness layer.
-	conn, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
-	require.NoError(t, err)
-	assert.NotNil(t, conn.TxProperties().SnakeRelease, "empty valve ID should still acquire a Snake slot")
-	conn.Unlock()
-
-	// Cleanup.
-	c, _ := txPool.GetAndLock(conn.ReservedID(), "")
-	_, _ = txPool.Commit(ctx, c)
-	c.Release(tx.TxCommit)
-}
-
 func TestTxPoolSnake_ReservedConnSkipsSnake(t *testing.T) {
 	_, txPool, closer := setupWithSnake(t, 1)
 	defer closer()
 
 	ctx := context.Background()
-	opts := &querypb.ExecuteOptions{LoadshedValveId: "req-1"}
 
 	// Fill the single slot.
-	conn, _, _, err := txPool.Begin(ctx, opts, false, 0, nil)
+	conn, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
 	require.NoError(t, err)
 	reservedID := conn.ReservedID()
 	conn.Unlock()
@@ -184,19 +164,21 @@ func TestTxPoolSnake_ReservedConnSkipsSnake(t *testing.T) {
 	require.NoError(t, err)
 	_, _ = txPool.Commit(ctx, conn2)
 	conn2.Release(tx.TxCommit)
+	assert.Equal(t, 0, txPool.snake.Stats().HolderCount)
 
 	// Begin with reservedID on the same conn: since the first tx committed and released,
 	// we need a new conn to test reservedID path. Create one via Begin first.
-	conn3, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{LoadshedValveId: "req-2"}, false, 0, nil)
+	conn3, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
 	require.NoError(t, err)
 	rid := conn3.ReservedID()
 	conn3.Unlock()
+	assert.Equal(t, 1, txPool.snake.Stats().HolderCount)
 
-	// Now do a Begin with the reservedID — this takes the reservedID != 0 path.
-	conn4, _, _, err := txPool.Begin(ctx, opts, false, rid, nil)
+	// Now do a Begin with the reservedID — this takes the reservedID != 0 path and
+	// must not acquire a second slot.
+	conn4, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, rid, nil)
 	require.NoError(t, err)
-	// SnakeRelease is nil because the reservedID path doesn't acquire from snake.
-	assert.Nil(t, conn4.TxProperties().SnakeRelease)
+	assert.Equal(t, 1, txPool.snake.Stats().HolderCount, "the reservedID path must not acquire from snake")
 	conn4.Unlock()
 	conn5, _ := txPool.GetAndLock(rid, "")
 	_, _ = txPool.Commit(ctx, conn5)
@@ -210,16 +192,16 @@ func TestTxPoolSnake_CapacityExhaustedShedsLoad(t *testing.T) {
 	ctx := context.Background()
 
 	// Fill the single slot.
-	conn, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{LoadshedValveId: "req-1"}, false, 0, nil)
+	conn, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
 	require.NoError(t, err)
 	conn.Unlock()
 
-	// Second request with a different contention ID should be shed once CoDel kicks in.
-	// Use a short-lived context to avoid waiting forever.
+	// A second request should be shed once CoDel kicks in. Use a short-lived context
+	// to avoid waiting forever.
 	shortCtx, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
 	defer cancel()
 
-	_, _, _, err = txPool.Begin(shortCtx, &querypb.ExecuteOptions{LoadshedValveId: "req-2"}, false, 0, nil)
+	_, _, _, err = txPool.Begin(shortCtx, &querypb.ExecuteOptions{}, false, 0, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "dml load shed")
 
@@ -232,8 +214,8 @@ func TestTxPoolSnake_CapacityExhaustedShedsLoad(t *testing.T) {
 // TestTxPoolSnake_DirectReleaseFreesSlot covers the leak path: a connection that
 // acquired a Snake slot in Begin but is torn down via conn.Release() directly —
 // as the kill/shutdown/taint/renew-fail paths do — instead of through
-// Commit/Rollback (txComplete). The Snake slot must still be freed, or the gate
-// leaks holders until capacity is exhausted and all writes stall.
+// Commit/Rollback. The Snake slot must still be freed, or the gate leaks holders
+// until capacity is exhausted and all writes stall.
 func TestTxPoolSnake_DirectReleaseFreesSlot(t *testing.T) {
 	_, txPool, closer := setupWithSnake(t, 1)
 	defer closer()
@@ -241,9 +223,9 @@ func TestTxPoolSnake_DirectReleaseFreesSlot(t *testing.T) {
 	ctx := context.Background()
 
 	// Fill the single slot.
-	conn, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{LoadshedValveId: "req-1"}, false, 0, nil)
+	conn, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
 	require.NoError(t, err)
-	require.NotNil(t, conn.TxProperties().SnakeRelease)
+	require.Equal(t, 1, txPool.snake.Stats().HolderCount)
 
 	// Tear the connection down the "bypass" way: a direct Release, NOT via
 	// Commit/Rollback. This is what transactionKiller, Shutdown, and tainted-conn
@@ -253,12 +235,50 @@ func TestTxPoolSnake_DirectReleaseFreesSlot(t *testing.T) {
 	// If the slot leaked, this Begin never gets granted and times out (shed).
 	shortCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
-	conn2, _, _, err := txPool.Begin(shortCtx, &querypb.ExecuteOptions{LoadshedValveId: "req-2"}, false, 0, nil)
+	conn2, _, _, err := txPool.Begin(shortCtx, &querypb.ExecuteOptions{}, false, 0, nil)
 	require.NoError(t, err, "slot must be freed by a direct Release; a leak would starve this Begin")
 	conn2.Unlock()
 	c, _ := txPool.GetAndLock(conn2.ReservedID(), "")
 	_, _ = txPool.Commit(ctx, c)
 	c.Release(tx.TxCommit)
+}
+
+// TestTxPoolSnake_SharedAcrossFoundRowsPool proves conns and foundRowsPool
+// share ONE Snake instance and capacity, not two independent gates. If the
+// wiring in tx_engine.go ever regressed to constructing two Snakes (or
+// forgetting to attach the second SetSnake call), a CLIENT_FOUND_ROWS
+// transaction would bypass shedding entirely while still counting against
+// the capacity the shared Snake believes it's tracking.
+func TestTxPoolSnake_SharedAcrossFoundRowsPool(t *testing.T) {
+	_, txPool, closer := setupWithSnake(t, 1)
+	defer closer()
+
+	ctx := context.Background()
+
+	// Fill the single shared slot via the regular (non-found-rows) pool.
+	conn, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
+	require.NoError(t, err)
+	conn.Unlock()
+
+	// A CLIENT_FOUND_ROWS transaction must be gated too, since it shares the
+	// same Snake capacity — not routed to an independently-gated pool.
+	shortCtx, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
+	defer cancel()
+	_, _, _, err = txPool.Begin(shortCtx, &querypb.ExecuteOptions{ClientFoundRows: true}, false, 0, nil)
+	require.Error(t, err, "found-rows transaction should be gated by the same shared Snake capacity")
+
+	// Releasing the original holder frees the shared slot for the
+	// found-rows transaction.
+	c, _ := txPool.GetAndLock(conn.ReservedID(), "")
+	_, _ = txPool.Commit(ctx, c)
+	c.Release(tx.TxCommit)
+
+	conn2, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{ClientFoundRows: true}, false, 0, nil)
+	require.NoError(t, err, "found-rows transaction should succeed once the shared slot is free")
+	conn2.Unlock()
+	c2, _ := txPool.GetAndLock(conn2.ReservedID(), "")
+	_, _ = txPool.Commit(ctx, c2)
+	c2.Release(tx.TxCommit)
 }
 
 func TestTxPoolSnake_NilSnakePassesThrough(t *testing.T) {
@@ -267,11 +287,9 @@ func TestTxPoolSnake_NilSnakePassesThrough(t *testing.T) {
 	defer closer()
 
 	ctx := context.Background()
-	opts := &querypb.ExecuteOptions{LoadshedValveId: "req-1"}
 
-	conn, _, _, err := txPool.Begin(ctx, opts, false, 0, nil)
+	conn, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
 	require.NoError(t, err)
-	assert.Nil(t, conn.TxProperties().SnakeRelease)
 	conn.Unlock()
 	c, _ := txPool.GetAndLock(conn.ReservedID(), "")
 	_, _ = txPool.Commit(ctx, c)


### PR DESCRIPTION
### Background / Why?

Snake's admission gate lives entirely at tabletserver call sites (`query_executor.go`, `tx_pool.go`) today: each caller manually calls `snake.Acquire` before the pool's `Get` and releases afterward. That per-call-site wiring is easy to miss — the app-debug path in `connpool.Pool.Get` and bare `Reserve()` (`txID==0`) both skip Snake entirely today, since neither goes through `query_executor.go` or `TxPool.Begin`. This PR moves the gate into `smartconnpool` and `connpool.Pool` themselves, so every acquisition from a pool with a Snake attached is gated by construction. Priority (including `loadshed.PriorityUndroppable`) becomes the only lever for exemption, replacing "don't call Acquire" as an opt-out — which intentionally expands what gets shed: app-debug and bare-`Reserve()` traffic, both previously bypassed, are now gated with a computed or undroppable priority. Threading the gate's outcome onto the returned `*Pooled[C]` instead of a caller-held closure surfaced a real leak: `Recycle`, `Taint`, and `Close` each have a branch that can discard a borrowed connection without calling `put()`. The old `TxProperties.SnakeRelease` field and its idempotent-release dance across `txComplete`/`ReleaseString` existed to cover that gap; all three methods now release the handle unconditionally before touching pool state, letting `SnakeRelease` be deleted rather than relocated. `TxPool`'s `conns` and `foundRowsPool` pools continue to share one Snake instance and one capacity, matching today's single-Acquire-gates-both-pools behavior. The only change inside `loadshed` itself: `Acquire` drops its `valveID` parameter and always enqueues with an empty ID, the same already-tested bypass path — valve support is deferred, not removed.

### Testing

New unit tests covering fast-path gating, `Recycle`-frees-slot, plain `Get` gated identically to `GetWithPriority`, `PriorityUndroppable` never shed, the app-debug path, the shared-capacity behavior across `conns`/`foundRowsPool`, and the now-gated `Reserve()` path. Existing unit tests updated for the `Acquire` signature change; several Snake-level valve-fairness tests were removed since `Acquire` no longer reaches the valve (redundant with `valved_codelq_test.go`'s queue-level coverage) — those should be revisited when valve support returns to the entrypoint.

AI disclosure: Claude Code assisted with development. Every line of code was either written by or carefully reviewed by me :)
