### PR TITLE
Make Snake configurable per pool

### DIFF
--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -190,13 +190,19 @@ Flags:
       --keep_logs_by_mtime duration                                      keep logs for this long (using mtime) (zero to keep forever)
       --keyspaces_to_watch strings                                       Specifies which keyspaces this vtgate should have access to while routing queries or accessing the vschema.
       --lameduck-period duration                                         keep running at least this long after SIGTERM before stopping (default 50ms)
-      --loadshed-drop-mode string                                        CoDel drop mode for the load shedder: slow (arm on enqueue, ramp), jump (arm only when head sojourn crosses the trigger), or both. (default "slow")
-      --loadshed-enabled                                                 If true, enables CoDel-based load shedding on the OLTP read and transaction pools. (default true)
-      --loadshed-grace-count int                                         CoDel grace count: suppress the head drop while the drop count is below this value. 1 disables the grace period. (default 1)
-      --loadshed-interval-ratio float                                    CoDel observation interval for the load shedder, as a multiple of loadshed-target (interval = target * ratio). Recommended 10-20. (default 20)
-      --loadshed-target duration                                         CoDel target delay for the load shedder. (default 5ms)
-      --loadshed-trigger duration                                        CoDel sojourn threshold that arms a jump in jump/both drop modes. 0 defaults to the CoDel interval (loadshed-target * loadshed-interval-ratio).
-      --loadshed-undroppable-schemas strings                             Schema qualifiers (e.g. performance_schema) whose queries the load shedder marks undroppable, so low-volume health-check traffic against them is never shed. (default [performance_schema,information_schema,sys,mysql])
+      --loadshed-oltp-read-drop-mode string                              CoDel drop mode for the oltp-read load shedder: slow, jump, or both. (default "slow")
+      --loadshed-oltp-read-enabled                                       If true, enables CoDel-based load shedding on the oltp-read pool. (default true)
+      --loadshed-oltp-read-grace-count int                               CoDel grace count for the oltp-read load shedder. (default 1)
+      --loadshed-oltp-read-interval-ratio float                          CoDel observation interval for the oltp-read load shedder, as a multiple of its target. (default 20)
+      --loadshed-oltp-read-target duration                               CoDel target delay for the oltp-read load shedder. (default 5ms)
+      --loadshed-oltp-read-trigger duration                              CoDel sojourn threshold for the oltp-read load shedder. 0 defaults to its CoDel interval.
+      --loadshed-oltp-read-undroppable-schemas strings                   Schema qualifiers whose OLTP read queries are never shed. (default [performance_schema,information_schema,sys,mysql])
+      --loadshed-tx-drop-mode string                                     CoDel drop mode for the tx load shedder: slow, jump, or both. (default "slow")
+      --loadshed-tx-enabled                                              If true, enables CoDel-based load shedding on the tx pool. (default true)
+      --loadshed-tx-grace-count int                                      CoDel grace count for the tx load shedder. (default 1)
+      --loadshed-tx-interval-ratio float                                 CoDel observation interval for the tx load shedder, as a multiple of its target. (default 20)
+      --loadshed-tx-target duration                                      CoDel target delay for the tx load shedder. (default 5ms)
+      --loadshed-tx-trigger duration                                     CoDel sojourn threshold for the tx load shedder. 0 defaults to its CoDel interval.
       --lock-timeout duration                                            Maximum time to wait when attempting to acquire a lock from the topo server (default 45s)
       --lock_heartbeat_time duration                                     If there is lock function used. This will keep the lock connection active by using this heartbeat (default 5s)
       --lock_tables_timeout duration                                     How long to keep the table locked before timing out (default 1m0s)

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -216,13 +216,19 @@ Flags:
       --keep_logs duration                                               keep logs for this long (using ctime) (zero to keep forever)
       --keep_logs_by_mtime duration                                      keep logs for this long (using mtime) (zero to keep forever)
       --lameduck-period duration                                         keep running at least this long after SIGTERM before stopping (default 50ms)
-      --loadshed-drop-mode string                                        CoDel drop mode for the load shedder: slow (arm on enqueue, ramp), jump (arm only when head sojourn crosses the trigger), or both. (default "slow")
-      --loadshed-enabled                                                 If true, enables CoDel-based load shedding on the OLTP read and transaction pools. (default true)
-      --loadshed-grace-count int                                         CoDel grace count: suppress the head drop while the drop count is below this value. 1 disables the grace period. (default 1)
-      --loadshed-interval-ratio float                                    CoDel observation interval for the load shedder, as a multiple of loadshed-target (interval = target * ratio). Recommended 10-20. (default 20)
-      --loadshed-target duration                                         CoDel target delay for the load shedder. (default 5ms)
-      --loadshed-trigger duration                                        CoDel sojourn threshold that arms a jump in jump/both drop modes. 0 defaults to the CoDel interval (loadshed-target * loadshed-interval-ratio).
-      --loadshed-undroppable-schemas strings                             Schema qualifiers (e.g. performance_schema) whose queries the load shedder marks undroppable, so low-volume health-check traffic against them is never shed. (default [performance_schema,information_schema,sys,mysql])
+      --loadshed-oltp-read-drop-mode string                              CoDel drop mode for the oltp-read load shedder: slow, jump, or both. (default "slow")
+      --loadshed-oltp-read-enabled                                       If true, enables CoDel-based load shedding on the oltp-read pool. (default true)
+      --loadshed-oltp-read-grace-count int                               CoDel grace count for the oltp-read load shedder. (default 1)
+      --loadshed-oltp-read-interval-ratio float                          CoDel observation interval for the oltp-read load shedder, as a multiple of its target. (default 20)
+      --loadshed-oltp-read-target duration                               CoDel target delay for the oltp-read load shedder. (default 5ms)
+      --loadshed-oltp-read-trigger duration                              CoDel sojourn threshold for the oltp-read load shedder. 0 defaults to its CoDel interval.
+      --loadshed-oltp-read-undroppable-schemas strings                   Schema qualifiers whose OLTP read queries are never shed. (default [performance_schema,information_schema,sys,mysql])
+      --loadshed-tx-drop-mode string                                     CoDel drop mode for the tx load shedder: slow, jump, or both. (default "slow")
+      --loadshed-tx-enabled                                              If true, enables CoDel-based load shedding on the tx pool. (default true)
+      --loadshed-tx-grace-count int                                      CoDel grace count for the tx load shedder. (default 1)
+      --loadshed-tx-interval-ratio float                                 CoDel observation interval for the tx load shedder, as a multiple of its target. (default 20)
+      --loadshed-tx-target duration                                      CoDel target delay for the tx load shedder. (default 5ms)
+      --loadshed-tx-trigger duration                                     CoDel sojourn threshold for the tx load shedder. 0 defaults to its CoDel interval.
       --lock-timeout duration                                            Maximum time to wait when attempting to acquire a lock from the topo server (default 45s)
       --lock_tables_timeout duration                                     How long to keep the table locked before timing out (default 1m0s)
       --log_backtrace_at traceLocations                                  when logging hits line file:N, emit a stack trace

