### PR TITLE
Move Snake semaphore outside of the codelq

### DIFF
--- a/go/vt/vttablet/tabletserver/loadshed/codelq.go
+++ b/go/vt/vttablet/tabletserver/loadshed/codelq.go
@@ -407,8 +407,6 @@ func (q *CoDelQueue) lockedRemove(r *Request) {
 	}
 }
 
-// lockedOnGrant marks a request granted and evicts it from the list.
-// Guarded so a second call, or a subsequent lockedComplete, is a no-op.
 func (q *CoDelQueue) lockedOnGrant(r *Request) {
 	// CoDel health check, measured at grant: if this request's queue-wait
 	// (now - enqueue) was under target, the system is healthy — leave the
@@ -424,11 +422,9 @@ func (q *CoDelQueue) lockedOnGrant(r *Request) {
 			q.dropping = false
 		}
 	}
-	if r.codelqElem != nil {
-		q.lockedAdvanceFirstWaiting(r.codelqElem)
-		q.queue.Remove(r.codelqElem)
-		r.codelqElem = nil
-	}
+	q.lockedAdvanceFirstWaiting(r.codelqElem)
+	q.queue.Remove(r.codelqElem)
+	r.codelqElem = nil
 }
 
 // lockedAdvanceFirstWaiting advances the firstWaiting pointer past elem if

--- a/go/vt/vttablet/tabletserver/loadshed/codelq.go
+++ b/go/vt/vttablet/tabletserver/loadshed/codelq.go
@@ -320,10 +320,14 @@ func (q *CoDelQueue) lockedEnqueue(req *Request) {
 	}
 }
 
-// lockedComplete removes a granted (undroppable) request from the queue on
-// Release. The CoDel health check happens at grant (see lockedOnGrant), so
-// this only unlinks the request.
+// lockedComplete is a no-op in the common case: lockedOnGrant already evicted
+// the request from the list eagerly at grant time, so by Release there's
+// nothing left to unlink. Guards against a nil codelqElem so a granted
+// request's Release is always safe.
 func (q *CoDelQueue) lockedComplete(r *Request) {
+	if r.codelqElem == nil {
+		return
+	}
 	q.queue.Remove(r.codelqElem)
 	r.codelqElem = nil
 }
@@ -405,6 +409,12 @@ func (q *CoDelQueue) lockedRemove(r *Request) {
 	}
 }
 
+// lockedOnGrant marks a request granted and evicts it from the underlying
+// list immediately: sojourn (queue-wait) is measured right here, at grant,
+// so a held request no longer needs to occupy a list node to preserve the
+// shedding signal — that's now lockedAdvance's job via lockedFirstWaiting.
+// Guarded by codelqElem != nil so a second call (or a subsequent
+// lockedComplete) is a safe no-op.
 func (q *CoDelQueue) lockedOnGrant(r *Request) {
 	// CoDel health check, measured at grant: if this request's queue-wait
 	// (now - enqueue) was under target, the system is healthy — leave the
@@ -420,7 +430,11 @@ func (q *CoDelQueue) lockedOnGrant(r *Request) {
 			q.dropping = false
 		}
 	}
-	q.lockedAdvanceFirstWaiting(r.codelqElem)
+	if r.codelqElem != nil {
+		q.lockedAdvanceFirstWaiting(r.codelqElem)
+		q.queue.Remove(r.codelqElem)
+		r.codelqElem = nil
+	}
 }
 
 // lockedAdvanceFirstWaiting advances the firstWaiting pointer past elem if

--- a/go/vt/vttablet/tabletserver/loadshed/codelq.go
+++ b/go/vt/vttablet/tabletserver/loadshed/codelq.go
@@ -78,7 +78,7 @@ import (
         | * timer: armed            |
         *---------------------------*
               |  ^            ^
-    timer     |  |            | release path w/ sojourn < target
+    timer     |  |            | dequeue/release w/ sojourn < target
     fires,    |  |            | or queue emptied (sets dropping=false)
     NOT       |  | timer fires,
     healthy   |  | healthy (dropping=false)
@@ -100,7 +100,7 @@ import (
         interval), jumping count to log2(droppableLen). An episode ends when
         count eases back to 1 — even if a backlog remains; the monitor then
         re-checks the head and re-arms when it next crosses the trigger. The
-        monitor (not release) drives arming so a stuck queue with no
+        monitor (not dequeue/release) drives arming so a stuck queue with no
         completions can still shed.
       * DropBoth: arms on enqueue like slow-start, but while count==1 it also
         watches the head's sojourn (lockedTryJump). The episode leaves count==1
@@ -126,7 +126,7 @@ import (
                |  |
  episode       |  | count eases to 1
  triggered in  |  | (fully relaxed, nothing to do)
- release path  |  |
+ dequeue/release|  |
  (sojourn>trig)|  v
       *-----------------*
       | timer not armed |

--- a/go/vt/vttablet/tabletserver/loadshed/codelq.go
+++ b/go/vt/vttablet/tabletserver/loadshed/codelq.go
@@ -78,7 +78,7 @@ import (
         | * timer: armed            |
         *---------------------------*
               |  ^            ^
-    timer     |  |            | lockedComplete() w/ sojourn < target
+    timer     |  |            | release path w/ sojourn < target
     fires,    |  |            | or queue emptied (sets dropping=false)
     NOT       |  | timer fires,
     healthy   |  | healthy (dropping=false)
@@ -100,7 +100,7 @@ import (
         interval), jumping count to log2(droppableLen). An episode ends when
         count eases back to 1 — even if a backlog remains; the monitor then
         re-checks the head and re-arms when it next crosses the trigger. The
-        monitor (not lockedComplete) drives arming so a stuck queue with no
+        monitor (not release) drives arming so a stuck queue with no
         completions can still shed.
       * DropBoth: arms on enqueue like slow-start, but while count==1 it also
         watches the head's sojourn (lockedTryJump). The episode leaves count==1
@@ -126,7 +126,7 @@ import (
                |  |
  episode       |  | count eases to 1
  triggered in  |  | (fully relaxed, nothing to do)
- lockedComplete|  |
+ release path  |  |
  (sojourn>trig)|  v
       *-----------------*
       | timer not armed |
@@ -318,16 +318,6 @@ func (q *CoDelQueue) lockedEnqueue(req *Request) {
 			}
 		}
 	}
-}
-
-// lockedComplete unlinks a request from the queue. Usually a no-op, since
-// lockedOnGrant already evicted it at grant time.
-func (q *CoDelQueue) lockedComplete(r *Request) {
-	if r.codelqElem == nil {
-		return
-	}
-	q.queue.Remove(r.codelqElem)
-	r.codelqElem = nil
 }
 
 // lockedFirstWaiting returns the first not-yet-granted request in the queue.

--- a/go/vt/vttablet/tabletserver/loadshed/codelq.go
+++ b/go/vt/vttablet/tabletserver/loadshed/codelq.go
@@ -320,10 +320,8 @@ func (q *CoDelQueue) lockedEnqueue(req *Request) {
 	}
 }
 
