### PR TITLE
Judge `lockedAdvance` staleness by oldest waiter, not list head

### DIFF
--- a/go/vt/vttablet/tabletserver/loadshed/codelq.go
+++ b/go/vt/vttablet/tabletserver/loadshed/codelq.go
@@ -537,16 +537,8 @@ func (q *CoDelQueue) lockedAdvance(now int64, dropFn func() bool) {
 		// from re-arming: only the monitor (on a trigger crossing) may take count
 		// off 1 in jump-start. In arm-on-enqueue modes the head-check re-arms at
 		// count==1 as usual.
-		//
-		// Judge staleness by the oldest WAITING request (lockedFirstWaiting),
-		// not the raw list head (lockedPeek): a granted request can stay
-		// resident in the list as UNDROPPABLE until Release, and it can never
-		// be a drop candidate, so its age must not drive this decision. We
-		// still call lockedPeek for its defensive cleanup side effect (it
-		// purges a done-with-error request left resident by a bypassed
-		// signal path) and to keep firstWaiting itself in sync.
 		if q.droppableLen > 0 && (q.count > 1 || q.armsOnEnqueue()) {
-			q.lockedPeek()
+			q.lockedPeek() // cleanup
 			if first := q.lockedFirstWaiting(); first != nil && first.codelqEnqueuedAtNs < q.dropNextNs {
 				q.dropping = true
 			}

--- a/go/vt/vttablet/tabletserver/loadshed/codelq.go
+++ b/go/vt/vttablet/tabletserver/loadshed/codelq.go
@@ -537,9 +537,17 @@ func (q *CoDelQueue) lockedAdvance(now int64, dropFn func() bool) {
 		// from re-arming: only the monitor (on a trigger crossing) may take count
 		// off 1 in jump-start. In arm-on-enqueue modes the head-check re-arms at
 		// count==1 as usual.
+		//
+		// Judge staleness by the oldest WAITING request (lockedFirstWaiting),
+		// not the raw list head (lockedPeek): a granted request can stay
+		// resident in the list as UNDROPPABLE until Release, and it can never
+		// be a drop candidate, so its age must not drive this decision. We
+		// still call lockedPeek for its defensive cleanup side effect (it
+		// purges a done-with-error request left resident by a bypassed
+		// signal path) and to keep firstWaiting itself in sync.
 		if q.droppableLen > 0 && (q.count > 1 || q.armsOnEnqueue()) {
-			first := q.lockedPeek()
-			if first.codelqEnqueuedAtNs < q.dropNextNs {
+			q.lockedPeek()
+			if first := q.lockedFirstWaiting(); first != nil && first.codelqEnqueuedAtNs < q.dropNextNs {
 				q.dropping = true
 			}
 		}

--- a/go/vt/vttablet/tabletserver/loadshed/codelq_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/codelq_test.go
@@ -511,6 +511,72 @@ func TestCoDelQueue_OnGrant_Idempotent(t *testing.T) {
 	assert.Equal(t, 0, q.droppableLen)
 }
 
+// --- Advance head-check: resident holder vs. real backlog staleness ---
+
+// TestCoDelQueue_Advance_ResidentGrantedStragglerDoesNotCauseExtraDrops proves
+// that lockedAdvance's re-arm head-check judges staleness by the oldest
+// WAITING request, not by whatever happens to sit at the raw list front. A
+// granted request that's still resident in the queue (as an UNDROPPABLE
+// entry, pending Release) can never itself be dropped, so its age is
+// irrelevant to "is there a stale droppable candidate" — using it anyway
+// makes a multi-interval catch-up (e.g. a backstop timer that fired late)
+// ramp count and shed a perfectly healthy backlog.
+//
+// Concretely: a straggler granted 900ms ago is still resident. A backstop
+// timer that's 3 intervals (300ms) behind fires against 6 requests that are
+// each only 5ms old (well under target). Judging staleness by the straggler
+// sheds the entire healthy backlog (6 drops, count ramps to 7) before easing
+// back down; judging it by the oldest real waiter sheds only 1 before
+// recognizing the backlog is healthy (count never exceeds 2). Both end with
+// dropping=true — the very last iteration's check is a tautology (any
+// resident timestamp is by definition <= now < the just-advanced
+// dropNextNs) — so the bug is about how many requests get shed along the
+// way during catch-up, not about the final dropping/healthy verdict.
+func TestCoDelQueue_Advance_ResidentGrantedStragglerDoesNotCauseExtraDrops(t *testing.T) {
+	clock := newTestClock()
+	cfg := CoDelConfig{
+		IntervalNs:     func() int64 { return 100_000_000 }, // 100ms
+		TargetNs:       func() int64 { return 20_000_000 },  // 20ms
+		Exponent:       func() float64 { return 1.0 },
+		MinDropDelayNs: func() int64 { return 100 },
+		EasingLogBase:  func() float64 { return 3.0 },
+	}
+	q, _ := newTestQueue(cfg, clock)
+
+	// Straggler: enqueued early, granted almost immediately, stays resident
+	// in the raw list (undroppable) until Release — that's unrelated to this
+	// fix; it's exactly the pre-existing "semaphore fused into the queue"
+	// behavior. This fix only changes which entry the staleness check reads.
+	clock.now = 100_000_000
+	straggler := testEnqueue(q, 0)
+	q.lockedOnGrant(straggler)
+	require.NotNil(t, straggler.codelqElem, "sanity: straggler remains resident (grant-time eviction is separate work)")
+
+	// Six fresh, healthy waiters arrive together, well after the straggler.
+	clock.now = 995_000_000
+	for range 6 {
+		testEnqueue(q, 0)
+	}
+	require.Equal(t, 6, q.droppableLen)
+
+	// Seed a catch-up scenario: dropNextNs is 3 intervals stale relative to
+	// "now" (simulating a delayed backstop timer fire), dropping already
+	// armed from whenever the episode originally started.
+	q.dropping = true
+	q.count = 1
+	q.dropNextNs = 700_000_000
+	clock.now = 1_000_000_000
+
+	drops := 0
+	q.lockedRunTimer(countingDropFn(q, &drops))
+
+	assert.Equal(t, 1, drops, "only the straggler's presence in the list should be irrelevant; the fresh backlog should cause at most 1 drop before being recognized as healthy")
+	assert.Equal(t, 1, q.count, "count should never ramp past the point where the real backlog is recognized as healthy")
+	assert.Equal(t, int64(1_050_000_000), q.dropNextNs)
+	assert.Equal(t, 5, q.droppableLen)
+	assert.True(t, q.dropping, "final-iteration tautology: re-marked true regardless, since dropNextNs just advanced past now")
+}
+
 // --- Integration: fast vs slow moving ---
 
 func TestCoDelQueue_FastMoving_NoDrop(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/loadshed/codelq_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/codelq_test.go
@@ -513,25 +513,6 @@ func TestCoDelQueue_OnGrant_Idempotent(t *testing.T) {
 
 // --- Advance head-check: resident holder vs. real backlog staleness ---
 
-// TestCoDelQueue_Advance_ResidentGrantedStragglerDoesNotCauseExtraDrops proves
-// that lockedAdvance's re-arm head-check judges staleness by the oldest
-// WAITING request, not by whatever happens to sit at the raw list front. A
-// granted request that's still resident in the queue (as an UNDROPPABLE
-// entry, pending Release) can never itself be dropped, so its age is
-// irrelevant to "is there a stale droppable candidate" — using it anyway
-// makes a multi-interval catch-up (e.g. a backstop timer that fired late)
-// ramp count and shed a perfectly healthy backlog.
-//
-// Concretely: a straggler granted 900ms ago is still resident. A backstop
-// timer that's 3 intervals (300ms) behind fires against 6 requests that are
-// each only 5ms old (well under target). Judging staleness by the straggler
-// sheds the entire healthy backlog (6 drops, count ramps to 7) before easing
-// back down; judging it by the oldest real waiter sheds only 1 before
-// recognizing the backlog is healthy (count never exceeds 2). Both end with
-// dropping=true — the very last iteration's check is a tautology (any
-// resident timestamp is by definition <= now < the just-advanced
-// dropNextNs) — so the bug is about how many requests get shed along the
-// way during catch-up, not about the final dropping/healthy verdict.
 func TestCoDelQueue_Advance_ResidentGrantedStragglerDoesNotCauseExtraDrops(t *testing.T) {
 	clock := newTestClock()
 	cfg := CoDelConfig{
@@ -543,14 +524,10 @@ func TestCoDelQueue_Advance_ResidentGrantedStragglerDoesNotCauseExtraDrops(t *te
 	}
 	q, _ := newTestQueue(cfg, clock)
 
-	// Straggler: enqueued early, granted almost immediately, stays resident
-	// in the raw list (undroppable) until Release — that's unrelated to this
-	// fix; it's exactly the pre-existing "semaphore fused into the queue"
-	// behavior. This fix only changes which entry the staleness check reads.
 	clock.now = 100_000_000
 	straggler := testEnqueue(q, 0)
 	q.lockedOnGrant(straggler)
-	require.NotNil(t, straggler.codelqElem, "sanity: straggler remains resident (grant-time eviction is separate work)")
+	require.NotNil(t, straggler.codelqElem, "precondition")
 
 	// Six fresh, healthy waiters arrive together, well after the straggler.
 	clock.now = 995_000_000

--- a/go/vt/vttablet/tabletserver/loadshed/codelq_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/codelq_test.go
@@ -547,11 +547,11 @@ func TestCoDelQueue_Advance_ResidentGrantedStragglerDoesNotCauseExtraDrops(t *te
 	drops := 0
 	q.lockedRunTimer(countingDropFn(q, &drops))
 
-	assert.Equal(t, 1, drops, "only the straggler's presence in the list should be irrelevant; the fresh backlog should cause at most 1 drop before being recognized as healthy")
-	assert.Equal(t, 1, q.count, "count should never ramp past the point where the real backlog is recognized as healthy")
+	assert.Equal(t, 1, drops)
+	assert.Equal(t, 1, q.count)
 	assert.Equal(t, int64(1_050_000_000), q.dropNextNs)
 	assert.Equal(t, 5, q.droppableLen)
-	assert.True(t, q.dropping, "final-iteration tautology: re-marked true regardless, since dropNextNs just advanced past now")
+	assert.True(t, q.dropping, "tautology: last iteration always re-marks true")
 }
 
 // --- Integration: fast vs slow moving ---


### PR DESCRIPTION
### Background / Why?

`lockedAdvance`'s re-arm check compared the raw CoDel-queue list front's enqueue time against the next drop deadline to decide whether real load was still stale — but a granted request stays resident in that list as `UNDROPPABLE` until `Release`, so a long-held straggler could be the list front and its age, not the real backlog's, drove the decision. Both checks still end a catch-up call with `dropping=true` — the last iteration's comparison is a tautology, since any resident entry's timestamp is by construction ≤ now < the just-advanced deadline — so the difference is in how much gets shed mid-catch-up, not the final verdict.

```mermaid
flowchart TB
    subgraph Q["CoDel list, oldest to newest"]
        A["A<br/>900ms, granted"]
        W1["W1<br/>5ms"]
        W2["W2<br/>5ms"]
        W3["W3<br/>5ms"]
        W4["W4<br/>5ms"]
        W5["W5<br/>5ms"]
        W6["W6<br/>5ms"]
        A --> W1 --> W2 --> W3 --> W4 --> W5 --> W6
    end

    Old["OLD: lockedPeek&#40;&#41;"]
    New["NEW: lockedFirstWaiting&#40;&#41;"]
    A -.-> Old
    W1 -.-> New

    OldResult["count 1 to 7, 6 dropped"]
    NewResult["count stays low, 1 dropped"]
    Old --> OldResult
    New --> NewResult

    classDef granted fill:#90EE90,stroke:#2e7d32,color:#000
    class A granted
```

### Testing

New unit tests.

AI disclosure: Claude Code assisted with development. Every line of code was either written by or carefully reviewed by me :)