--- a/go/vt/vttablet/endtoend/connecttcp/main_test.go
+++ b/go/vt/vttablet/endtoend/connecttcp/main_test.go
@@ -88,7 +88,8 @@ func TestMain(m *testing.M) {
 
 		config := tabletenv.NewDefaultConfig()
 		config.TwoPCAbandonAge = 1 * time.Second
-		config.LoadshedEnabled = false
+		config.LoadshedOltpRead.Enabled = false
+		config.LoadshedTx.Enabled = false
 
 		if err := framework.StartCustomServer(ctx, connParams, connAppDebugParams, cluster.DbName(), config); err != nil {
 			fmt.Fprintf(os.Stderr, "%v", err)

--- a/go/vt/vttablet/endtoend/connkilling/main_test.go
+++ b/go/vt/vttablet/endtoend/connkilling/main_test.go
@@ -83,7 +83,8 @@ func TestMain(m *testing.M) {
 		connAppDebugParams = cluster.MySQLAppDebugConnParams()
 		config := tabletenv.NewDefaultConfig()
 		config.Oltp.TxTimeout = 3 * time.Second
-		config.LoadshedEnabled = false
+		config.LoadshedOltpRead.Enabled = false
+		config.LoadshedTx.Enabled = false
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		err := framework.StartCustomServer(ctx, connParams, connAppDebugParams, cluster.DbName(), config)

--- a/go/vt/vttablet/endtoend/framework/server.go
+++ b/go/vt/vttablet/endtoend/framework/server.go
@@ -119,7 +119,8 @@ func StartServer(ctx context.Context, connParams, connAppDebugParams mysql.ConnP
 	config.EnableViews = true
 	config.QueryCacheDoorkeeper = false
 	config.SchemaReloadInterval = 5 * time.Second
-	config.LoadshedEnabled = false
+	config.LoadshedOltpRead.Enabled = false
+	config.LoadshedTx.Enabled = false
 	gotBytes, _ := yaml2.Marshal(config)
 	log.Infof("Config:\n%s", gotBytes)
 	return StartCustomServer(ctx, connParams, connAppDebugParams, dbName, config)

--- a/go/vt/vttablet/endtoend/twopc/main_test.go
+++ b/go/vt/vttablet/endtoend/twopc/main_test.go
@@ -85,7 +85,8 @@ func TestMain(m *testing.M) {
 
 		config := tabletenv.NewDefaultConfig()
 		config.TwoPCAbandonAge = 1 * time.Second
-		config.LoadshedEnabled = false
+		config.LoadshedOltpRead.Enabled = false
+		config.LoadshedTx.Enabled = false
 		err := framework.StartCustomServer(ctx, connParams, connAppDebugParams, cluster.DbName(), config)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%v", err)

--- a/go/vt/vttablet/tabletserver/debugenv.go
+++ b/go/vt/vttablet/tabletserver/debugenv.go
@@ -31,6 +31,7 @@ import (
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/loadshed"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )
 
 var (
@@ -145,6 +146,16 @@ func handlePost(tsv *TabletServer, w http.ResponseWriter, r *http.Request) {
 		return nil
 	}
 
+	setBoolVal := func(f func(bool)) error {
+		bval, err := strconv.ParseBool(value)
+		if err != nil {
+			return fmt.Errorf("invalid bool value for %v: %v", varname, err)
+		}
+		f(bval)
+		msg = fmt.Sprintf("Setting %v to: %v", varname, value)
+		return nil
+	}
+
 	setStringVal := func(f func(string) error) error {
 		if err := f(value); err != nil {
 			return fmt.Errorf("invalid value for %v: %v", varname, err)
@@ -173,15 +184,22 @@ func handlePost(tsv *TabletServer, w http.ResponseWriter, r *http.Request) {
 		err = setDurationVal(func(d time.Duration) { tsv.Config().Healthcheck.UnhealthyThreshold = d })
 	case "ThrottleMetricThreshold":
 		err = setFloat64Val(tsv.SetThrottleMetricThreshold)
-	case "LoadshedTarget":
-		err = setDurationVal(func(d time.Duration) { tsv.Config().LoadshedTarget = d })
-	case "LoadshedIntervalRatio":
-		err = setFloat64Val(func(v float64) { tsv.Config().LoadshedIntervalRatio = v })
-	case "LoadshedTrigger":
-		err = setDurationVal(func(d time.Duration) { tsv.Config().LoadshedTrigger = d })
-	case "LoadshedGraceCount":
-		err = setIntVal(func(v int) { tsv.Config().LoadshedGraceCount = v })
-	case "LoadshedUndroppableSchemas":
+	case "LoadshedOltpReadEnabled", "LoadshedTxEnabled":
+		cfg := loadshedConfig(tsv, varname)
+		err = setBoolVal(cfg.SetEnabled)
+	case "LoadshedOltpReadTarget", "LoadshedTxTarget":
+		cfg := loadshedConfig(tsv, varname)
+		err = setDurationVal(cfg.SetTarget)
+	case "LoadshedOltpReadIntervalRatio", "LoadshedTxIntervalRatio":
+		cfg := loadshedConfig(tsv, varname)
+		err = setFloat64Val(cfg.SetIntervalRatio)
+	case "LoadshedOltpReadTrigger", "LoadshedTxTrigger":
+		cfg := loadshedConfig(tsv, varname)
+		err = setDurationVal(cfg.SetTrigger)
+	case "LoadshedOltpReadGraceCount", "LoadshedTxGraceCount":
+		cfg := loadshedConfig(tsv, varname)
+		err = setIntVal(cfg.SetGraceCount)
+	case "LoadshedOltpReadUndroppableSchemas":
 		err = setStringVal(func(v string) error {
 			var schemas []string
 			for _, s := range strings.Split(v, ",") {
@@ -189,20 +207,23 @@ func handlePost(tsv *TabletServer, w http.ResponseWriter, r *http.Request) {
 					schemas = append(schemas, s)
 				}
 			}
-			tsv.Config().LoadshedUndroppableSchemas = schemas
+			tsv.Config().LoadshedOltpRead.SetUndroppableSchemas(schemas)
 			return nil
 		})
-	case "LoadshedDropMode":
+	case "LoadshedOltpReadDropMode", "LoadshedTxDropMode":
+		cfg := loadshedConfig(tsv, varname)
 		err = setStringVal(func(v string) error {
 			if _, perr := loadshed.ParseDropMode(v); perr != nil {
 				return perr
 			}
-			tsv.Config().LoadshedDropMode = v
+			cfg.SetDropMode(v)
 			return nil
 		})
 	case "Consolidator":
 		tsv.SetConsolidatorMode(value)
 		msg = fmt.Sprintf("Setting %v to: %v", varname, value)
+	default:
+		err = fmt.Errorf("unknown variable %q", varname)
 	}
 
 	if err != nil {
@@ -239,21 +260,33 @@ func getVars(tsv *TabletServer) []envValue {
 	vars = addVar(vars, "RowStreamerMaxMySQLReplLagSecs", func() int64 { return tsv.Config().RowStreamer.MaxMySQLReplLagSecs })
 	vars = addVar(vars, "UnhealthyThreshold", func() time.Duration { return tsv.Config().Healthcheck.UnhealthyThreshold })
 	vars = addVar(vars, "ThrottleMetricThreshold", tsv.ThrottleMetricThreshold)
-	vars = addVar(vars, "LoadshedTarget", func() time.Duration { return tsv.Config().LoadshedTarget })
-	vars = addVar(vars, "LoadshedIntervalRatio", func() float64 { return tsv.Config().LoadshedIntervalRatio })
-	vars = addVar(vars, "LoadshedDropMode", func() string { return tsv.Config().LoadshedDropMode })
-	vars = addVar(vars, "LoadshedTrigger", func() time.Duration { return tsv.Config().LoadshedTrigger })
-	vars = addVar(vars, "LoadshedGraceCount", func() int { return tsv.Config().LoadshedGraceCount })
+	addLoadshedVars := func(prefix string, cfg *tabletenv.LoadshedConfig) {
+		vars = addVar(vars, prefix+"Enabled", cfg.IsEnabled)
+		vars = addVar(vars, prefix+"Target", cfg.TargetValue)
+		vars = addVar(vars, prefix+"IntervalRatio", cfg.IntervalRatioValue)
+		vars = addVar(vars, prefix+"DropMode", cfg.DropModeValue)
+		vars = addVar(vars, prefix+"Trigger", cfg.TriggerValue)
+		vars = addVar(vars, prefix+"GraceCount", cfg.GraceCountValue)
+	}
+	addLoadshedVars("LoadshedOltpRead", &tsv.Config().LoadshedOltpRead.LoadshedConfig)
 	vars = append(vars, envValue{
-		Name:  "LoadshedUndroppableSchemas",
-		Value: strings.Join(tsv.Config().LoadshedUndroppableSchemas, ","),
+		Name:  "LoadshedOltpReadUndroppableSchemas",
+		Value: strings.Join(tsv.Config().LoadshedOltpRead.UndroppableSchemasValue(), ","),
 	})
+	addLoadshedVars("LoadshedTx", &tsv.Config().LoadshedTx)
 	vars = append(vars, envValue{
 		Name:  "Consolidator",
 		Value: tsv.ConsolidatorMode(),
 	})
 
 	return vars
+}
+
+func loadshedConfig(tsv *TabletServer, varname string) *tabletenv.LoadshedConfig {
+	if strings.HasPrefix(varname, "LoadshedTx") {
+		return &tsv.Config().LoadshedTx
+	}
+	return &tsv.Config().LoadshedOltpRead.LoadshedConfig
 }
 
 func respondWithJSON(w http.ResponseWriter, vars []envValue, msg string) {

--- a/go/vt/vttablet/tabletserver/debugenv_test.go
+++ b/go/vt/vttablet/tabletserver/debugenv_test.go
@@ -60,39 +60,58 @@ func postVar(t *testing.T, tsv *TabletServer, name, value string) {
 func TestDebugEnvLoadshedCoDelParams(t *testing.T) {
 	tsv := newDebugEnvTabletServer(t)
 
-	postVar(t, tsv, "LoadshedTarget", "7ms")
-	assert.Equal(t, 7*time.Millisecond, tsv.Config().LoadshedTarget)
+	postVar(t, tsv, "LoadshedOltpReadEnabled", "false")
+	assert.False(t, tsv.Config().LoadshedOltpRead.IsEnabled())
 
-	postVar(t, tsv, "LoadshedIntervalRatio", "15")
-	assert.Equal(t, 15.0, tsv.Config().LoadshedIntervalRatio)
+	postVar(t, tsv, "LoadshedTxEnabled", "false")
+	assert.False(t, tsv.Config().LoadshedTx.IsEnabled())
+
+	postVar(t, tsv, "LoadshedOltpReadTarget", "7ms")
+	assert.Equal(t, 7*time.Millisecond, tsv.Config().LoadshedOltpRead.TargetValue())
+
+	postVar(t, tsv, "LoadshedTxIntervalRatio", "15")
+	assert.Equal(t, 15.0, tsv.Config().LoadshedTx.IntervalRatioValue())
+	assert.NotEqual(t, tsv.Config().LoadshedOltpRead.IntervalRatioValue(), tsv.Config().LoadshedTx.IntervalRatioValue())
 
 }
 
 func TestDebugEnvLoadshedJumpStartParams(t *testing.T) {
 	tsv := newDebugEnvTabletServer(t)
 
-	postVar(t, tsv, "LoadshedDropMode", "both")
-	assert.Equal(t, "both", tsv.Config().LoadshedDropMode)
+	postVar(t, tsv, "LoadshedOltpReadDropMode", "both")
+	assert.Equal(t, "both", tsv.Config().LoadshedOltpRead.DropModeValue())
 
-	postVar(t, tsv, "LoadshedTrigger", "12ms")
-	assert.Equal(t, 12*time.Millisecond, tsv.Config().LoadshedTrigger)
+	postVar(t, tsv, "LoadshedOltpReadTrigger", "12ms")
+	assert.Equal(t, 12*time.Millisecond, tsv.Config().LoadshedOltpRead.TriggerValue())
 
-	postVar(t, tsv, "LoadshedGraceCount", "4")
-	assert.Equal(t, 4, tsv.Config().LoadshedGraceCount)
+	postVar(t, tsv, "LoadshedTxGraceCount", "4")
+	assert.Equal(t, 4, tsv.Config().LoadshedTx.GraceCountValue())
 }
 
 func TestDebugEnvLoadshedDropModeInvalid(t *testing.T) {
 	tsv := newDebugEnvTabletServer(t)
-	orig := tsv.Config().LoadshedDropMode
+	orig := tsv.Config().LoadshedOltpRead.DropModeValue()
 
-	form := url.Values{"varname": {"LoadshedDropMode"}, "value": {"bogus"}}
+	form := url.Values{"varname": {"LoadshedOltpReadDropMode"}, "value": {"bogus"}}
 	r := httptest.NewRequest(http.MethodPost, "/debug/env", strings.NewReader(form.Encode()))
 	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w := httptest.NewRecorder()
 	handlePost(tsv, w, r)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Equal(t, orig, tsv.Config().LoadshedDropMode, "invalid value must not mutate config")
+	assert.Equal(t, orig, tsv.Config().LoadshedOltpRead.DropModeValue(), "invalid value must not mutate config")
+}
+
+func TestDebugEnvUnknownVariable(t *testing.T) {
+	tsv := newDebugEnvTabletServer(t)
+	form := url.Values{"varname": {"LoadshedTarget"}, "value": {"7ms"}}
+	r := httptest.NewRequest(http.MethodPost, "/debug/env", strings.NewReader(form.Encode()))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+
+	handlePost(tsv, w, r)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 // TestDebugEnvLoadshedParamsListed ensures every load-shed knob is surfaced in
@@ -105,12 +124,17 @@ func TestDebugEnvLoadshedParamsListed(t *testing.T) {
 		names[v.Name] = struct{}{}
 	}
 	for _, want := range []string{
-		"LoadshedTarget", "LoadshedIntervalRatio",
-		"LoadshedDropMode", "LoadshedTrigger", "LoadshedGraceCount",
+		"LoadshedOltpReadEnabled", "LoadshedOltpReadTarget", "LoadshedOltpReadIntervalRatio",
+		"LoadshedOltpReadDropMode", "LoadshedOltpReadTrigger", "LoadshedOltpReadGraceCount",
+		"LoadshedOltpReadUndroppableSchemas",
+		"LoadshedTxEnabled", "LoadshedTxTarget", "LoadshedTxIntervalRatio",
+		"LoadshedTxDropMode", "LoadshedTxTrigger", "LoadshedTxGraceCount",
 	} {
 		_, ok := names[want]
 		assert.Truef(t, ok, "getVars should list %s", want)
 	}
+	_, ok := names["LoadshedTxUndroppableSchemas"]
+	assert.False(t, ok, "transaction pool must not expose undroppable schemas")
 }
 
 // TestDebugEnvDropModeWiredToGate confirms a drop-mode override flows through to
@@ -119,9 +143,20 @@ func TestDebugEnvDropModeWiredToGate(t *testing.T) {
 	tsv := newDebugEnvTabletServer(t)
 	require.NotNil(t, tsv.qe.snake, "loadshed must be enabled for this test")
 
-	postVar(t, tsv, "LoadshedDropMode", "jump")
+	postVar(t, tsv, "LoadshedOltpReadDropMode", "jump")
 
-	mode, err := loadshed.ParseDropMode(tsv.Config().LoadshedDropMode)
+	mode, err := loadshed.ParseDropMode(tsv.Config().LoadshedOltpRead.DropModeValue())
 	require.NoError(t, err)
 	assert.Equal(t, loadshed.DropJumpStart, mode)
+}
+
+func TestDebugEnvEnablementWiredToOltpGate(t *testing.T) {
+	tsv := newDebugEnvTabletServer(t)
+	require.NotNil(t, tsv.qe.snake)
+
+	postVar(t, tsv, "LoadshedOltpReadEnabled", "false")
+	assert.False(t, tsv.Config().LoadshedOltpRead.IsEnabled())
+
+	postVar(t, tsv, "LoadshedOltpReadEnabled", "true")
+	assert.True(t, tsv.Config().LoadshedOltpRead.IsEnabled())
 }

--- a/go/vt/vttablet/tabletserver/loadshed/codelq.go
+++ b/go/vt/vttablet/tabletserver/loadshed/codelq.go
@@ -450,6 +450,10 @@ func (q *CoDelQueue) lockedFindLowestPriorityDroppable() *list.Element {
 // independent of drop pacing, so it runs on every call; the paced drop/ease/
 // re-arm work runs only when a drop is actually due (now >= dropNextNs).
 func (q *CoDelQueue) lockedRunTimer(dropFn func() bool) {
+	q.lockedRunTimerLimited(dropFn, -1)
+}
+
+func (q *CoDelQueue) lockedRunTimerLimited(dropFn func() bool, maxDrops int) {
 	now := q.nowNs()
 
 	// Jump-start: while count==1 the timer is disarmed and only monitors the
@@ -471,7 +475,7 @@ func (q *CoDelQueue) lockedRunTimer(dropFn func() bool) {
 		return
 	}
 
-	q.lockedAdvance(now, dropFn)
+	q.lockedAdvanceLimited(now, dropFn, maxDrops)
 
 	// Jump-start: after easing back to 1, hand off to the monitor rather than
 	// re-arming. In jump-start the monitor is the sole arming authority (it arms
@@ -497,12 +501,17 @@ func (q *CoDelQueue) lockedRunTimer(dropFn func() bool) {
 // waiting on the possibly-late backstop timer. It does NOT arm/disarm the timer
 // or run mode-specific jump/monitor logic; those remain the timer's job.
 func (q *CoDelQueue) lockedAdvance(now int64, dropFn func() bool) {
+	q.lockedAdvanceLimited(now, dropFn, -1)
+}
+
+func (q *CoDelQueue) lockedAdvanceLimited(now int64, dropFn func() bool, maxDrops int) {
+	drops := 0
 	// Step the control law per interval while a drop is due AND there is still
 	// work to do: either a droppable backlog to shed, or an elevated count that
 	// must ease back to 1. The count>1 term is essential for recovery — once the
 	// queue drains (droppableLen==0) the ease branch still needs to run to decay
 	// count and end the episode, otherwise the queue never returns to healthy.
-	for now >= q.dropNextNs && (q.droppableLen > 0 || q.count > 1) {
+	for now >= q.dropNextNs && (q.droppableLen > 0 || q.count > 1) && (maxDrops < 0 || drops < maxDrops) {
 		// Dropping: actively shed load.
 		dropped := q.dropping
 		if q.dropping {
@@ -512,6 +521,7 @@ func (q *CoDelQueue) lockedAdvance(now int64, dropFn func() bool) {
 				dropped = dropFn()
 			}
 			if dropped {
+				drops++
 				q.count++
 				q.dropNextNs = q.lockedControlLaw(q.dropNextNs)
 			}

--- a/go/vt/vttablet/tabletserver/loadshed/dequeue_shed_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/dequeue_shed_test.go
@@ -136,3 +136,55 @@ func TestValved_Drop_DefersSignalOutsideLock(t *testing.T) {
 		}
 	}
 }
+
+func TestValved_DisabledDropAdvancesCoDelWithoutDropping(t *testing.T) {
+	clock := newTestClock()
+	sq, _ := newValvedQueue(clock)
+	sq.codelq.cfg.TargetNs = func() int64 { return 1_000_000 }
+	sq.codelq.cfg.IntervalNs = func() int64 { return 10_000_000 }
+
+	const backlog = 5
+	reqs := make([]*Request, backlog)
+	for i := range reqs {
+		reqs[i] = sq.lockedEnqueue(string(rune('a'+i)), 0)
+	}
+	sq.codelq.count = sq.codelq.graceCount()
+	sq.codelq.dropNextNs = 1
+	clock.advance(1_000_000_000)
+
+	initialCount := sq.codelq.count
+	sq.lockedRunTimerIf(func() bool { return false })
+
+	assert.Greater(t, sq.codelq.count, initialCount)
+	assert.Equal(t, backlog, sq.lockedLen())
+	for _, req := range reqs {
+		assert.Nil(t, req.signaledValue)
+	}
+}
+
+func TestValved_EnablementSnapshottedOncePerBatch(t *testing.T) {
+	clock := newTestClock()
+	sq, _ := newValvedQueue(clock)
+	sq.codelq.cfg.TargetNs = func() int64 { return 1_000_000 }
+	sq.codelq.cfg.IntervalNs = func() int64 { return 10_000_000 }
+
+	const backlog = 10
+	reqs := make([]*Request, backlog)
+	for i := range reqs {
+		reqs[i] = sq.lockedEnqueue(string(rune('a'+i)), 0)
+	}
+	sq.codelq.count = sq.codelq.graceCount()
+	sq.codelq.dropNextNs = 1
+	clock.advance(1_000_000_000)
+
+	checks := 0
+	sq.lockedRunTimerIf(func() bool {
+		checks++
+		return false
+	})
+
+	assert.Equal(t, 1, checks)
+	for _, req := range reqs {
+		assert.Nil(t, req.signaledValue)
+	}
+}

--- a/go/vt/vttablet/tabletserver/loadshed/snake.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake.go
@@ -308,7 +308,7 @@ func (s *Snake) releaseOnCancel(req *Request) {
 func (s *Snake) lockedReleaseAndShed(req *Request) {
 	s.q.lockedRelease(req)
 	if s.q.lockedNeedsAdvance() {
-		s.q.lockedRunTimer()
+		s.q.lockedRunTimerIf(s.loadsheddingAllowed)
 	}
 }
 
@@ -319,7 +319,7 @@ func (s *Snake) lockedReleaseAndShed(req *Request) {
 // drops; the pending rejections are returned so the caller sends them AFTER
 // releasing s.mu (draining the goready storm off the lock).
 func (s *Snake) lockedEnqueueAdvance() []*Request {
-	s.q.lockedRunTimer()
+	s.q.lockedRunTimerIf(s.loadsheddingAllowed)
 	s.interval.Add(s.q.lockedCurrentInterval())
 	s.dropCount.Add(int64(s.q.lockedCount()))
 	return s.q.lockedTakePendingSignals()
@@ -383,10 +383,11 @@ func (s *Snake) runReleaseCBs(excValue error) {
 }
 
 func (s *Snake) priority(priority float64) float64 {
-	if s.cfg.LoadsheddingAllowed != nil && !s.cfg.LoadsheddingAllowed() {
-		return PriorityUndroppable
-	}
 	return priority
+}
+
+func (s *Snake) loadsheddingAllowed() bool {
+	return s.cfg.LoadsheddingAllowed == nil || s.cfg.LoadsheddingAllowed()
 }
 
 func (s *Snake) acquireError(priority float64) error {
@@ -464,7 +465,7 @@ func (s *Snake) runDropTimer() {
 	} else {
 		s.timerLag.Add(0)
 	}
-	s.q.lockedRunTimer()
+	s.q.lockedRunTimerIf(s.loadsheddingAllowed)
 	s.interval.Add(s.q.lockedCurrentInterval())
 	s.dropCount.Add(int64(s.q.lockedCount()))
 	s.lockedObserveLengths()

--- a/go/vt/vttablet/tabletserver/loadshed/snake_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_test.go
@@ -856,16 +856,108 @@ func TestSnake_Priority_HonorsCallerPriority(t *testing.T) {
 	}
 }
 
-// TestSnake_Priority_GateOverridesToUndroppable confirms that when shedding is
-// disallowed the caller's priority is ignored and the request is made
-// undroppable, regardless of how important the caller marked it.
-func TestSnake_Priority_GateOverridesToUndroppable(t *testing.T) {
+func TestSnake_Priority_DisabledPreservesCallerPriority(t *testing.T) {
 	cfg := defaultSnakeConfig()
 	cfg.LoadsheddingAllowed = func() bool { return false }
 	s := newTestSnake(cfg)
 
 	for _, priority := range []float64{0, 50, 100} {
-		assert.Equal(t, PriorityUndroppable, s.priority(priority),
-			"a closed shedding gate must override any caller priority to undroppable")
+		assert.Equal(t, priority, s.priority(priority))
 	}
+}
+
+func TestSnake_DisablePreventsQueuedRequestFromBeingShed(t *testing.T) {
+	type result struct {
+		unlock *SafeUnlock
+		err    error
+	}
+	const waiters = 10
+
+	runDueBatch := func(s *Snake) {
+		s.mu.Lock()
+		s.lockedStopDropTimer()
+		s.q.codelq.dropping = true
+		s.q.codelq.count = s.q.codelq.graceCount()
+		s.q.codelq.dropNextNs = s.clockFunc()
+		pending := s.lockedEnqueueAdvance()
+		s.mu.Unlock()
+		for _, req := range pending {
+			req.sendSignal()
+		}
+	}
+
+	newLoadedSnake := func(t *testing.T) (*Snake, *SafeUnlock, *atomic.Bool, context.CancelFunc, <-chan result) {
+		t.Helper()
+		allowed := &atomic.Bool{}
+		allowed.Store(true)
+		cfg := defaultSnakeConfig()
+		cfg.Capacity = func() int { return 1 }
+		cfg.LoadsheddingAllowed = allowed.Load
+		cfg.CoDel.TargetNs = func() int64 { return time.Millisecond.Nanoseconds() }
+		cfg.CoDel.IntervalNs = func() int64 { return (10 * time.Millisecond).Nanoseconds() }
+		cfg.CoDel.MinDropDelayNs = func() int64 { return (10 * time.Millisecond).Nanoseconds() }
+		s := newTestSnake(cfg)
+
+		holder, err := s.Acquire(t.Context(), "", 0)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		resultCh := make(chan result, waiters)
+		for range waiters {
+			go func() {
+				unlock, err := s.Acquire(ctx, "", 0)
+				resultCh <- result{unlock: unlock, err: err}
+			}()
+		}
+		require.Eventually(t, func() bool {
+			return s.Stats().DroppableLen == waiters
+		}, time.Second, time.Millisecond)
+		return s, holder, allowed, cancel, resultCh
+	}
+
+	t.Run("enabled sheds", func(t *testing.T) {
+		s, holder, _, cancel, resultCh := newLoadedSnake(t)
+		defer cancel()
+		runDueBatch(s)
+
+		var first result
+		require.Eventually(t, func() bool {
+			select {
+			case first = <-resultCh:
+				return true
+			default:
+				return false
+			}
+		}, time.Second, time.Millisecond)
+		assert.Error(t, first.err)
+
+		cancel()
+		require.NoError(t, holder.Release())
+		for range waiters - 1 {
+			res := <-resultCh
+			if res.unlock != nil {
+				require.NoError(t, res.unlock.Release())
+			}
+		}
+	})
+
+	t.Run("disabled preserves waiters", func(t *testing.T) {
+		s, holder, allowed, cancel, resultCh := newLoadedSnake(t)
+		defer cancel()
+		allowed.Store(false)
+		runDueBatch(s)
+
+		assert.Never(t, func() bool {
+			return len(resultCh) > 0
+		}, 150*time.Millisecond, time.Millisecond)
+		assert.False(t, s.IsHealthy(), "disabled shedding must still observe queue health")
+
+		require.NoError(t, holder.Release())
+		for range waiters {
+			res := <-resultCh
+			require.NoError(t, res.err)
+			require.NotNil(t, res.unlock)
+			require.NoError(t, res.unlock.Release())
+		}
+	})
 }

--- a/go/vt/vttablet/tabletserver/loadshed/valved_codelq.go
+++ b/go/vt/vttablet/tabletserver/loadshed/valved_codelq.go
@@ -255,16 +255,7 @@ const keepDroppableFloor = 4
 // valve successor.
 func (q *ValvedCoDelQueue) lockedDropFn() func() bool {
 	return func() bool {
-		if q.codelq.droppableLen <= keepDroppableFloor {
-			return false
-		}
-		elem := q.codelq.lockedFindLowestPriorityDroppable()
-		if elem == nil {
-			return false
-		}
-		req := elem.Value.(*Request)
-		q.lockedDrop(req)
-		return true
+		return q.lockedDropOne()
 	}
 }
 
@@ -273,7 +264,31 @@ func (q *ValvedCoDelQueue) lockedDropFn() func() bool {
 // the backstop timer and synchronously from the release/dequeue path, so
 // shedding tracks target as slots free rather than waiting for the timer.
 func (q *ValvedCoDelQueue) lockedRunTimer() {
-	q.codelq.lockedRunTimer(q.lockedDropFn())
+	q.lockedRunTimerIf(func() bool { return true })
+}
+
+func (q *ValvedCoDelQueue) lockedRunTimerIf(loadsheddingAllowed func() bool) {
+	enabled := loadsheddingAllowed()
+	if enabled {
+		q.codelq.lockedRunTimer(q.lockedDropFn())
+		return
+	}
+	maxDrops := max(q.codelq.droppableLen-keepDroppableFloor, 0)
+	q.codelq.lockedRunTimerLimited(func() bool {
+		return q.codelq.lockedFindLowestPriorityDroppable() != nil
+	}, maxDrops)
+}
+
+func (q *ValvedCoDelQueue) lockedDropOne() bool {
+	if q.codelq.droppableLen <= keepDroppableFloor {
+		return false
+	}
+	elem := q.codelq.lockedFindLowestPriorityDroppable()
+	if elem == nil {
+		return false
+	}
+	q.lockedDrop(elem.Value.(*Request))
+	return true
 }
 
 func (q *ValvedCoDelQueue) lockedOnGrant(r *Request) {

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -245,32 +245,33 @@ func NewQueryEngine(env tabletenv.Env, se *schema.Engine) *QueryEngine {
 	}
 	qe.txSerializer = txserializer.New(env)
 
-	if config.LoadshedEnabled {
-		qe.snake = loadshed.NewSnake(loadshed.SnakeConfig{
-			Name: "oltp-read",
-			CoDel: loadshed.CoDelConfig{
-				TargetNs: func() int64 { return config.LoadshedTarget.Nanoseconds() },
-				IntervalNs: func() int64 {
-					return int64(float64(config.LoadshedTarget.Nanoseconds()) * config.LoadshedIntervalRatio)
-				},
-				Exponent:       func() float64 { return 1 },
-				MinDropDelayNs: func() int64 { return int64(100 * time.Millisecond) },
-				TriggerNs:      func() int64 { return config.LoadshedTrigger.Nanoseconds() },
-				DropMode:       func() loadshed.CoDelDropMode { mode, _ := loadshed.ParseDropMode(config.LoadshedDropMode); return mode },
-				GraceCount:     func() int { return config.LoadshedGraceCount },
+	qe.snake = loadshed.NewSnake(loadshed.SnakeConfig{
+		Name: "oltp-read",
+		CoDel: loadshed.CoDelConfig{
+			TargetNs: func() int64 { return config.LoadshedOltpRead.TargetValue().Nanoseconds() },
+			IntervalNs: func() int64 {
+				return int64(float64(config.LoadshedOltpRead.TargetValue().Nanoseconds()) * config.LoadshedOltpRead.IntervalRatioValue())
 			},
-			// Track live pool capacity so runtime resizes keep the gate in sync.
-			// Capacity() is 0 until the pool opens; fall back to config until then.
-			Capacity: func() int {
-				if c := int(qe.conns.Capacity()); c > 0 {
-					return c
-				}
-				return config.OltpReadPool.Size
+			Exponent:       func() float64 { return 1 },
+			MinDropDelayNs: func() int64 { return int64(100 * time.Millisecond) },
+			TriggerNs:      func() int64 { return config.LoadshedOltpRead.TriggerValue().Nanoseconds() },
+			DropMode: func() loadshed.CoDelDropMode {
+				mode, _ := loadshed.ParseDropMode(config.LoadshedOltpRead.DropModeValue())
+				return mode
 			},
-			LoadsheddingAllowed: func() bool { return true },
-		})
-		loadshed.PublishStats(env.Exporter(), "SnakeOltpRead", qe.snake)
-	}
+			GraceCount: func() int { return config.LoadshedOltpRead.GraceCountValue() },
+		},
+		// Track live pool capacity so runtime resizes keep the gate in sync.
+		// Capacity() is 0 until the pool opens; fall back to config until then.
+		Capacity: func() int {
+			if c := int(qe.conns.Capacity()); c > 0 {
+				return c
+			}
+			return config.OltpReadPool.Size
+		},
+		LoadsheddingAllowed: func() bool { return config.LoadshedOltpRead.IsEnabled() },
+	})
+	loadshed.PublishStats(env.Exporter(), "SnakeOltpRead", qe.snake)
 
 	qe.strictTableACL = config.StrictTableACL
 	qe.enableTableACLDryRun = config.EnableTableACLDryRun

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -837,7 +837,7 @@ func (qre *QueryExecutor) getConn() (*connpool.PooledConn, func(), error) {
 		// schema (e.g. performance_schema health checks) are marked undroppable
 		// instead, so they are never shed.
 		snakePriority := snakePriorityFromOptions(qre.options, qre.tsv.config.TxThrottlerDefaultPriority)
-		if matchesUndroppableSchema(qre.plan.SchemaQualifiers, qre.tsv.Config().LoadshedUndroppableSchemas) {
+		if matchesUndroppableSchema(qre.plan.SchemaQualifiers, qre.tsv.Config().LoadshedOltpRead.UndroppableSchemasValue()) {
 			snakePriority = loadshed.PriorityUndroppable
 		}
 		unlock, err := snake.Acquire(ctx, valveID, snakePriority)

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1658,9 +1658,9 @@ func TestGetConnSnakeEmptyValveID(t *testing.T) {
 	cfg := tabletenv.NewDefaultConfig()
 	cfg.OltpReadPool.Size = 2
 	cfg.TxPool.Size = 100
-	cfg.LoadshedEnabled = true
-	cfg.LoadshedTarget = 5 * time.Millisecond
-	cfg.LoadshedIntervalRatio = 20
+	cfg.LoadshedOltpRead.Enabled = true
+	cfg.LoadshedOltpRead.Target = 5 * time.Millisecond
+	cfg.LoadshedOltpRead.IntervalRatio = 20
 	cfg.DB = newDBConfigs(db)
 
 	srvTopoCounts := stats.NewCountersWithSingleLabel("", "Resilient srvtopo server operations", "type")
@@ -1700,9 +1700,9 @@ func TestGetConnWithSnake(t *testing.T) {
 	cfg := tabletenv.NewDefaultConfig()
 	cfg.OltpReadPool.Size = 2
 	cfg.TxPool.Size = 100
-	cfg.LoadshedEnabled = true
-	cfg.LoadshedTarget = 5 * time.Millisecond
-	cfg.LoadshedIntervalRatio = 20
+	cfg.LoadshedOltpRead.Enabled = true
+	cfg.LoadshedOltpRead.Target = 5 * time.Millisecond
+	cfg.LoadshedOltpRead.IntervalRatio = 20
 	cfg.DB = newDBConfigs(db)
 
 	srvTopoCounts := stats.NewCountersWithSingleLabel("", "Resilient srvtopo server operations", "type")
@@ -1712,7 +1712,7 @@ func TestGetConnWithSnake(t *testing.T) {
 	require.NoError(t, err)
 	defer tsv.StopService()
 
-	require.NotNil(t, tsv.qe.snake, "snake should be initialized when LoadshedEnabled=true")
+	require.NotNil(t, tsv.qe.snake)
 
 	input := "select * from test_table limit 1"
 
@@ -1734,15 +1734,25 @@ func TestGetConnSnakeDisabled(t *testing.T) {
 	tsv := newTestTabletServer(ctx, noFlags, db)
 	defer tsv.StopService()
 
-	assert.Nil(t, tsv.qe.snake, "snake should be nil when LoadshedEnabled=false")
+	require.NotNil(t, tsv.qe.snake, "snake must exist so it can be enabled at runtime")
 
 	input := "select * from test_table limit 1"
 	qre := newTestQueryExecutor(ctx, tsv, input, 0)
 	conn, release, err := qre.getConn()
 	require.NoError(t, err)
 	require.NotNil(t, conn)
+	assert.Equal(t, 1, tsv.qe.snake.Stats().HolderCount)
 	conn.Recycle()
 	release()
+	assert.Equal(t, 0, tsv.qe.snake.Stats().HolderCount)
+
+	tsv.Config().LoadshedOltpRead.SetEnabled(true)
+	conn, release, err = qre.getConn()
+	require.NoError(t, err)
+	assert.Equal(t, 1, tsv.qe.snake.Stats().HolderCount)
+	conn.Recycle()
+	release()
+	assert.Equal(t, 0, tsv.qe.snake.Stats().HolderCount)
 }
 
 type executorFlags int64
@@ -1794,7 +1804,8 @@ func newTestTabletServer(ctx context.Context, flags executorFlags, db *fakesqldb
 	}
 	// Loadshed defaults to on, but the shared test tablet should leave Snake
 	// disabled unless a test opts in (TestGetConnWithSnake builds its own config).
-	cfg.LoadshedEnabled = false
+	cfg.LoadshedOltpRead.Enabled = false
+	cfg.LoadshedTx.Enabled = false
 	dbconfigs := newDBConfigs(db)
 	cfg.DB = dbconfigs
 	srvTopoCounts := stats.NewCountersWithSingleLabel("", "Resilient srvtopo server operations", "type")

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -80,7 +80,6 @@ var (
 	unhealthyThreshold           time.Duration
 	transitionGracePeriod        time.Duration
 	enableReplicationReporter    bool
-	enableLoadshed               bool
 )
 
 func init() {
@@ -225,13 +224,18 @@ func registerTabletEnvFlags(fs *pflag.FlagSet) {
 
 	fs.BoolVar(&currentConfig.Unmanaged, "unmanaged", false, "Indicates an unmanaged tablet, i.e. using an external mysql-compatible database")
 
-	fs.BoolVar(&enableLoadshed, "loadshed-enabled", true, "If true, enables CoDel-based load shedding on the OLTP read and transaction pools.")
-	fs.DurationVar(&currentConfig.LoadshedTarget, "loadshed-target", defaultConfig.LoadshedTarget, "CoDel target delay for the load shedder.")
-	fs.Float64Var(&currentConfig.LoadshedIntervalRatio, "loadshed-interval-ratio", defaultConfig.LoadshedIntervalRatio, "CoDel observation interval for the load shedder, as a multiple of loadshed-target (interval = target * ratio). Recommended 10-20.")
-	fs.StringVar(&currentConfig.LoadshedDropMode, "loadshed-drop-mode", defaultConfig.LoadshedDropMode, "CoDel drop mode for the load shedder: slow (arm on enqueue, ramp), jump (arm only when head sojourn crosses the trigger), or both.")
-	fs.DurationVar(&currentConfig.LoadshedTrigger, "loadshed-trigger", defaultConfig.LoadshedTrigger, "CoDel sojourn threshold that arms a jump in jump/both drop modes. 0 defaults to the CoDel interval (loadshed-target * loadshed-interval-ratio).")
-	fs.IntVar(&currentConfig.LoadshedGraceCount, "loadshed-grace-count", defaultConfig.LoadshedGraceCount, "CoDel grace count: suppress the head drop while the drop count is below this value. 1 disables the grace period.")
-	fs.StringSliceVar(&currentConfig.LoadshedUndroppableSchemas, "loadshed-undroppable-schemas", defaultConfig.LoadshedUndroppableSchemas, "Schema qualifiers (e.g. performance_schema) whose queries the load shedder marks undroppable, so low-volume health-check traffic against them is never shed.")
+	registerLoadshedFlags(fs, "oltp-read", &currentConfig.LoadshedOltpRead.LoadshedConfig, defaultConfig.LoadshedOltpRead.LoadshedConfig)
+	fs.StringSliceVar(&currentConfig.LoadshedOltpRead.UndroppableSchemas, "loadshed-oltp-read-undroppable-schemas", defaultConfig.LoadshedOltpRead.UndroppableSchemas, "Schema qualifiers whose OLTP read queries are never shed.")
+	registerLoadshedFlags(fs, "tx", &currentConfig.LoadshedTx, defaultConfig.LoadshedTx)
+}
+
+func registerLoadshedFlags(fs *pflag.FlagSet, pool string, cfg *LoadshedConfig, defaultCfg LoadshedConfig) {
+	fs.BoolVar(&cfg.Enabled, "loadshed-"+pool+"-enabled", defaultCfg.Enabled, "If true, enables CoDel-based load shedding on the "+pool+" pool.")
+	fs.DurationVar(&cfg.Target, "loadshed-"+pool+"-target", defaultCfg.Target, "CoDel target delay for the "+pool+" load shedder.")
+	fs.Float64Var(&cfg.IntervalRatio, "loadshed-"+pool+"-interval-ratio", defaultCfg.IntervalRatio, "CoDel observation interval for the "+pool+" load shedder, as a multiple of its target.")
+	fs.StringVar(&cfg.DropMode, "loadshed-"+pool+"-drop-mode", defaultCfg.DropMode, "CoDel drop mode for the "+pool+" load shedder: slow, jump, or both.")
+	fs.DurationVar(&cfg.Trigger, "loadshed-"+pool+"-trigger", defaultCfg.Trigger, "CoDel sojourn threshold for the "+pool+" load shedder. 0 defaults to its CoDel interval.")
+	fs.IntVar(&cfg.GraceCount, "loadshed-"+pool+"-grace-count", defaultCfg.GraceCount, "CoDel grace count for the "+pool+" load shedder.")
 }
 
 var (
@@ -304,7 +308,6 @@ func Init() {
 	currentConfig.GracePeriods.Transition = transitionGracePeriod
 	currentConfig.SemiSyncMonitor.Interval = semiSyncMonitorInterval
 
-	currentConfig.LoadshedEnabled = enableLoadshed
 	logFormat := streamlog.GetQueryLogConfig().Format
 	switch logFormat {
 	case streamlog.QueryLogFormatText:
@@ -398,35 +401,133 @@ type TabletConfig struct {
 
 	EnablePerWorkloadTableMetrics bool `json:"-"`
 
-	LoadshedEnabled       bool          `json:"-"`
-	LoadshedTarget        time.Duration `json:"-"`
-	LoadshedIntervalRatio float64       `json:"-"`
-	LoadshedDropMode      string        `json:"-"`
-	LoadshedTrigger       time.Duration `json:"-"`
-	LoadshedGraceCount    int           `json:"-"`
-	// LoadshedUndroppableSchemas lists schema qualifiers (e.g. performance_schema)
-	// whose queries are marked undroppable by the load shedder, so low-volume
-	// health-check/monitoring traffic against them is never shed. Matched
-	// case-insensitively against the query's table qualifiers.
-	LoadshedUndroppableSchemas []string `json:"-"`
+	LoadshedOltpRead OltpLoadshedConfig `json:"-"`
+	LoadshedTx       LoadshedConfig     `json:"-"`
+}
+
+type LoadshedConfig struct {
+	mu            *sync.RWMutex
+	Enabled       bool
+	Target        time.Duration
+	IntervalRatio float64
+	DropMode      string
+	Trigger       time.Duration
+	GraceCount    int
+}
+
+type OltpLoadshedConfig struct {
+	LoadshedConfig
+	schemasMu          *sync.RWMutex
+	UndroppableSchemas []string
+}
+
+func (c *LoadshedConfig) IsEnabled() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.Enabled
+}
+
+func (c *LoadshedConfig) SetEnabled(enabled bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.Enabled = enabled
+}
+
+func (c *LoadshedConfig) TargetValue() time.Duration {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.Target
+}
+
+func (c *LoadshedConfig) SetTarget(target time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.Target = target
+}
+
+func (c *LoadshedConfig) IntervalRatioValue() float64 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.IntervalRatio
+}
+
+func (c *LoadshedConfig) SetIntervalRatio(intervalRatio float64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.IntervalRatio = intervalRatio
+}
+
+func (c *LoadshedConfig) DropModeValue() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.DropMode
+}
+
+func (c *LoadshedConfig) SetDropMode(dropMode string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.DropMode = dropMode
+}
+
+func (c *LoadshedConfig) TriggerValue() time.Duration {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.Trigger
+}
+
+func (c *LoadshedConfig) SetTrigger(trigger time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.Trigger = trigger
+}
+
+func (c *LoadshedConfig) GraceCountValue() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.GraceCount
+}
+
+func (c *LoadshedConfig) SetGraceCount(graceCount int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.GraceCount = graceCount
+}
+
+func (c *OltpLoadshedConfig) UndroppableSchemasValue() []string {
+	if c.schemasMu == nil {
+		return append([]string(nil), c.UndroppableSchemas...)
+	}
+	c.schemasMu.RLock()
+	defer c.schemasMu.RUnlock()
+	return append([]string(nil), c.UndroppableSchemas...)
+}
+
+func (c *OltpLoadshedConfig) SetUndroppableSchemas(schemas []string) {
+	if c.schemasMu == nil {
+		c.schemasMu = &sync.RWMutex{}
+	}
+	c.schemasMu.Lock()
+	defer c.schemasMu.Unlock()
+	c.UndroppableSchemas = append([]string(nil), schemas...)
 }
 
 func (cfg *TabletConfig) MarshalJSON() ([]byte, error) {
 	type TCProxy TabletConfig
 
+	snapshot := cfg.Clone()
 	tmp := struct {
 		TCProxy
 		SchemaReloadInterval      string `json:"schemaReloadIntervalSeconds,omitempty"`
 		SchemaChangeReloadTimeout string `json:"schemaChangeReloadTimeout,omitempty"`
 	}{
-		TCProxy: TCProxy(*cfg),
+		TCProxy: TCProxy(*snapshot),
 	}
 
-	if d := cfg.SchemaReloadInterval; d != 0 {
+	if d := snapshot.SchemaReloadInterval; d != 0 {
 		tmp.SchemaReloadInterval = d.String()
 	}
 
-	if d := cfg.SchemaChangeReloadTimeout; d != 0 {
+	if d := snapshot.SchemaChangeReloadTimeout; d != 0 {
 		tmp.SchemaChangeReloadTimeout = d.String()
 	}
 
@@ -898,11 +999,70 @@ func NewDefaultConfig() *TabletConfig {
 
 // Clone creates a clone of TabletConfig.
 func (c *TabletConfig) Clone() *TabletConfig {
+	if c.LoadshedOltpRead.mu != nil {
+		c.LoadshedOltpRead.mu.RLock()
+		defer c.LoadshedOltpRead.mu.RUnlock()
+	}
+	if c.LoadshedOltpRead.schemasMu != nil {
+		c.LoadshedOltpRead.schemasMu.RLock()
+		defer c.LoadshedOltpRead.schemasMu.RUnlock()
+	}
+	if c.LoadshedTx.mu != nil {
+		c.LoadshedTx.mu.RLock()
+		defer c.LoadshedTx.mu.RUnlock()
+	}
+
 	tc := *c
 	if tc.DB != nil {
 		tc.DB = c.DB.Clone()
 	}
+	var oltpMu *sync.RWMutex
+	if c.LoadshedOltpRead.mu != nil {
+		oltpMu = &sync.RWMutex{}
+	}
+	var schemasMu *sync.RWMutex
+	if c.LoadshedOltpRead.schemasMu != nil {
+		schemasMu = &sync.RWMutex{}
+	}
+	tc.LoadshedOltpRead = OltpLoadshedConfig{
+		LoadshedConfig: LoadshedConfig{
+			mu:            oltpMu,
+			Enabled:       c.LoadshedOltpRead.Enabled,
+			Target:        c.LoadshedOltpRead.Target,
+			IntervalRatio: c.LoadshedOltpRead.IntervalRatio,
+			DropMode:      c.LoadshedOltpRead.DropMode,
+			Trigger:       c.LoadshedOltpRead.Trigger,
+			GraceCount:    c.LoadshedOltpRead.GraceCount,
+		},
+		schemasMu:          schemasMu,
+		UndroppableSchemas: append([]string(nil), c.LoadshedOltpRead.UndroppableSchemas...),
+	}
+	var txMu *sync.RWMutex
+	if c.LoadshedTx.mu != nil {
+		txMu = &sync.RWMutex{}
+	}
+	tc.LoadshedTx = LoadshedConfig{
+		mu:            txMu,
+		Enabled:       c.LoadshedTx.Enabled,
+		Target:        c.LoadshedTx.Target,
+		IntervalRatio: c.LoadshedTx.IntervalRatio,
+		DropMode:      c.LoadshedTx.DropMode,
+		Trigger:       c.LoadshedTx.Trigger,
+		GraceCount:    c.LoadshedTx.GraceCount,
+	}
 	return &tc
+}
+
+func (c *TabletConfig) InitLoadshedConfig() {
+	if c.LoadshedOltpRead.mu == nil {
+		c.LoadshedOltpRead.mu = &sync.RWMutex{}
+	}
+	if c.LoadshedOltpRead.schemasMu == nil {
+		c.LoadshedOltpRead.schemasMu = &sync.RWMutex{}
+	}
+	if c.LoadshedTx.mu == nil {
+		c.LoadshedTx.mu = &sync.RWMutex{}
+	}
 }
 
 // SetTxTimeoutForWorkload updates workload transaction timeouts. Used in tests only.
@@ -1161,15 +1321,24 @@ var defaultConfig = TabletConfig{
 
 	TwoPCAbandonAge: 15 * time.Minute,
 
-	LoadshedEnabled:       true,
-	LoadshedTarget:        5 * time.Millisecond,
-	LoadshedIntervalRatio: 20,
-	LoadshedDropMode:      "slow",
-	LoadshedTrigger:       0,
-	LoadshedGraceCount:    1,
-	// System schemas are queried by health checks/monitoring, which are
-	// low-volume and must succeed; default to marking them undroppable.
-	LoadshedUndroppableSchemas: []string{"performance_schema", "information_schema", "sys", "mysql"},
+	LoadshedOltpRead: OltpLoadshedConfig{
+		LoadshedConfig:     defaultLoadshedConfig(),
+		schemasMu:          &sync.RWMutex{},
+		UndroppableSchemas: []string{"performance_schema", "information_schema", "sys", "mysql"},
+	},
+	LoadshedTx: defaultLoadshedConfig(),
+}
+
+func defaultLoadshedConfig() LoadshedConfig {
+	return LoadshedConfig{
+		mu:            &sync.RWMutex{},
+		Enabled:       true,
+		Target:        5 * time.Millisecond,
+		IntervalRatio: 20,
+		DropMode:      "slow",
+		Trigger:       0,
+		GraceCount:    1,
+	}
 }
 
 // defaultTxThrottlerConfig returns the default TxThrottlerConfigFlag object based on

--- a/go/vt/vttablet/tabletserver/tabletenv/config_test.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package tabletenv
 
 import (
+	"encoding/json"
+	"sync"
 	"testing"
 	"time"
 
@@ -337,6 +339,71 @@ func TestFlags(t *testing.T) {
 	Init()
 	want.SanitizeLogMessages = true
 	assert.Equal(t, want, currentConfig)
+}
+
+func TestLoadshedConfigIsIndependentPerPool(t *testing.T) {
+	cfg := NewDefaultConfig()
+
+	assert.True(t, cfg.LoadshedOltpRead.Enabled)
+	assert.True(t, cfg.LoadshedTx.Enabled)
+	assert.Equal(t, cfg.LoadshedOltpRead.Target, cfg.LoadshedTx.Target)
+	assert.Equal(t, cfg.LoadshedOltpRead.IntervalRatio, cfg.LoadshedTx.IntervalRatio)
+	assert.NotEmpty(t, cfg.LoadshedOltpRead.UndroppableSchemas)
+
+	cfg.LoadshedOltpRead.Target = time.Second
+	cfg.LoadshedOltpRead.Enabled = false
+
+	assert.False(t, cfg.LoadshedOltpRead.Enabled)
+	assert.True(t, cfg.LoadshedTx.Enabled)
+	assert.NotEqual(t, cfg.LoadshedOltpRead.Target, cfg.LoadshedTx.Target)
+}
+
+func TestLoadshedConfigConcurrentSnapshot(t *testing.T) {
+	cfg := NewDefaultConfig()
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	go func() {
+		defer wg.Done()
+		for i := range 100 {
+			cfg.LoadshedOltpRead.SetGraceCount(i)
+			cfg.LoadshedOltpRead.SetUndroppableSchemas([]string{"schema"})
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := range 100 {
+			cfg.LoadshedTx.SetGraceCount(i)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range 100 {
+			cfg.Clone()
+			_, err := json.Marshal(cfg)
+			assert.NoError(t, err)
+		}
+	}()
+
+	wg.Wait()
+}
+
+func TestLoadshedFlagsAreIndependentPerPool(t *testing.T) {
+	original := currentConfig
+	defer func() { currentConfig = original }()
+
+	currentConfig = *NewDefaultConfig()
+	fs := pflag.NewFlagSet("TestLoadshedFlags", pflag.ContinueOnError)
+	registerTabletEnvFlags(fs)
+
+	require.NoError(t, fs.Set("loadshed-oltp-read-enabled", "false"))
+	require.NoError(t, fs.Set("loadshed-oltp-read-target", "7ms"))
+	require.NoError(t, fs.Set("loadshed-tx-target", "11ms"))
+
+	assert.False(t, currentConfig.LoadshedOltpRead.Enabled)
+	assert.Equal(t, 7*time.Millisecond, currentConfig.LoadshedOltpRead.Target)
+	assert.True(t, currentConfig.LoadshedTx.Enabled)
+	assert.Equal(t, 11*time.Millisecond, currentConfig.LoadshedTx.Target)
 }
 
 func TestTxThrottlerConfigFlag(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/tabletenv/env.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/env.go
@@ -47,6 +47,9 @@ type testEnv struct {
 // without an actual TabletServer.
 func NewEnv(env *vtenv.Environment, config *TabletConfig, exporterName string) Env {
 	exporter := servenv.NewExporter(exporterName, "Tablet")
+	if config != nil {
+		config.InitLoadshedConfig()
+	}
 	return &testEnv{
 		config:   config,
 		exporter: exporter,

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -148,6 +148,7 @@ func NewServer(ctx context.Context, env *vtenv.Environment, name string, topoSer
 // NewTabletServer creates an instance of TabletServer. Only the first
 // instance of TabletServer will expose its state variables.
 func NewTabletServer(ctx context.Context, env *vtenv.Environment, name string, config *tabletenv.TabletConfig, topoServer *topo.Server, alias *topodatapb.TabletAlias, srvTopoCounts *stats.CountersWithSingleLabel) *TabletServer {
+	config.InitLoadshedConfig()
 	exporter := servenv.NewExporter(name, "Tablet")
 	tsv := &TabletServer{
 		exporter:               exporter,

--- a/go/vt/vttablet/tabletserver/tx_engine.go
+++ b/go/vt/vttablet/tabletserver/tx_engine.go
@@ -115,32 +115,33 @@ func NewTxEngine(env tabletenv.Env, dxNotifier func()) *TxEngine {
 	}
 	limiter := txlimiter.New(env)
 	te.txPool = NewTxPool(env, limiter)
-	if config.LoadshedEnabled {
-		te.txPool.snake = loadshed.NewSnake(loadshed.SnakeConfig{
-			Name: "dml",
-			CoDel: loadshed.CoDelConfig{
-				TargetNs: func() int64 { return config.LoadshedTarget.Nanoseconds() },
-				IntervalNs: func() int64 {
-					return int64(float64(config.LoadshedTarget.Nanoseconds()) * config.LoadshedIntervalRatio)
-				},
-				Exponent:       func() float64 { return 1 },
-				MinDropDelayNs: func() int64 { return int64(100 * time.Millisecond) },
-				TriggerNs:      func() int64 { return config.LoadshedTrigger.Nanoseconds() },
-				DropMode:       func() loadshed.CoDelDropMode { mode, _ := loadshed.ParseDropMode(config.LoadshedDropMode); return mode },
-				GraceCount:     func() int { return config.LoadshedGraceCount },
+	te.txPool.snake = loadshed.NewSnake(loadshed.SnakeConfig{
+		Name: "dml",
+		CoDel: loadshed.CoDelConfig{
+			TargetNs: func() int64 { return config.LoadshedTx.TargetValue().Nanoseconds() },
+			IntervalNs: func() int64 {
+				return int64(float64(config.LoadshedTx.TargetValue().Nanoseconds()) * config.LoadshedTx.IntervalRatioValue())
 			},
-			// Track live pool capacity so runtime resizes keep the gate in sync.
-			// Capacity() is 0 until the pool opens; fall back to config until then.
-			Capacity: func() int {
-				if c := te.txPool.scp.Capacity(); c > 0 {
-					return c
-				}
-				return config.TxPool.Size
+			Exponent:       func() float64 { return 1 },
+			MinDropDelayNs: func() int64 { return int64(100 * time.Millisecond) },
+			TriggerNs:      func() int64 { return config.LoadshedTx.TriggerValue().Nanoseconds() },
+			DropMode: func() loadshed.CoDelDropMode {
+				mode, _ := loadshed.ParseDropMode(config.LoadshedTx.DropModeValue())
+				return mode
 			},
-			LoadsheddingAllowed: func() bool { return true },
-		})
-		loadshed.PublishStats(env.Exporter(), "SnakeDml", te.txPool.snake)
-	}
+			GraceCount: func() int { return config.LoadshedTx.GraceCountValue() },
+		},
+		// Track live pool capacity so runtime resizes keep the gate in sync.
+		// Capacity() is 0 until the pool opens; fall back to config until then.
+		Capacity: func() int {
+			if c := te.txPool.scp.Capacity(); c > 0 {
+				return c
+			}
+			return config.TxPool.Size
+		},
+		LoadsheddingAllowed: func() bool { return config.LoadshedTx.IsEnabled() },
+	})
+	loadshed.PublishStats(env.Exporter(), "SnakeDml", te.txPool.snake)
 	// We initially allow twoPC (handles vttablet restarts).
 	// We will disallow them for a few reasons -
 	//	1. When a new tablet is promoted if semi-sync is turned off.

--- a/go/vt/vttablet/tabletserver/tx_pool.go
+++ b/go/vt/vttablet/tabletserver/tx_pool.go
@@ -18,6 +18,7 @@ package tabletserver
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync"
 	"time"
@@ -256,9 +257,19 @@ func (tp *TxPool) Begin(ctx context.Context, options *querypb.ExecuteOptions, re
 		if tp.snake != nil {
 			valveID := options.GetLoadshedValveId()
 			snakePriority := snakePriorityFromOptions(options, tp.env.Config().TxThrottlerDefaultPriority)
-			unlock, snakeErr := tp.snake.Acquire(ctx, valveID, snakePriority)
+			snakeCtx := ctx
+			cancel := func() {}
+			if timeout := tp.env.Config().TxPool.Timeout; timeout > 0 {
+				snakeCtx, cancel = context.WithTimeout(ctx, timeout)
+			}
+			unlock, snakeErr := tp.snake.Acquire(snakeCtx, valveID, snakePriority)
+			cancel()
 			if snakeErr != nil {
 				tp.limiter.Release(immediateCaller, effectiveCaller)
+				if errors.Is(snakeErr, context.DeadlineExceeded) && ctx.Err() == nil {
+					tp.LogActive()
+					return nil, "", "", vterrors.Errorf(vtrpcpb.Code_RESOURCE_EXHAUSTED, "transaction pool connection limit exceeded")
+				}
 				return nil, "", "", errDMLLoadShed
 			}
 			snakeRelease = func() { unlock.Release() }

--- a/go/vt/vttablet/tabletserver/tx_pool_snake_test.go
+++ b/go/vt/vttablet/tabletserver/tx_pool_snake_test.go
@@ -277,3 +277,20 @@ func TestTxPoolSnake_NilSnakePassesThrough(t *testing.T) {
 	_, _ = txPool.Commit(ctx, c)
 	c.Release(tx.TxCommit)
 }
+
+func TestTxPoolSnake_RuntimeEnablement(t *testing.T) {
+	_, txPool, closer := setupWithSnake(t, 2)
+	defer closer()
+
+	txPool.env.Config().LoadshedTx.SetEnabled(false)
+	conn, _, _, err := txPool.Begin(t.Context(), &querypb.ExecuteOptions{}, false, 0, nil)
+	require.NoError(t, err)
+	assert.NotNil(t, conn.TxProperties().SnakeRelease)
+	conn.Release(tx.ConnRelease)
+
+	txPool.env.Config().LoadshedTx.SetEnabled(true)
+	conn, _, _, err = txPool.Begin(t.Context(), &querypb.ExecuteOptions{}, false, 0, nil)
+	require.NoError(t, err)
+	assert.NotNil(t, conn.TxProperties().SnakeRelease)
+	conn.Release(tx.ConnRelease)
+}

--- a/go/vt/vttablet/tabletserver/tx_pool_snake_test.go
+++ b/go/vt/vttablet/tabletserver/tx_pool_snake_test.go
@@ -294,3 +294,18 @@ func TestTxPoolSnake_RuntimeEnablement(t *testing.T) {
 	assert.NotNil(t, conn.TxProperties().SnakeRelease)
 	conn.Release(tx.ConnRelease)
 }
+
+func TestTxPoolSnake_RespectsPoolTimeout(t *testing.T) {
+	_, txPool, closer := setupWithSnake(t, 1)
+	defer closer()
+	txPool.env.Config().TxPool.Timeout = 20 * time.Millisecond
+
+	conn, _, _, err := txPool.Begin(t.Context(), &querypb.ExecuteOptions{}, false, 0, nil)
+	require.NoError(t, err)
+	defer conn.Release(tx.ConnRelease)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+	_, _, _, err = txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
+	require.ErrorContains(t, err, "transaction pool connection limit exceeded")
+}


### PR DESCRIPTION
## What's this?

Makes Snake independently configurable for OLTP reads and transactions, including runtime controls through `/debug/env`.

## How it works

Each pool has separate enablement and CoDel tuning. Disabled mode still traverses Snake and records queue/control metrics, but uses dry-run drops instead of rejecting requests. Transaction undroppable schemas are intentionally not exposed.

The independent review noted that retained requests can contribute to dry-run metrics across multiple disabled batches and influence state when shedding is re-enabled. We accepted that behavior to keep the implementation and runtime state simpler.

## Testing

- Full `tabletenv` and `loadshed` suites
- Focused tabletserver OLTP, transaction, and `/debug/env` tests
- Focused race tests for runtime configuration and disabled dry-run behavior