-// lockedComplete is a no-op in the common case: lockedOnGrant already evicted
-// the request from the list eagerly at grant time, so by Release there's
-// nothing left to unlink. Guards against a nil codelqElem so a granted
-// request's Release is always safe.
+// lockedComplete unlinks a request from the queue. Usually a no-op, since
+// lockedOnGrant already evicted it at grant time.
 func (q *CoDelQueue) lockedComplete(r *Request) {
 	if r.codelqElem == nil {
 		return
@@ -409,12 +407,8 @@ func (q *CoDelQueue) lockedRemove(r *Request) {
 	}
 }
 
-// lockedOnGrant marks a request granted and evicts it from the underlying
-// list immediately: sojourn (queue-wait) is measured right here, at grant,
-// so a held request no longer needs to occupy a list node to preserve the
-// shedding signal — that's now lockedAdvance's job via lockedFirstWaiting.
-// Guarded by codelqElem != nil so a second call (or a subsequent
-// lockedComplete) is a safe no-op.
+// lockedOnGrant marks a request granted and evicts it from the list.
+// Guarded so a second call, or a subsequent lockedComplete, is a no-op.
 func (q *CoDelQueue) lockedOnGrant(r *Request) {
 	// CoDel health check, measured at grant: if this request's queue-wait
 	// (now - enqueue) was under target, the system is healthy — leave the

--- a/go/vt/vttablet/tabletserver/loadshed/codelq.go
+++ b/go/vt/vttablet/tabletserver/loadshed/codelq.go
@@ -335,7 +335,7 @@ func (q *CoDelQueue) lockedPeek() *Request {
 	for q.queue.Len() > 0 {
 		front := q.queue.Front()
 		req := front.Value.(*Request)
-		if req.signaledValue == nil || req.signaledValue == grantSentinel {
+		if req.signaledValue == nil {
 			return req
 		}
 		q.lockedAdvanceFirstWaiting(front)
@@ -406,7 +406,6 @@ func (q *CoDelQueue) lockedOnGrant(r *Request) {
 	}
 	if r.isDroppable() {
 		q.droppable.remove(r)
-		r.priority = PriorityUndroppable
 		q.droppableLen--
 		if q.droppableLen == 0 {
 			q.dropping = false

--- a/go/vt/vttablet/tabletserver/loadshed/codelq_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/codelq_test.go
@@ -249,18 +249,28 @@ func TestCoDelQueue_Peek_CleansHeadCancelled(t *testing.T) {
 	assert.Equal(t, 1, q.lockedLen())
 }
 
-func TestCoDelQueue_Peek_KeepsDoneNotCancelled(t *testing.T) {
+// TestCoDelQueue_OnGrant_EvictsFromListImmediately proves that a granted
+// request leaves the underlying list at grant time rather than lingering
+// (as an UNDROPPABLE entry) until Release — sojourn is measured at grant, so
+// the queue no longer needs a held request occupying a list node to
+// preserve the shedding signal. lockedComplete on the already-evicted
+// request must stay a safe no-op (no double-removal panic).
+func TestCoDelQueue_OnGrant_EvictsFromListImmediately(t *testing.T) {
 	clock := newTestClock()
 	q, _ := newTestQueue(defaultTestConfig(), clock)
 
 	r1 := testEnqueue(q, 0)
+	require.NotNil(t, r1.codelqElem)
 
 	r1.signal(grantSentinel)
 	q.lockedOnGrant(r1)
 
-	peeked := q.lockedPeek()
-	assert.Same(t, r1, peeked)
-	assert.Equal(t, 1, q.lockedLen())
+	assert.Nil(t, r1.codelqElem, "grant should evict immediately")
+	assert.Nil(t, q.lockedPeek(), "nothing left to peek")
+	assert.Equal(t, 0, q.lockedLen())
+
+	q.lockedComplete(r1)
+	assert.Equal(t, 0, q.lockedLen(), "release after grant-time eviction is a no-op, not a double-decrement")
 }
 
 // --- Drop tests ---
@@ -509,6 +519,7 @@ func TestCoDelQueue_OnGrant_Idempotent(t *testing.T) {
 	q.lockedOnGrant(r1)
 	q.lockedOnGrant(r1)
 	assert.Equal(t, 0, q.droppableLen)
+	assert.Nil(t, r1.codelqElem, "second grant must not double-remove an already-evicted request")
 }
 
 // --- Advance head-check: resident holder vs. real backlog staleness ---

--- a/go/vt/vttablet/tabletserver/loadshed/codelq_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/codelq_test.go
@@ -484,7 +484,6 @@ func TestCoDelQueue_OnGrant(t *testing.T) {
 
 	q.lockedOnGrant(r1)
 	assert.Equal(t, 0, q.droppableLen)
-	assert.False(t, r1.isDroppable())
 }
 
 func TestCoDelQueue_OnGrant_AlreadyNotDroppable(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/loadshed/codelq_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/codelq_test.go
@@ -503,19 +503,6 @@ func TestCoDelQueue_OnGrant_AlreadyNotDroppable(t *testing.T) {
 	assert.Equal(t, 0, q.droppableLen)
 }
 
-func TestCoDelQueue_OnGrant_Idempotent(t *testing.T) {
-	clock := newTestClock()
-	q, _ := newTestQueue(defaultTestConfig(), clock)
-
-	r1 := testEnqueue(q, 0)
-	assert.Equal(t, 1, q.droppableLen)
-
-	q.lockedOnGrant(r1)
-	q.lockedOnGrant(r1)
-	assert.Equal(t, 0, q.droppableLen)
-	assert.Nil(t, r1.codelqElem, "no double-remove")
-}
-
 // --- Advance head-check: resident holder vs. real backlog staleness ---
 
 func TestCoDelQueue_Advance_ResidentGrantedStragglerDoesNotCauseExtraDrops(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/loadshed/codelq_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/codelq_test.go
@@ -249,12 +249,6 @@ func TestCoDelQueue_Peek_CleansHeadCancelled(t *testing.T) {
 	assert.Equal(t, 1, q.lockedLen())
 }
 
-// TestCoDelQueue_OnGrant_EvictsFromListImmediately proves that a granted
-// request leaves the underlying list at grant time rather than lingering
-// (as an UNDROPPABLE entry) until Release — sojourn is measured at grant, so
-// the queue no longer needs a held request occupying a list node to
-// preserve the shedding signal. lockedComplete on the already-evicted
-// request must stay a safe no-op (no double-removal panic).
 func TestCoDelQueue_OnGrant_EvictsFromListImmediately(t *testing.T) {
 	clock := newTestClock()
 	q, _ := newTestQueue(defaultTestConfig(), clock)
@@ -265,12 +259,12 @@ func TestCoDelQueue_OnGrant_EvictsFromListImmediately(t *testing.T) {
 	r1.signal(grantSentinel)
 	q.lockedOnGrant(r1)
 
-	assert.Nil(t, r1.codelqElem, "grant should evict immediately")
-	assert.Nil(t, q.lockedPeek(), "nothing left to peek")
+	assert.Nil(t, r1.codelqElem)
+	assert.Nil(t, q.lockedPeek())
 	assert.Equal(t, 0, q.lockedLen())
 
 	q.lockedComplete(r1)
-	assert.Equal(t, 0, q.lockedLen(), "release after grant-time eviction is a no-op, not a double-decrement")
+	assert.Equal(t, 0, q.lockedLen(), "no double-decrement")
 }
 
 // --- Drop tests ---
@@ -519,7 +513,7 @@ func TestCoDelQueue_OnGrant_Idempotent(t *testing.T) {
 	q.lockedOnGrant(r1)
 	q.lockedOnGrant(r1)
 	assert.Equal(t, 0, q.droppableLen)
-	assert.Nil(t, r1.codelqElem, "second grant must not double-remove an already-evicted request")
+	assert.Nil(t, r1.codelqElem, "no double-remove")
 }
 
 // --- Advance head-check: resident holder vs. real backlog staleness ---

--- a/go/vt/vttablet/tabletserver/loadshed/codelq_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/codelq_test.go
@@ -497,49 +497,6 @@ func TestCoDelQueue_OnGrant_AlreadyNotDroppable(t *testing.T) {
 	assert.Equal(t, 0, q.droppableLen)
 }
 
-// --- Advance head-check: resident holder vs. real backlog staleness ---
-
-func TestCoDelQueue_Advance_ResidentGrantedStragglerDoesNotCauseExtraDrops(t *testing.T) {
-	clock := newTestClock()
-	cfg := CoDelConfig{
-		IntervalNs:     func() int64 { return 100_000_000 }, // 100ms
-		TargetNs:       func() int64 { return 20_000_000 },  // 20ms
-		Exponent:       func() float64 { return 1.0 },
-		MinDropDelayNs: func() int64 { return 100 },
-		EasingLogBase:  func() float64 { return 3.0 },
-	}
-	q, _ := newTestQueue(cfg, clock)
-
-	clock.now = 100_000_000
-	straggler := testEnqueue(q, 0)
-	q.lockedOnGrant(straggler)
-	require.NotNil(t, straggler.codelqElem, "precondition")
-
-	// Six fresh, healthy waiters arrive together, well after the straggler.
-	clock.now = 995_000_000
-	for range 6 {
-		testEnqueue(q, 0)
-	}
-	require.Equal(t, 6, q.droppableLen)
-
-	// Seed a catch-up scenario: dropNextNs is 3 intervals stale relative to
-	// "now" (simulating a delayed backstop timer fire), dropping already
-	// armed from whenever the episode originally started.
-	q.dropping = true
-	q.count = 1
-	q.dropNextNs = 700_000_000
-	clock.now = 1_000_000_000
-
-	drops := 0
-	q.lockedRunTimer(countingDropFn(q, &drops))
-
-	assert.Equal(t, 1, drops)
-	assert.Equal(t, 1, q.count)
-	assert.Equal(t, int64(1_050_000_000), q.dropNextNs)
-	assert.Equal(t, 5, q.droppableLen)
-	assert.True(t, q.dropping, "tautology: last iteration always re-marks true")
-}
-
 // --- Integration: fast vs slow moving ---
 
 func TestCoDelQueue_FastMoving_NoDrop(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/loadshed/codelq_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/codelq_test.go
@@ -139,8 +139,7 @@ func TestCoDelQueue_Enqueue_UndroppableNoSchedule(t *testing.T) {
 	assert.Equal(t, 0, q.droppableLen)
 }
 
-// testDequeue simulates the old lockedDequeue behavior using the new primitives:
-// lockedFirstWaiting + lockedOnGrant + signal.
+// testDequeue grants the oldest waiting request.
 func testDequeue(q *CoDelQueue) *Request {
 	req := q.lockedFirstWaiting()
 	if req == nil {
@@ -151,7 +150,7 @@ func testDequeue(q *CoDelQueue) *Request {
 	return req
 }
 
-// --- FirstWaiting tests (replaces old Dequeue tests) ---
+// --- FirstWaiting tests ---
 
 func TestCoDelQueue_FirstWaiting_FIFO(t *testing.T) {
 	clock := newTestClock()
@@ -953,7 +952,7 @@ func TestCoDelQueue_Grant_DoesNotArmInGatedMode(t *testing.T) {
 	q.lockedOnGrant(r)
 	r.signal(grantSentinel)
 	clock.now = 2_000_000_000 // slow sojourn > trigger
-	assert.False(t, q.dropping, "grant no longer arms an episode; the monitor does")
+	assert.False(t, q.dropping, "grant does not arm an episode; the monitor does")
 }
 
 func TestCoDelQueue_Easing_DisarmsAtCountOneWithBacklog(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/loadshed/codelq_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/codelq_test.go
@@ -140,7 +140,7 @@ func TestCoDelQueue_Enqueue_UndroppableNoSchedule(t *testing.T) {
 }
 
 // testDequeue simulates the old lockedDequeue behavior using the new primitives:
-// lockedFirstWaiting + lockedOnGrant + signal + lockedComplete.
+// lockedFirstWaiting + lockedOnGrant + signal.
 func testDequeue(q *CoDelQueue) *Request {
 	req := q.lockedFirstWaiting()
 	if req == nil {
@@ -148,11 +148,10 @@ func testDequeue(q *CoDelQueue) *Request {
 	}
 	q.lockedOnGrant(req)
 	req.signal(grantSentinel)
-	q.lockedComplete(req)
 	return req
 }
 
-// --- FirstWaiting / Complete tests (replaces old Dequeue tests) ---
+// --- FirstWaiting tests (replaces old Dequeue tests) ---
 
 func TestCoDelQueue_FirstWaiting_FIFO(t *testing.T) {
 	clock := newTestClock()
@@ -183,7 +182,7 @@ func TestCoDelQueue_OnGrant_DecrementsDroppableLen(t *testing.T) {
 	assert.Equal(t, 1, q.droppableLen)
 }
 
-func TestCoDelQueue_Complete_ExitsDroppingOnTarget(t *testing.T) {
+func TestCoDelQueue_Grant_ExitsDroppingOnTarget(t *testing.T) {
 	clock := newTestClock()
 	cfg := defaultTestConfig()
 	cfg.TargetNs = func() int64 { return 1_000_000 }
@@ -262,9 +261,6 @@ func TestCoDelQueue_OnGrant_EvictsFromListImmediately(t *testing.T) {
 	assert.Nil(t, r1.codelqElem)
 	assert.Nil(t, q.lockedPeek())
 	assert.Equal(t, 0, q.lockedLen())
-
-	q.lockedComplete(r1)
-	assert.Equal(t, 0, q.lockedLen(), "no double-decrement")
 }
 
 // --- Drop tests ---
@@ -575,7 +571,7 @@ func TestCoDelQueue_FastMoving_NoDrop(t *testing.T) {
 	assert.Equal(t, enqueued, dequeued, "fast-moving queue should not drop")
 }
 
-func TestCoDelQueue_Complete_TransitionsToEasing(t *testing.T) {
+func TestCoDelQueue_Grant_TransitionsToEasing(t *testing.T) {
 	clock := newTestClock()
 	cfg := CoDelConfig{
 		IntervalNs:     func() int64 { return 1_000_000 },
@@ -595,10 +591,8 @@ func TestCoDelQueue_Complete_TransitionsToEasing(t *testing.T) {
 	q.count = 4
 	q.dropNextNs = clock.now + cfg.IntervalNs()
 
-	// Grant r1 (mark not droppable) and then complete it with a fast sojourn
+	// Grant r1 with a fast sojourn.
 	q.lockedOnGrant(r1)
-	clock.now = 100
-	q.lockedComplete(r1)
 
 	assert.False(t, q.dropping, "should exit dropping state")
 	assert.Equal(t, 4, q.count, "count preserved for easing — timer will halve it when it fires")
@@ -638,22 +632,6 @@ func TestCoDelQueue_Sojourn_SlowGrantKeepsDropping(t *testing.T) {
 	clock.now = 100 * 1_000_000 // 100ms > 50ms target
 	q.lockedOnGrant(r)
 	assert.True(t, q.dropping, "slow queue-wait keeps dropping")
-}
-
-func TestCoDelQueue_Sojourn_CompletionDoesNotRecord(t *testing.T) {
-	clock := newTestClock()
-	q, _ := newTestQueue(defaultTestConfig(), clock) // TargetNs = 50ms
-
-	clock.now = 0
-	r := testEnqueue(q, 0)
-	testEnqueue(q, 0) // second droppable keeps droppableLen > 0
-	q.dropping = true
-
-	// Completion never records sojourn, even a fast one that would otherwise
-	// clear the dropping state.
-	r.codelqEnqueuedAtNs = q.nowNs() - 10*1_000_000 // 10ms < 50ms target
-	q.lockedComplete(r)
-	assert.True(t, q.dropping, "completion does not record sojourn")
 }
 
 // --- Easing tests ---
@@ -812,7 +790,7 @@ func TestCoDelQueue_Easing_DroppableLen_ReentersDroppingWithCurrentCount(t *test
 	assert.True(t, rec.scheduled, "timer should re-arm for continued dropping")
 }
 
-func TestCoDelQueue_Easing_CompleteDoesNotResetCount(t *testing.T) {
+func TestCoDelQueue_Easing_GrantDoesNotResetCount(t *testing.T) {
 	clock := newTestClock()
 	cfg := defaultTestConfig()
 	cfg.TargetNs = func() int64 { return 1_000_000 }
@@ -826,10 +804,6 @@ func TestCoDelQueue_Easing_CompleteDoesNotResetCount(t *testing.T) {
 	req := testEnqueue(q, 0)
 	q.lockedOnGrant(req)
 	req.signal(grantSentinel)
-
-	// Complete with sojourn < target → transitions to !dropping
-	clock.now = 500_000
-	q.lockedComplete(req)
 
 	assert.False(t, q.dropping, "should exit dropping")
 	assert.Equal(t, 10, q.count, "count should NOT be reset on transition to healthy")
@@ -970,7 +944,7 @@ func TestCoDelQueue_Enqueue_DoesNotArm(t *testing.T) {
 	assert.Equal(t, 1, q.count, "gated enqueue must not raise count")
 }
 
-func TestCoDelQueue_Complete_DoesNotArmInGatedMode(t *testing.T) {
+func TestCoDelQueue_Grant_DoesNotArmInGatedMode(t *testing.T) {
 	clock := newTestClock()
 	q, _ := newTestQueue(defaultTriggerGatedConfig(), clock)
 	clock.now = 0
@@ -979,8 +953,7 @@ func TestCoDelQueue_Complete_DoesNotArmInGatedMode(t *testing.T) {
 	q.lockedOnGrant(r)
 	r.signal(grantSentinel)
 	clock.now = 2_000_000_000 // slow sojourn > trigger
-	q.lockedComplete(r)
-	assert.False(t, q.dropping, "completion no longer arms an episode; the monitor does")
+	assert.False(t, q.dropping, "grant no longer arms an episode; the monitor does")
 }
 
 func TestCoDelQueue_Easing_DisarmsAtCountOneWithBacklog(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/loadshed/request.go
+++ b/go/vt/vttablet/tabletserver/loadshed/request.go
@@ -26,9 +26,9 @@ type (
 	// Request represents an entry in the CoDel queue. Named a 'request' since
 	// it may be rejected(dropped) or granted. Each request owns a signalChan
 	// that receives nil on grant or a *DroppedRequestError on drop. The
-	// signaledValue field allows non-consuming inspection of signal state
-	// (used by lockedPeek to avoid channel pop/push-back): nil means
-	// unsignaled, grantSentinel means granted, any other value means dropped.
+	// signaledValue allows non-consuming inspection of signal state (used by
+	// lockedPeek to avoid channel pop/push-back): nil means unsignaled, and any
+	// non-nil value means the request has completed.
 	Request struct {
 		priority           float64
 		codelqEnqueuedAtNs int64

--- a/go/vt/vttablet/tabletserver/loadshed/snake.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake.go
@@ -43,8 +43,10 @@ type (
 	// Capacity() concurrent holders are allowed. Acquire requests are either
 	// granted or dropped, each within a timely manner.
 	//
-	// Granted requests stay in the CoDel queue as undroppable until Release,
-	// preserving the queue's system-pressure signal for accurate shedding.
+	// Granted requests leave the CoDel queue immediately (see
+	// CoDelQueue.lockedOnGrant): sojourn — the shedding signal — is measured
+	// at grant, before eviction, so a held request no longer needs to
+	// occupy a queue node to preserve that signal.
 	Snake struct {
 		mu sync.Mutex
 

--- a/go/vt/vttablet/tabletserver/loadshed/snake.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake.go
@@ -277,7 +277,7 @@ func (s *Snake) release(req *Request, excValue error) error {
 	}
 	delete(s.holders, req)
 	s.lockedObserveHolderCount()
-	s.lockedCompleteAndShed(req)
+	s.lockedReleaseAndShed(req)
 	s.lockedTryGrantOne()
 	s.lockedObserveLengths()
 	s.lockedObserveDropping()
@@ -297,7 +297,7 @@ func (s *Snake) releaseOnCancel(req *Request) {
 	s.mu.Lock()
 	delete(s.holders, req)
 	s.lockedObserveHolderCount()
-	s.lockedCompleteAndShed(req)
+	s.lockedReleaseAndShed(req)
 	s.lockedTryGrantOne()
 	s.lockedObserveLengths()
 	s.lockedObserveDropping()
@@ -308,14 +308,15 @@ func (s *Snake) releaseOnCancel(req *Request) {
 	}
 }
 
-// lockedCompleteAndShed unlinks the released request and, when an episode is
-// active, sheds stale requests synchronously at this dequeue point using a
+// lockedReleaseAndShed releases the request from the valved queue and, when an
+// episode is active, sheds stale requests synchronously at release using a
 // fresh clock — so shedding tracks target continuously instead of waiting on
 // the (possibly late) backstop timer, and runs before granting the next waiter
-// so we promote the freshest survivor. The lockedNeedsAdvance guard keeps the
-// healthy path free of both the advance call and the clock read.
-func (s *Snake) lockedCompleteAndShed(req *Request) {
-	s.q.lockedComplete(req)
+// so we promote the freshest survivor.
+// The lockedNeedsAdvance guard keeps the healthy path free of both the advance
+// call and the clock read.
+func (s *Snake) lockedReleaseAndShed(req *Request) {
+	s.q.lockedRelease(req)
 	if s.q.lockedNeedsAdvance() {
 		s.q.lockedRunTimer()
 	}

--- a/go/vt/vttablet/tabletserver/loadshed/snake.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake.go
@@ -42,11 +42,6 @@ type (
 	// Snake is a CoDel-based load-shedding gate with dynamic capacity. Up to
 	// Capacity() concurrent holders are allowed. Acquire requests are either
 	// granted or dropped, each within a timely manner.
-	//
-	// Granted requests leave the CoDel queue immediately (see
-	// CoDelQueue.lockedOnGrant) — sojourn is measured at grant, so a held
-	// request no longer needs to occupy a queue node to preserve the
-	// shedding signal.
 	Snake struct {
 		mu sync.Mutex
 
@@ -308,13 +303,8 @@ func (s *Snake) releaseOnCancel(req *Request) {
 	}
 }
 
-// lockedReleaseAndShed releases the request from the valved queue and, when an
-// episode is active, sheds stale requests synchronously at release using a
-// fresh clock — so shedding tracks target continuously instead of waiting on
-// the (possibly late) backstop timer, and runs before granting the next waiter
-// so we promote the freshest survivor.
-// The lockedNeedsAdvance guard keeps the healthy path free of both the advance
-// call and the clock read.
+// lockedReleaseAndShed releases the request and advances CoDel before granting
+// the next waiter when there is active shedding work.
 func (s *Snake) lockedReleaseAndShed(req *Request) {
 	s.q.lockedRelease(req)
 	if s.q.lockedNeedsAdvance() {

--- a/go/vt/vttablet/tabletserver/loadshed/snake.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake.go
@@ -44,9 +44,9 @@ type (
 	// granted or dropped, each within a timely manner.
 	//
 	// Granted requests leave the CoDel queue immediately (see
-	// CoDelQueue.lockedOnGrant): sojourn — the shedding signal — is measured
-	// at grant, before eviction, so a held request no longer needs to
-	// occupy a queue node to preserve that signal.
+	// CoDelQueue.lockedOnGrant) — sojourn is measured at grant, so a held
+	// request no longer needs to occupy a queue node to preserve the
+	// shedding signal.
 	Snake struct {
 		mu sync.Mutex
 

--- a/go/vt/vttablet/tabletserver/loadshed/snake_bench_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_bench_test.go
@@ -162,7 +162,7 @@ func BenchmarkSnake_GOMAXPROCS(b *testing.B) {
 
 // --- CoDel queue enqueue/dequeue (low-level, no Snake overhead) ---
 
-func BenchmarkCoDelQueue_EnqueueComplete(b *testing.B) {
+func BenchmarkCoDelQueue_EnqueueGrant(b *testing.B) {
 	clock := newTestClock()
 	rec := &testDropTimerRecorder{}
 	q := newCoDelQueue(defaultTestConfig(), clock.nowFunc, rec.schedule, rec.stop, nil)
@@ -172,7 +172,6 @@ func BenchmarkCoDelQueue_EnqueueComplete(b *testing.B) {
 		req := newRequest(0)
 		q.lockedEnqueue(req)
 		q.lockedOnGrant(req)
-		q.lockedComplete(req)
 	}
 }
 

--- a/go/vt/vttablet/tabletserver/loadshed/snake_overload_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_overload_test.go
@@ -71,27 +71,57 @@ func TestSnake_Overload_RecoveryToHealthy(t *testing.T) {
 	u.Release()
 }
 
-// --- Holder keeps queue non-empty (preserves CoDel pressure signal) ---
+// --- Holder not counted in queue length (sojourn is measured at grant) ---
 
-func TestSnake_Overload_HolderKeepsQueueNonEmpty(t *testing.T) {
+func TestSnake_Overload_HolderNotCountedInQueueLen(t *testing.T) {
 	s := NewSnake(defaultSnakeConfig())
 
 	unlock, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 
-	// The holder stays at the head — queue length should be 1 even though
-	// the lock is granted and no one else is waiting.
+	// Sojourn is measured at grant, before the request is evicted from the
+	// list, so a held request no longer needs to stay resident to preserve
+	// the shedding signal — queue length should be 0 even right after grant.
 	s.mu.Lock()
 	qLen := s.q.lockedLen()
 	s.mu.Unlock()
-	assert.Equal(t, 1, qLen, "holder should remain in queue to preserve pressure signal")
+	assert.Equal(t, 0, qLen, "holder should not be counted toward queue length")
 
 	unlock.Release()
 
 	s.mu.Lock()
 	qLen = s.q.lockedLen()
 	s.mu.Unlock()
-	assert.Equal(t, 0, qLen, "queue should be empty after release")
+	assert.Equal(t, 0, qLen, "queue should still be empty after release")
+}
+
+// TestSnake_Overload_WaiterCountedNotHolder proves QueueLen reflects only
+// requests actually waiting for a slot — a held (granted) request is
+// evicted from the list at grant, so it's never counted, while a request
+// still waiting behind it is.
+func TestSnake_Overload_WaiterCountedNotHolder(t *testing.T) {
+	s := NewSnake(defaultSnakeConfig())
+
+	unlock, err := s.Acquire(t.Context(), "", 0)
+	require.NoError(t, err)
+
+	waiterDone := make(chan error, 1)
+	go func() {
+		u, err := s.Acquire(t.Context(), "", 0)
+		if err == nil {
+			u.Release()
+		}
+		waiterDone <- err
+	}()
+
+	assert.Eventually(t, func() bool {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		return s.q.lockedLen() == 1
+	}, time.Second, time.Millisecond, "the waiter should be counted, the holder should not")
+
+	unlock.Release()
+	require.NoError(t, <-waiterDone)
 }
 
 // --- Mass cancel at Snake layer ---

--- a/go/vt/vttablet/tabletserver/loadshed/snake_overload_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_overload_test.go
@@ -71,7 +71,7 @@ func TestSnake_Overload_RecoveryToHealthy(t *testing.T) {
 	u.Release()
 }
 
-// --- Holder not counted in queue length (sojourn is measured at grant) ---
+// --- Holder not counted in queue length ---
 
 func TestSnake_Overload_HolderNotCountedInQueueLen(t *testing.T) {
 	s := NewSnake(defaultSnakeConfig())
@@ -79,26 +79,19 @@ func TestSnake_Overload_HolderNotCountedInQueueLen(t *testing.T) {
 	unlock, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 
-	// Sojourn is measured at grant, before the request is evicted from the
-	// list, so a held request no longer needs to stay resident to preserve
-	// the shedding signal — queue length should be 0 even right after grant.
 	s.mu.Lock()
 	qLen := s.q.lockedLen()
 	s.mu.Unlock()
-	assert.Equal(t, 0, qLen, "holder should not be counted toward queue length")
+	assert.Equal(t, 0, qLen)
 
 	unlock.Release()
 
 	s.mu.Lock()
 	qLen = s.q.lockedLen()
 	s.mu.Unlock()
-	assert.Equal(t, 0, qLen, "queue should still be empty after release")
+	assert.Equal(t, 0, qLen)
 }
 
-// TestSnake_Overload_WaiterCountedNotHolder proves QueueLen reflects only
-// requests actually waiting for a slot — a held (granted) request is
-// evicted from the list at grant, so it's never counted, while a request
-// still waiting behind it is.
 func TestSnake_Overload_WaiterCountedNotHolder(t *testing.T) {
 	s := NewSnake(defaultSnakeConfig())
 
@@ -118,7 +111,7 @@ func TestSnake_Overload_WaiterCountedNotHolder(t *testing.T) {
 		s.mu.Lock()
 		defer s.mu.Unlock()
 		return s.q.lockedLen() == 1
-	}, time.Second, time.Millisecond, "the waiter should be counted, the holder should not")
+	}, time.Second, time.Millisecond, "waiter counted, holder not")
 
 	unlock.Release()
 	require.NoError(t, <-waiterDone)

--- a/go/vt/vttablet/tabletserver/loadshed/snake_stats_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_stats_test.go
@@ -252,8 +252,8 @@ func TestPublishStats_QueueAndHolderHistogramsRecord(t *testing.T) {
 	assert.Positive(t, queueLen.Count(), "enqueue should record a queue-length observation")
 	assert.Positive(t, holderCount.Count(), "grant should record a holder-count observation")
 
-	// Release records again (queue length drops as the granted entry leaves; the
-	// holder delete is observed too).
+	// Release records again (queue length already dropped at grant, when the
+	// entry was evicted from the list; the holder delete is observed here).
 	beforeQueue := queueLen.Count()
 	beforeHolder := holderCount.Count()
 	require.NoError(t, unlock.Release())

--- a/go/vt/vttablet/tabletserver/loadshed/snake_stats_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_stats_test.go
@@ -252,8 +252,8 @@ func TestPublishStats_QueueAndHolderHistogramsRecord(t *testing.T) {
 	assert.Positive(t, queueLen.Count(), "enqueue should record a queue-length observation")
 	assert.Positive(t, holderCount.Count(), "grant should record a holder-count observation")
 
-	// Release records again (queue length already dropped at grant, when the
-	// entry was evicted from the list; the holder delete is observed here).
+	// Release records again (queue length already dropped at grant; the
+	// holder delete is observed here).
 	beforeQueue := queueLen.Count()
 	beforeHolder := holderCount.Count()
 	require.NoError(t, unlock.Release())

--- a/go/vt/vttablet/tabletserver/loadshed/valved_codelq.go
+++ b/go/vt/vttablet/tabletserver/loadshed/valved_codelq.go
@@ -51,9 +51,8 @@ type (
 	// job execution instance ID.
 	//
 	// Invariant: each nonempty valve always has exactly one droppable entry
-	// in the CoDel queue. A valve may also have one undroppable (granted)
-	// entry — but the droppable entry is always present so CoDel can measure
-	// sojourn time and shed load when necessary.
+	// in the CoDel queue. The droppable entry is always present so CoDel can
+	// measure sojourn time and shed load when necessary.
 	//
 	// This approach has a few benefits:
 	//   1. Pushes successive requests back to the end of the queue, which is
@@ -90,9 +89,7 @@ type (
 		valves map[string][]*Request
 
 		// outstandingCounts tracks the total number of outstanding requests per
-		// valve ID (in CoDel queue + in valve). Note that there may be multiple
-		// requests for any one valve in the CoDel queue (one droppable and
-		// one-or-more granted).
+		// valve ID (in CoDel queue + in valve).
 		outstandingCounts map[string]int
 
 		// droppablePerValve tracks which request is the current droppable

--- a/go/vt/vttablet/tabletserver/loadshed/valved_codelq.go
+++ b/go/vt/vttablet/tabletserver/loadshed/valved_codelq.go
@@ -185,11 +185,8 @@ func (q *ValvedCoDelQueue) lockedEnqueue(valveID string, priority float64) *Requ
 	return req
 }
 
-// lockedRelease releases a granted request. Decrements outstanding counts for
-// the valve ID. Promotes the next
-// valve entry if this was the last active entry for the valve ID (i.e., the
-// eager promotion at grant time found nothing to promote, but requests arrived
-// in the valve between grant and release).
+// lockedRelease updates valve accounting for a granted request and promotes a
+// pending request when needed.
 func (q *ValvedCoDelQueue) lockedRelease(req *Request) {
 	q.decrementOutstanding(req.valveID)
 	if req.valveID != "" {

--- a/go/vt/vttablet/tabletserver/loadshed/valved_codelq.go
+++ b/go/vt/vttablet/tabletserver/loadshed/valved_codelq.go
@@ -185,13 +185,12 @@ func (q *ValvedCoDelQueue) lockedEnqueue(valveID string, priority float64) *Requ
 	return req
 }
 
-// lockedComplete removes a granted (undroppable) request from the queue on
-// Release. Decrements outstanding counts for the valve ID. Promotes the next
+// lockedRelease releases a granted request. Decrements outstanding counts for
+// the valve ID. Promotes the next
 // valve entry if this was the last active entry for the valve ID (i.e., the
 // eager promotion at grant time found nothing to promote, but requests arrived
 // in the valve between grant and release).
-func (q *ValvedCoDelQueue) lockedComplete(req *Request) {
-	q.codelq.lockedComplete(req)
+func (q *ValvedCoDelQueue) lockedRelease(req *Request) {
 	q.decrementOutstanding(req.valveID)
 	if req.valveID != "" {
 		// Promote if no droppable entry exists. This handles the case where

--- a/go/vt/vttablet/tabletserver/loadshed/valved_codelq_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/valved_codelq_test.go
@@ -40,7 +40,7 @@ func testValvedDequeue(sq *ValvedCoDelQueue) *Request {
 	}
 	sq.lockedOnGrant(req)
 	req.signal(grantSentinel)
-	sq.lockedComplete(req)
+	sq.lockedRelease(req)
 	return req
 }
 


### PR DESCRIPTION
### Background / Why?

CoDel measures sojourn when a request is granted, so an executing request contributes no new queue-health information after grant. This PR is a refactor; it has no behavioral change.

It removes granted requests from the CoDel list at grant time while leaving Snake's semaphore and holder lifecycle unchanged; release still performs the holder and valve accounting that belongs to the current Snake API. Admission decisions therefore remain unchanged.

This is a step in preparation for replacing `wl.list` from `go/pools/smartconnpool/waitlist.go` with the snake. In that world, the semaphore is the conn pool itself.

### Testing

Existing unit tests updated.

AI assisted with development. Every line of code was either written by or carefully reviewed by me :)