### PR TITLE
Parameterize loadshed queue types

### DIFF
--- a/go/vt/vttablet/tabletserver/loadshed/codelq.go
+++ b/go/vt/vttablet/tabletserver/loadshed/codelq.go
@@ -148,7 +148,7 @@ type (
 	// CoDelQueue implements the CoDel (Controlled Delay) load-shedding
 	// algorithm. All methods are prefixed locked* and assume the caller holds
 	// the mutex, which is defined in the files for the higher-level structure
-	CoDelQueue struct {
+	CoDelQueue[T any] struct {
 		queue        *list.List
 		firstWaiting *list.Element
 		dropping     bool
@@ -158,13 +158,13 @@ type (
 		// droppable indexes the droppable queue entries by priority so the
 		// lowest-priority one is found in O(1) rather than an O(n) scan. Kept in
 		// lockstep with droppableLen: every insert/remove pairs with a ++/--.
-		droppable droppableIndex
+		droppable droppableIndex[T]
 
 		cfg               CoDelConfig
 		nowNs             func() int64
 		scheduleDropTimer func(delayNs int64)
 		stopDropTimer     func()
-		onPeekCleanup     func(*Request)
+		onPeekCleanup     func(*Request[T])
 	}
 )
 
@@ -172,8 +172,8 @@ func (e *DroppedRequestError) Error() string {
 	return "request dropped by CoDel queue"
 }
 
-func newCoDelQueue(cfg CoDelConfig, nowNs func() int64, scheduleDropTimer func(delayNs int64), stopDropTimer func(), onPeekCleanup func(*Request)) *CoDelQueue {
-	q := &CoDelQueue{
+func newCoDelQueue[T any](cfg CoDelConfig, nowNs func() int64, scheduleDropTimer func(delayNs int64), stopDropTimer func(), onPeekCleanup func(*Request[T])) *CoDelQueue[T] {
+	q := &CoDelQueue[T]{
 		queue:             list.New(),
 		count:             1,
 		cfg:               cfg,
@@ -186,15 +186,15 @@ func newCoDelQueue(cfg CoDelConfig, nowNs func() int64, scheduleDropTimer func(d
 	return q
 }
 
-func (q *CoDelQueue) lockedLen() int {
+func (q *CoDelQueue[T]) lockedLen() int {
 	return q.queue.Len()
 }
 
-func (q *CoDelQueue) lockedIsHealthy() bool {
+func (q *CoDelQueue[T]) lockedIsHealthy() bool {
 	return !q.dropping
 }
 
-func (q *CoDelQueue) lockedEnqueue(req *Request) {
+func (q *CoDelQueue[T]) lockedEnqueue(req *Request[T]) {
 	now := q.nowNs()
 
 	req.codelqEnqueuedAtNs = now
@@ -220,20 +220,20 @@ func (q *CoDelQueue) lockedEnqueue(req *Request) {
 }
 
 // lockedFirstWaiting returns the first not-yet-granted request in the queue.
-func (q *CoDelQueue) lockedFirstWaiting() *Request {
+func (q *CoDelQueue[T]) lockedFirstWaiting() *Request[T] {
 	if q.firstWaiting == nil {
 		return nil
 	}
-	return q.firstWaiting.Value.(*Request)
+	return q.firstWaiting.Value.(*Request[T])
 }
 
 // lockedPeek returns the head request without removing it. As a side effect,
 // cleans up done-and-not-granted requests at the head (requests whose result
 // channel has an error). Empty queue transitions to healthy.
-func (q *CoDelQueue) lockedPeek() *Request {
+func (q *CoDelQueue[T]) lockedPeek() *Request[T] {
 	for q.queue.Len() > 0 {
 		front := q.queue.Front()
-		req := front.Value.(*Request)
+		req := front.Value.(*Request[T])
 		if req.signaledValue == nil {
 			return req
 		}
@@ -257,8 +257,8 @@ func (q *CoDelQueue) lockedPeek() *Request {
 // result channel, and updates bookkeeping. Use with care: this bypasses the
 // health-state transitions in peek/dequeue, so callers are responsible for
 // updating dropping state if appropriate.
-func (q *CoDelQueue) lockedPopElem(elem *list.Element, err error) *Request {
-	req := elem.Value.(*Request)
+func (q *CoDelQueue[T]) lockedPopElem(elem *list.Element, err error) *Request[T] {
+	req := elem.Value.(*Request[T])
 	q.lockedAdvanceFirstWaiting(elem)
 	q.queue.Remove(elem)
 	req.codelqElem = nil
@@ -279,7 +279,7 @@ func (q *CoDelQueue) lockedPopElem(elem *list.Element, err error) *Request {
 }
 
 // lockedRemove removes a specific request from the queue without signaling it.
-func (q *CoDelQueue) lockedRemove(r *Request) {
+func (q *CoDelQueue[T]) lockedRemove(r *Request[T]) {
 	if r.codelqElem == nil {
 		return
 	}
@@ -296,7 +296,7 @@ func (q *CoDelQueue) lockedRemove(r *Request) {
 	}
 }
 
-func (q *CoDelQueue) lockedOnGrant(r *Request) {
+func (q *CoDelQueue[T]) lockedOnGrant(r *Request[T]) {
 	// CoDel health check, measured at grant: if this request's queue-wait
 	// (now - enqueue) was under target, the system is healthy — leave the
 	// dropping state. Separate from the droppableLen==0 clear below.
@@ -318,12 +318,12 @@ func (q *CoDelQueue) lockedOnGrant(r *Request) {
 // lockedAdvanceFirstWaiting advances the firstWaiting pointer past elem if
 // elem is the current firstWaiting. elem is a queue entry that is no longer
 // waiting — either because it was granted, removed, or dropped.
-func (q *CoDelQueue) lockedAdvanceFirstWaiting(elem *list.Element) {
+func (q *CoDelQueue[T]) lockedAdvanceFirstWaiting(elem *list.Element) {
 	if q.firstWaiting != elem {
 		return
 	}
 	for e := elem.Next(); e != nil; e = e.Next() {
-		if e.Value.(*Request).signaledValue == nil {
+		if e.Value.(*Request[T]).signaledValue == nil {
 			q.firstWaiting = e
 			return
 		}
@@ -333,8 +333,8 @@ func (q *CoDelQueue) lockedAdvanceFirstWaiting(elem *list.Element) {
 
 // lockedFindLowestPriorityDroppable finds the lowest-priority droppable
 // element in the queue — the oldest one at the lowest priority present — or nil
-// if none exists. O(1) via the droppable priority index (see droppableIndex).
-func (q *CoDelQueue) lockedFindLowestPriorityDroppable() *list.Element {
+// if none exists. O(1) via the droppable priority index (see droppableIndex[T]).
+func (q *CoDelQueue[T]) lockedFindLowestPriorityDroppable() *list.Element {
 	req := q.droppable.min()
 	if req == nil {
 		return nil
@@ -345,11 +345,11 @@ func (q *CoDelQueue) lockedFindLowestPriorityDroppable() *list.Element {
 // lockedRunTimer runs the CoDel drop logic. It is invoked both by the backstop
 // timer and synchronously from the release/dequeue path, so shedding is driven
 // as slots free rather than waiting for the (possibly late) timer to fire.
-func (q *CoDelQueue) lockedRunTimer(dropFn func() bool) {
+func (q *CoDelQueue[T]) lockedRunTimer(dropFn func() bool) {
 	q.lockedRunTimerLimited(dropFn, -1)
 }
 
-func (q *CoDelQueue) lockedRunTimerLimited(dropFn func() bool, maxDrops int) {
+func (q *CoDelQueue[T]) lockedRunTimerLimited(dropFn func() bool, maxDrops int) {
 	now := q.nowNs()
 
 	// Paced work: only advance the drop/ease control law and re-arm when a drop
@@ -373,11 +373,11 @@ func (q *CoDelQueue) lockedRunTimerLimited(dropFn func() bool, maxDrops int) {
 // `now`, so calling it is idempotent and safe outside the timer — the release
 // (dequeue) path invokes it to shed stale requests in real time rather than
 // waiting on the possibly-late backstop timer. It does NOT arm/disarm the timer.
-func (q *CoDelQueue) lockedAdvance(now int64, dropFn func() bool) {
+func (q *CoDelQueue[T]) lockedAdvance(now int64, dropFn func() bool) {
 	q.lockedAdvanceLimited(now, dropFn, -1)
 }
 
-func (q *CoDelQueue) lockedAdvanceLimited(now int64, dropFn func() bool, maxDrops int) {
+func (q *CoDelQueue[T]) lockedAdvanceLimited(now int64, dropFn func() bool, maxDrops int) {
 	drops := 0
 	// Step the control law per interval while a drop is due AND there is still
 	// work to do: either a droppable backlog to shed, or an elevated count that
@@ -417,7 +417,7 @@ func (q *CoDelQueue) lockedAdvanceLimited(now int64, dropFn func() bool, maxDrop
 // lockedEaseCount returns the next drop count during easing:
 // count -= floor(log_base(count) / base), floored at 1. A larger base yields a
 // smaller step (gentler ease-out); base defaults to 3 when unset or <= 1.
-func (q *CoDelQueue) lockedEaseCount() int {
+func (q *CoDelQueue[T]) lockedEaseCount() int {
 	base := 3.0
 	if q.cfg.EasingLogBase != nil {
 		base = q.cfg.EasingLogBase()
@@ -433,7 +433,7 @@ func (q *CoDelQueue) lockedEaseCount() int {
 // inverse proportion to count^exponent, exploiting the non-linear
 // relationship between drop rate and throughput to achieve linear change
 // in throughput.
-func (q *CoDelQueue) lockedControlLaw(t int64) int64 {
+func (q *CoDelQueue[T]) lockedControlLaw(t int64) int64 {
 	return t + q.lockedCurrentInterval()
 }
 
@@ -441,7 +441,7 @@ func (q *CoDelQueue) lockedControlLaw(t int64) int64 {
 // The interval is compressed whenever count > 1 — both in the dropping state
 // and during easing (!dropping, count > 1), so that the ease-out timer fires
 // at progressively longer intervals as the count decays toward 1.
-func (q *CoDelQueue) lockedCurrentInterval() int64 {
+func (q *CoDelQueue[T]) lockedCurrentInterval() int64 {
 	interval := q.cfg.IntervalNs()
 	if q.count <= 1 {
 		return interval
@@ -452,7 +452,7 @@ func (q *CoDelQueue) lockedCurrentInterval() int64 {
 	return max(result, 1)
 }
 
-func (q *CoDelQueue) lockedArmDropTimer() {
+func (q *CoDelQueue[T]) lockedArmDropTimer() {
 	// Mark the episode active for this armed interval; the next timer fire
 	// re-evaluates health.
 	q.dropping = q.droppableLen > 0

--- a/go/vt/vttablet/tabletserver/loadshed/codelq_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/codelq_test.go
@@ -24,6 +24,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type testRequest = Request[struct{}]
+type testCoDelQueue = CoDelQueue[struct{}]
+type testValvedCoDelQueue = ValvedCoDelQueue[struct{}]
+type testSnake = Snake[struct{}]
+type testSafeUnlock = SafeUnlock[struct{}]
+
 func defaultTestConfig() CoDelConfig {
 	return CoDelConfig{
 		IntervalNs:     func() int64 { return int64(1e9) },
@@ -79,14 +85,14 @@ func (r *testDropTimerRecorder) reset() {
 	r.scheduled = false
 }
 
-func newTestQueue(cfg CoDelConfig, clock *testClock) (*CoDelQueue, *testDropTimerRecorder) {
+func newTestQueue(cfg CoDelConfig, clock *testClock) (*testCoDelQueue, *testDropTimerRecorder) {
 	rec := &testDropTimerRecorder{}
-	q := newCoDelQueue(cfg, clock.nowFunc, rec.schedule, rec.stop, nil)
+	q := newCoDelQueue[struct{}](cfg, clock.nowFunc, rec.schedule, rec.stop, nil)
 	return q, rec
 }
 
-func testEnqueue(q *CoDelQueue, priority float64) *Request {
-	req := newRequest(priority)
+func testEnqueue(q *testCoDelQueue, priority float64) *testRequest {
+	req := newRequest[struct{}](priority)
 	q.lockedEnqueue(req)
 	return req
 }
@@ -140,7 +146,7 @@ func TestCoDelQueue_Enqueue_UndroppableNoSchedule(t *testing.T) {
 }
 
 // testDequeue grants the oldest waiting request.
-func testDequeue(q *CoDelQueue) *Request {
+func testDequeue(q *testCoDelQueue) *testRequest {
 	req := q.lockedFirstWaiting()
 	if req == nil {
 		return nil
@@ -292,7 +298,7 @@ func TestCoDelQueue_FindLowestPriorityDroppable_ZeroInstantPick(t *testing.T) {
 
 	elem := q.lockedFindLowestPriorityDroppable()
 	require.NotNil(t, elem)
-	assert.Same(t, r2, elem.Value.(*Request))
+	assert.Same(t, r2, elem.Value.(*testRequest))
 }
 
 func TestCoDelQueue_DropSkipsUndroppable(t *testing.T) {
@@ -304,7 +310,7 @@ func TestCoDelQueue_DropSkipsUndroppable(t *testing.T) {
 
 	elem := q.lockedFindLowestPriorityDroppable()
 	require.NotNil(t, elem)
-	assert.Same(t, droppable, elem.Value.(*Request))
+	assert.Same(t, droppable, elem.Value.(*testRequest))
 	q.lockedPopElem(elem, &DroppedRequestError{})
 	assert.Equal(t, 1, q.lockedLen())
 }
@@ -321,7 +327,7 @@ func TestCoDelQueue_DropSkipsDone(t *testing.T) {
 
 	elem := q.lockedFindLowestPriorityDroppable()
 	require.NotNil(t, elem)
-	assert.Same(t, r2, elem.Value.(*Request))
+	assert.Same(t, r2, elem.Value.(*testRequest))
 }
 
 func TestCoDelQueue_DropAllUndroppable_ReturnsNil(t *testing.T) {
@@ -344,7 +350,7 @@ func TestCoDelQueue_DropUndroppableVsInf(t *testing.T) {
 
 	elem := q.lockedFindLowestPriorityDroppable()
 	require.NotNil(t, elem)
-	assert.Same(t, inf, elem.Value.(*Request))
+	assert.Same(t, inf, elem.Value.(*testRequest))
 }
 
 func TestCoDelQueue_DropAllInf_NoPanic(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/loadshed/dequeue_shed_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/dequeue_shed_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 // dropAll is the standard test dropFn: sheds the lowest-priority droppable head.
-func dropAllFn(q *CoDelQueue) func() bool {
+func dropAllFn(q *testCoDelQueue) func() bool {
 	return func() bool {
 		elem := q.lockedFindLowestPriorityDroppable()
 		if elem == nil {
@@ -94,7 +94,7 @@ func TestValved_Drop_DefersSignalOutsideLock(t *testing.T) {
 	// A backlog of distinct-valve droppable requests (distinct valves so each is
 	// its own droppable representative and all are eligible to shed).
 	const backlog = 5
-	reqs := make([]*Request, backlog)
+	reqs := make([]*testRequest, backlog)
 	for i := range reqs {
 		reqs[i] = sq.lockedEnqueue(string(rune('a'+i)), 0)
 	}
@@ -144,7 +144,7 @@ func TestValved_DisabledDropAdvancesCoDelWithoutDropping(t *testing.T) {
 	sq.codelq.cfg.IntervalNs = func() int64 { return 10_000_000 }
 
 	const backlog = 5
-	reqs := make([]*Request, backlog)
+	reqs := make([]*testRequest, backlog)
 	for i := range reqs {
 		reqs[i] = sq.lockedEnqueue(string(rune('a'+i)), 0)
 	}
@@ -169,7 +169,7 @@ func TestValved_EnablementSnapshottedOncePerBatch(t *testing.T) {
 	sq.codelq.cfg.IntervalNs = func() int64 { return 10_000_000 }
 
 	const backlog = 10
-	reqs := make([]*Request, backlog)
+	reqs := make([]*testRequest, backlog)
 	for i := range reqs {
 		reqs[i] = sq.lockedEnqueue(string(rune('a'+i)), 0)
 	}

--- a/go/vt/vttablet/tabletserver/loadshed/droppable_index.go
+++ b/go/vt/vttablet/tabletserver/loadshed/droppable_index.go
@@ -40,7 +40,7 @@ const (
 // non-empty so min() is a trailing-zeros scan rather than a walk.
 //
 // Not safe for concurrent use; the caller holds the queue mutex.
-type droppableIndex struct {
+type droppableIndex[T any] struct {
 	buckets  [numPriorityBuckets]list.List
 	overflow list.List
 	// occ is the occupancy bitset over buckets: bit i is set iff buckets[i] is
@@ -50,7 +50,7 @@ type droppableIndex struct {
 
 // init prepares the index for use. The zero list.List is a valid empty list, so
 // this only needs to run once (idempotent) and mainly documents intent.
-func (idx *droppableIndex) init() {
+func (idx *droppableIndex[T]) init() {
 	for i := range idx.buckets {
 		idx.buckets[i].Init()
 	}
@@ -73,7 +73,7 @@ func bucketFor(priority float64) int {
 // insert adds a droppable request to its priority bucket (FIFO). Records the
 // bucket and list node on the request for O(1) removal. Must not be called for
 // an undroppable request.
-func (idx *droppableIndex) insert(req *Request) {
+func (idx *droppableIndex[T]) insert(req *Request[T]) {
 	b := bucketFor(req.priority)
 	req.bucketIdx = b
 	if b == overflowBucket {
@@ -86,7 +86,7 @@ func (idx *droppableIndex) insert(req *Request) {
 
 // remove unlinks a request from its bucket in O(1). No-op if the request is not
 // currently indexed. Clears the bucket's occupancy bit if it becomes empty.
-func (idx *droppableIndex) remove(req *Request) {
+func (idx *droppableIndex[T]) remove(req *Request[T]) {
 	if req.bucketElem == nil {
 		return
 	}
@@ -105,12 +105,12 @@ func (idx *droppableIndex) remove(req *Request) {
 // min returns the lowest-priority droppable request — the oldest in the
 // lowest-numbered non-empty bucket — or nil if the index is empty. In-domain
 // buckets always outrank the overflow list.
-func (idx *droppableIndex) min() *Request {
+func (idx *droppableIndex[T]) min() *Request[T] {
 	if b := idx.lowestOccupiedBucket(); b >= 0 {
-		return idx.buckets[b].Front().Value.(*Request)
+		return idx.buckets[b].Front().Value.(*Request[T])
 	}
 	if e := idx.overflow.Front(); e != nil {
-		return e.Value.(*Request)
+		return e.Value.(*Request[T])
 	}
 	return nil
 }
@@ -118,7 +118,7 @@ func (idx *droppableIndex) min() *Request {
 // lowestOccupiedBucket returns the lowest non-empty in-domain bucket index, or
 // -1 if all in-domain buckets are empty. O(1) via trailing-zeros on the
 // occupancy words.
-func (idx *droppableIndex) lowestOccupiedBucket() int {
+func (idx *droppableIndex[T]) lowestOccupiedBucket() int {
 	if idx.occ[0] != 0 {
 		return bits.TrailingZeros64(idx.occ[0])
 	}

--- a/go/vt/vttablet/tabletserver/loadshed/droppable_index_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/droppable_index_test.go
@@ -24,14 +24,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type testDroppableIndex = droppableIndex[struct{}]
+
 // idxReq builds a droppable request at the given priority for index tests.
-func idxReq(priority float64) *Request {
-	return newRequest(priority)
+func idxReq(priority float64) *testRequest {
+	return newRequest[struct{}](priority)
 }
 
 // TestDroppableIndex_Empty: min of an empty index returns nil.
 func TestDroppableIndex_Empty(t *testing.T) {
-	var idx droppableIndex
+	var idx testDroppableIndex
 	idx.init()
 	assert.Nil(t, idx.min())
 }
@@ -39,7 +41,7 @@ func TestDroppableIndex_Empty(t *testing.T) {
 // TestDroppableIndex_LowestPriorityWins: min returns the request in the
 // lowest-numbered non-empty bucket.
 func TestDroppableIndex_LowestPriorityWins(t *testing.T) {
-	var idx droppableIndex
+	var idx testDroppableIndex
 	idx.init()
 
 	idx.insert(idxReq(10))
@@ -53,7 +55,7 @@ func TestDroppableIndex_LowestPriorityWins(t *testing.T) {
 // TestDroppableIndex_FIFOWithinBucket: among equal priorities, min returns the
 // oldest (first inserted) — matching the front-most tie-break of the old scan.
 func TestDroppableIndex_FIFOWithinBucket(t *testing.T) {
-	var idx droppableIndex
+	var idx testDroppableIndex
 	idx.init()
 
 	first := idxReq(5)
@@ -69,7 +71,7 @@ func TestDroppableIndex_FIFOWithinBucket(t *testing.T) {
 // TestDroppableIndex_RemoveMiddle: removing a request that is not the min is
 // O(1) and leaves min unchanged.
 func TestDroppableIndex_RemoveMiddle(t *testing.T) {
-	var idx droppableIndex
+	var idx testDroppableIndex
 	idx.init()
 
 	lowest := idxReq(1)
@@ -84,7 +86,7 @@ func TestDroppableIndex_RemoveMiddle(t *testing.T) {
 // TestDroppableIndex_RemoveEmptiesBucket: removing the last entry of a bucket
 // clears its occupancy bit so min advances to the next non-empty bucket.
 func TestDroppableIndex_RemoveEmptiesBucket(t *testing.T) {
-	var idx droppableIndex
+	var idx testDroppableIndex
 	idx.init()
 
 	low := idxReq(1)
@@ -102,7 +104,7 @@ func TestDroppableIndex_RemoveEmptiesBucket(t *testing.T) {
 // TestDroppableIndex_Priority0 and Priority100 are the domain boundaries
 // (production priorities are integers in [0,100]).
 func TestDroppableIndex_DomainBoundaries(t *testing.T) {
-	var idx droppableIndex
+	var idx testDroppableIndex
 	idx.init()
 
 	r100 := idxReq(100)
@@ -119,7 +121,7 @@ func TestDroppableIndex_DomainBoundaries(t *testing.T) {
 // land in the overflow list. They are only picked when no in-domain bucket has
 // entries, and among overflow entries the oldest wins.
 func TestDroppableIndex_Overflow(t *testing.T) {
-	var idx droppableIndex
+	var idx testDroppableIndex
 	idx.init()
 
 	inf := idxReq(math.Inf(1))
@@ -138,7 +140,7 @@ func TestDroppableIndex_Overflow(t *testing.T) {
 // TestDroppableIndex_OverflowFIFO: multiple overflow entries preserve insertion
 // order.
 func TestDroppableIndex_OverflowFIFO(t *testing.T) {
-	var idx droppableIndex
+	var idx testDroppableIndex
 	idx.init()
 
 	first := idxReq(math.Inf(1))
@@ -154,7 +156,7 @@ func TestDroppableIndex_OverflowFIFO(t *testing.T) {
 // TestDroppableIndex_SecondWordBoundary exercises the 64-bit word split in the
 // occupancy bitset: bucket 63 (word 0) vs bucket 64 (word 1).
 func TestDroppableIndex_SecondWordBoundary(t *testing.T) {
-	var idx droppableIndex
+	var idx testDroppableIndex
 	idx.init()
 
 	r64 := idxReq(64)

--- a/go/vt/vttablet/tabletserver/loadshed/request.go
+++ b/go/vt/vttablet/tabletserver/loadshed/request.go
@@ -29,7 +29,7 @@ type (
 	// signaledValue allows non-consuming inspection of signal state (used by
 	// lockedPeek to avoid channel pop/push-back): nil means unsignaled, and any
 	// non-nil value means the request has completed.
-	Request struct {
+	Request[T any] struct {
 		priority           float64
 		codelqEnqueuedAtNs int64
 		signalChan         chan error
@@ -55,14 +55,14 @@ var PriorityUndroppable = math.Inf(-1)
 
 var grantSentinel = errors.New("granted") //nolint:staticcheck // not an error; sentinel for non-consuming signal state inspection
 
-func newRequest(priority float64) *Request {
-	return &Request{
+func newRequest[T any](priority float64) *Request[T] {
+	return &Request[T]{
 		priority:   priority,
 		signalChan: make(chan error, 1),
 	}
 }
 
-func (r *Request) isDroppable() bool {
+func (r *Request[T]) isDroppable() bool {
 	return r.priority != PriorityUndroppable
 }
 
@@ -71,7 +71,7 @@ func (r *Request) isDroppable() bool {
 // where the caller holds no lock across the send, or the send is single-shot
 // (grant, cancel). Batch paths mark under the lock and send after (see
 // markSignaled / sendSignal).
-func (r *Request) signal(val error) {
+func (r *Request[T]) signal(val error) {
 	r.markSignaled(val)
 	r.sendSignal()
 }
@@ -81,7 +81,7 @@ func (r *Request) signal(val error) {
 // under-lock readers key off signaledValue, so it must be set synchronously.
 // Returns true if this call performed the nil->set transition, so the caller can
 // enqueue the deferred send exactly once. Panics on a second distinct signal.
-func (r *Request) markSignaled(val error) bool {
+func (r *Request[T]) markSignaled(val error) bool {
 	if r.signaledValue != nil {
 		panic("loadshed: signal called more than once")
 	}
@@ -93,6 +93,6 @@ func (r *Request) markSignaled(val error) bool {
 // performs the goready of the parked Acquire goroutine, so batch drop paths call
 // it AFTER releasing the queue mutex to keep the wakeup storm out of the critical
 // section. Must be called exactly once, after markSignaled.
-func (r *Request) sendSignal() {
+func (r *Request[T]) sendSignal() {
 	r.signalChan <- r.signaledValue
 }

--- a/go/vt/vttablet/tabletserver/loadshed/snake.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake.go
@@ -42,11 +42,11 @@ type (
 	// Snake is a CoDel-based load-shedding gate with dynamic capacity. Up to
 	// Capacity() concurrent holders are allowed. Acquire requests are either
 	// granted or dropped, each within a timely manner.
-	Snake struct {
+	Snake[T any] struct {
 		mu sync.Mutex
 
-		q              *ValvedCoDelQueue
-		holders        map[*Request]struct{}
+		q              *ValvedCoDelQueue[T]
+		holders        map[*Request[T]]struct{}
 		dropTimer      *time.Timer
 		dropTimerArmed bool
 		// dropTimerExpectedNs is the clock time the drop timer was scheduled to
@@ -84,9 +84,9 @@ type (
 
 	// SafeUnlock is a handle for releasing a slot. Only the goroutine that
 	// acquired the slot should call Release. Release is idempotent.
-	SafeUnlock struct {
-		s    *Snake
-		req  *Request
+	SafeUnlock[T any] struct {
+		s    *Snake[T]
+		req  *Request[T]
 		once sync.Once
 		err  error
 	}
@@ -99,11 +99,11 @@ func defaultClock() int64 {
 }
 
 // NewSnake creates a new CoDel-based load-shedding gate.
-func NewSnake(cfg SnakeConfig) *Snake {
-	s := &Snake{
+func NewSnake[T any](cfg SnakeConfig) *Snake[T] {
+	s := &Snake[T]{
 		cfg:          cfg,
 		clockFunc:    defaultClock,
-		holders:      make(map[*Request]struct{}),
+		holders:      make(map[*Request[T]]struct{}),
 		sojourn:      stats.NewHistogram("", "", loadshedBucketCutoffs),
 		queueLen:     stats.NewHistogram("", "", lengthBucketCutoffs),
 		droppableLen: stats.NewHistogram("", "", lengthBucketCutoffs),
@@ -113,27 +113,27 @@ func NewSnake(cfg SnakeConfig) *Snake {
 		timerLag:     stats.NewHistogram("", "", loadshedBucketCutoffs),
 		valveDepth:   stats.NewHistogram("", "", lengthBucketCutoffs),
 	}
-	s.q = newValvedCoDelQueue(cfg.CoDel, defaultClock, s.lockedScheduleDropTimer, s.lockedStopDropTimer)
+	s.q = newValvedCoDelQueue[T](cfg.CoDel, defaultClock, s.lockedScheduleDropTimer, s.lockedStopDropTimer)
 	return s
 }
 
-func (s *Snake) lockedObserveLengths() {
+func (s *Snake[T]) lockedObserveLengths() {
 	s.queueLen.Add(int64(s.q.lockedLen()))
 	s.droppableLen.Add(int64(s.q.lockedDroppableLen()))
 }
 
-func (s *Snake) lockedObserveValveDepth(valveID string) {
+func (s *Snake[T]) lockedObserveValveDepth(valveID string) {
 	s.valveDepth.Add(int64(s.q.lockedValveDepth(valveID)))
 }
 
-func (s *Snake) capacity() int {
+func (s *Snake[T]) capacity() int {
 	if s.cfg.Capacity == nil {
 		return 1
 	}
 	return max(s.cfg.Capacity(), 1)
 }
 
-func (s *Snake) hasCapacity() bool {
+func (s *Snake[T]) hasCapacity() bool {
 	return len(s.holders) < s.capacity()
 }
 
@@ -148,7 +148,7 @@ func (s *Snake) hasCapacity() bool {
 //
 // The priority ordering convention is that lower-valued priorities indicate
 // less important requests. Lower values are shed first.
-func (s *Snake) Acquire(ctx context.Context, valveID string, priority float64) (*SafeUnlock, error) {
+func (s *Snake[T]) Acquire(ctx context.Context, valveID string, priority float64) (*SafeUnlock[T], error) {
 	priority = s.priority(priority)
 
 	if s.acquireByPriority != nil {
@@ -165,7 +165,7 @@ func (s *Snake) Acquire(ctx context.Context, valveID string, priority float64) (
 		s.lockedGrant(req)
 		s.lockedObserveLengths()
 		s.mu.Unlock()
-		return &SafeUnlock{s: s, req: req}, nil
+		return &SafeUnlock[T]{s: s, req: req}, nil
 	}
 
 	// Enqueue-advance: a non-granted arrival drives the CoDel control law itself,
@@ -185,7 +185,7 @@ func (s *Snake) Acquire(ctx context.Context, valveID string, priority float64) (
 		if val != grantSentinel {
 			return nil, s.acquireError(req.priority)
 		}
-		return &SafeUnlock{s: s, req: req}, nil
+		return &SafeUnlock[T]{s: s, req: req}, nil
 
 	case <-ctx.Done():
 		// Race: Go's select picks randomly when both signalChan and
@@ -219,7 +219,7 @@ func (s *Snake) Acquire(ctx context.Context, valveID string, priority float64) (
 }
 
 // IsHealthy reports whether the CoDel queue is healthy.
-func (s *Snake) IsHealthy() bool {
+func (s *Snake[T]) IsHealthy() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.q.lockedIsHealthy()
@@ -236,7 +236,7 @@ type SnakeStats struct {
 }
 
 // Stats returns a point-in-time snapshot of Snake's internal state.
-func (s *Snake) Stats() SnakeStats {
+func (s *Snake[T]) Stats() SnakeStats {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return SnakeStats{
@@ -251,7 +251,7 @@ func (s *Snake) Stats() SnakeStats {
 
 // Release releases the slot. exc is an optional error that caused the release
 // (passed to release callbacks). Release is idempotent.
-func (u *SafeUnlock) Release(exc ...error) error {
+func (u *SafeUnlock[T]) Release(exc ...error) error {
 	u.once.Do(func() {
 		var excValue error
 		if len(exc) > 0 {
@@ -262,7 +262,7 @@ func (u *SafeUnlock) Release(exc ...error) error {
 	return u.err
 }
 
-func (s *Snake) release(req *Request, excValue error) error {
+func (s *Snake[T]) release(req *Request[T], excValue error) error {
 	s.mu.Lock()
 	// Release is idempotent and can race a context-cancel release for the same
 	// req. The loser sees the req already gone from holders and no-ops.
@@ -288,7 +288,7 @@ func (s *Snake) release(req *Request, excValue error) error {
 	return nil
 }
 
-func (s *Snake) releaseOnCancel(req *Request) {
+func (s *Snake[T]) releaseOnCancel(req *Request[T]) {
 	s.mu.Lock()
 	delete(s.holders, req)
 	s.lockedObserveHolderCount()
@@ -305,7 +305,7 @@ func (s *Snake) releaseOnCancel(req *Request) {
 
 // lockedReleaseAndShed releases the request and advances CoDel before granting
 // the next waiter when there is active shedding work.
-func (s *Snake) lockedReleaseAndShed(req *Request) {
+func (s *Snake[T]) lockedReleaseAndShed(req *Request[T]) {
 	s.q.lockedRelease(req)
 	if s.q.lockedNeedsAdvance() {
 		s.q.lockedRunTimerIf(s.loadsheddingAllowed)
@@ -318,14 +318,14 @@ func (s *Snake) lockedReleaseAndShed(req *Request) {
 // sparse or the timer fires late. Must hold s.mu. lockedRunTimer only MARKS
 // drops; the pending rejections are returned so the caller sends them AFTER
 // releasing s.mu (draining the goready storm off the lock).
-func (s *Snake) lockedEnqueueAdvance() []*Request {
+func (s *Snake[T]) lockedEnqueueAdvance() []*Request[T] {
 	s.q.lockedRunTimerIf(s.loadsheddingAllowed)
 	s.interval.Add(s.q.lockedCurrentInterval())
 	s.dropCount.Add(int64(s.q.lockedCount()))
 	return s.q.lockedTakePendingSignals()
 }
 
-func (s *Snake) lockedGrant(req *Request) {
+func (s *Snake[T]) lockedGrant(req *Request[T]) {
 	s.holders[req] = struct{}{}
 	s.lockedObserveHolderCount()
 	s.q.lockedOnGrant(req)
@@ -335,11 +335,11 @@ func (s *Snake) lockedGrant(req *Request) {
 	req.signal(grantSentinel)
 }
 
-func (s *Snake) lockedObserveHolderCount() {
+func (s *Snake[T]) lockedObserveHolderCount() {
 	s.holderCount.Add(int64(len(s.holders)))
 }
 
-func (s *Snake) lockedObserveDropping() {
+func (s *Snake[T]) lockedObserveDropping() {
 	dropping := !s.q.lockedIsHealthy()
 	if dropping == (s.droppingSinceNs != 0) {
 		return
@@ -347,7 +347,7 @@ func (s *Snake) lockedObserveDropping() {
 	s.lockedAccrueDropping(s.clockFunc())
 }
 
-func (s *Snake) lockedAccrueDropping(now int64) {
+func (s *Snake[T]) lockedAccrueDropping(now int64) {
 	dropping := !s.q.lockedIsHealthy()
 	switch {
 	case dropping && s.droppingSinceNs == 0:
@@ -358,7 +358,7 @@ func (s *Snake) lockedAccrueDropping(now int64) {
 	}
 }
 
-func (s *Snake) lockedTryGrantOne() {
+func (s *Snake[T]) lockedTryGrantOne() {
 	if !s.hasCapacity() {
 		return
 	}
@@ -369,7 +369,7 @@ func (s *Snake) lockedTryGrantOne() {
 }
 
 // runReleaseCBs executes release callbacks outside the mutex.
-func (s *Snake) runReleaseCBs(excValue error) {
+func (s *Snake[T]) runReleaseCBs(excValue error) {
 	for _, cb := range s.cfg.ReleaseCBs {
 		func() {
 			defer func() {
@@ -382,15 +382,15 @@ func (s *Snake) runReleaseCBs(excValue error) {
 	}
 }
 
-func (s *Snake) priority(priority float64) float64 {
+func (s *Snake[T]) priority(priority float64) float64 {
 	return priority
 }
 
-func (s *Snake) loadsheddingAllowed() bool {
+func (s *Snake[T]) loadsheddingAllowed() bool {
 	return s.cfg.LoadsheddingAllowed == nil || s.cfg.LoadsheddingAllowed()
 }
 
-func (s *Snake) acquireError(priority float64) error {
+func (s *Snake[T]) acquireError(priority float64) error {
 	s.shedCount.Add(1)
 	if s.shedByPriority != nil {
 		s.shedByPriority.Add([]string{shedPriorityLabel(priority)}, 1)
@@ -416,11 +416,11 @@ func shedPriorityLabel(priority float64) string {
 
 // ShedCount returns the cumulative number of requests this Snake has shed.
 // Context cancellations are not counted — only gate-driven drops.
-func (s *Snake) ShedCount() int64 {
+func (s *Snake[T]) ShedCount() int64 {
 	return s.shedCount.Load()
 }
 
-func (s *Snake) DroppingNanos() int64 {
+func (s *Snake[T]) DroppingNanos() int64 {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	total := s.droppingNanos
@@ -432,7 +432,7 @@ func (s *Snake) DroppingNanos() int64 {
 
 // --- timer management (must be called with s.mu held) ---
 
-func (s *Snake) lockedScheduleDropTimer(delayNs int64) {
+func (s *Snake[T]) lockedScheduleDropTimer(delayNs int64) {
 	if s.dropTimerArmed {
 		return
 	}
@@ -442,7 +442,7 @@ func (s *Snake) lockedScheduleDropTimer(delayNs int64) {
 	s.dropTimer = time.AfterFunc(delay, s.runDropTimer)
 }
 
-func (s *Snake) lockedStopDropTimer() {
+func (s *Snake[T]) lockedStopDropTimer() {
 	if !s.dropTimerArmed {
 		return
 	}
@@ -450,7 +450,7 @@ func (s *Snake) lockedStopDropTimer() {
 	s.dropTimer.Stop()
 }
 
-func (s *Snake) runDropTimer() {
+func (s *Snake[T]) runDropTimer() {
 	s.mu.Lock()
 	if !s.dropTimerArmed {
 		s.mu.Unlock()

--- a/go/vt/vttablet/tabletserver/loadshed/snake_bench_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_bench_test.go
@@ -28,7 +28,7 @@ import (
 // --- Uncontended acquire/release ---
 
 func BenchmarkSnake_Uncontended(b *testing.B) {
-	s := NewSnake(defaultSnakeConfig())
+	s := NewSnake[struct{}](defaultSnakeConfig())
 	ctx := context.Background()
 
 	b.ResetTimer()
@@ -42,7 +42,7 @@ func BenchmarkSnake_Uncontended(b *testing.B) {
 }
 
 func BenchmarkSnake_Uncontended_WithValveID(b *testing.B) {
-	s := NewSnake(defaultSnakeConfig())
+	s := NewSnake[struct{}](defaultSnakeConfig())
 	ctx := context.Background()
 
 	b.ResetTimer()
@@ -60,7 +60,7 @@ func BenchmarkSnake_Uncontended_WithValveID(b *testing.B) {
 func BenchmarkSnake_Contended(b *testing.B) {
 	for _, parallelism := range []int{4, 16, 64, 256} {
 		b.Run(fmt.Sprintf("P%d", parallelism), func(b *testing.B) {
-			s := NewSnake(defaultSnakeConfig())
+			s := NewSnake[struct{}](defaultSnakeConfig())
 			ctx := context.Background()
 
 			b.SetParallelism(parallelism / runtime.GOMAXPROCS(0))
@@ -82,7 +82,7 @@ func BenchmarkSnake_Contended(b *testing.B) {
 
 func BenchmarkSnake_ValveOverhead(b *testing.B) {
 	b.Run("NoValve", func(b *testing.B) {
-		s := NewSnake(defaultSnakeConfig())
+		s := NewSnake[struct{}](defaultSnakeConfig())
 		ctx := context.Background()
 
 		b.ResetTimer()
@@ -96,7 +96,7 @@ func BenchmarkSnake_ValveOverhead(b *testing.B) {
 	})
 
 	b.Run("WithValve", func(b *testing.B) {
-		s := NewSnake(defaultSnakeConfig())
+		s := NewSnake[struct{}](defaultSnakeConfig())
 		ctx := context.Background()
 
 		b.ResetTimer()
@@ -115,7 +115,7 @@ func BenchmarkSnake_ValveOverhead(b *testing.B) {
 func BenchmarkSnake_ValveIDScaling(b *testing.B) {
 	for _, numIDs := range []int{1, 10, 100, 1000} {
 		b.Run(fmt.Sprintf("IDs%d", numIDs), func(b *testing.B) {
-			s := NewSnake(defaultSnakeConfig())
+			s := NewSnake[struct{}](defaultSnakeConfig())
 			ctx := context.Background()
 			ids := make([]string, numIDs)
 			for i := range numIDs {
@@ -142,7 +142,7 @@ func BenchmarkSnake_GOMAXPROCS(b *testing.B) {
 			prev := runtime.GOMAXPROCS(procs)
 			defer runtime.GOMAXPROCS(prev)
 
-			s := NewSnake(defaultSnakeConfig())
+			s := NewSnake[struct{}](defaultSnakeConfig())
 			ctx := context.Background()
 
 			b.SetParallelism(procs)
@@ -165,11 +165,11 @@ func BenchmarkSnake_GOMAXPROCS(b *testing.B) {
 func BenchmarkCoDelQueue_EnqueueGrant(b *testing.B) {
 	clock := newTestClock()
 	rec := &testDropTimerRecorder{}
-	q := newCoDelQueue(defaultTestConfig(), clock.nowFunc, rec.schedule, rec.stop, nil)
+	q := newCoDelQueue[struct{}](defaultTestConfig(), clock.nowFunc, rec.schedule, rec.stop, nil)
 
 	b.ResetTimer()
 	for range b.N {
-		req := newRequest(0)
+		req := newRequest[struct{}](0)
 		q.lockedEnqueue(req)
 		q.lockedOnGrant(req)
 	}
@@ -178,11 +178,11 @@ func BenchmarkCoDelQueue_EnqueueGrant(b *testing.B) {
 func BenchmarkCoDelQueue_Enqueue_Only(b *testing.B) {
 	clock := newTestClock()
 	rec := &testDropTimerRecorder{}
-	q := newCoDelQueue(defaultTestConfig(), clock.nowFunc, rec.schedule, rec.stop, nil)
+	q := newCoDelQueue[struct{}](defaultTestConfig(), clock.nowFunc, rec.schedule, rec.stop, nil)
 
 	b.ResetTimer()
 	for range b.N {
-		req := newRequest(0)
+		req := newRequest[struct{}](0)
 		q.lockedEnqueue(req)
 	}
 	b.StopTimer()
@@ -198,12 +198,12 @@ func BenchmarkCoDelQueue_FindLowestPriority(b *testing.B) {
 		b.Run(fmt.Sprintf("Depth%d", depth), func(b *testing.B) {
 			clock := newTestClock()
 			rec := &testDropTimerRecorder{}
-			q := newCoDelQueue(defaultTestConfig(), clock.nowFunc, rec.schedule, rec.stop, nil)
+			q := newCoDelQueue[struct{}](defaultTestConfig(), clock.nowFunc, rec.schedule, rec.stop, nil)
 
 			// Use varied priorities so the scan must traverse the full queue.
 			// The lowest priority is at position depth-1, forcing a full scan.
 			for i := range depth {
-				req := newRequest(float64(depth - i))
+				req := newRequest[struct{}](float64(depth - i))
 				q.lockedEnqueue(req)
 			}
 
@@ -250,7 +250,7 @@ func BenchmarkValved_ValvePromotion_Chain(b *testing.B) {
 // --- Allocation benchmarks ---
 
 func BenchmarkSnake_Allocs_Uncontended(b *testing.B) {
-	s := NewSnake(defaultSnakeConfig())
+	s := NewSnake[struct{}](defaultSnakeConfig())
 	ctx := context.Background()
 
 	b.ReportAllocs()
@@ -265,7 +265,7 @@ func BenchmarkSnake_Allocs_Uncontended(b *testing.B) {
 }
 
 func BenchmarkSnake_Allocs_WithValve(b *testing.B) {
-	s := NewSnake(defaultSnakeConfig())
+	s := NewSnake[struct{}](defaultSnakeConfig())
 	ctx := context.Background()
 
 	b.ReportAllocs()
@@ -280,7 +280,7 @@ func BenchmarkSnake_Allocs_WithValve(b *testing.B) {
 }
 
 func BenchmarkSnake_Allocs_Contended(b *testing.B) {
-	s := NewSnake(defaultSnakeConfig())
+	s := NewSnake[struct{}](defaultSnakeConfig())
 	ctx := context.Background()
 	const workers = 8
 
@@ -310,7 +310,7 @@ func BenchmarkSnake_Allocs_Contended(b *testing.B) {
 func BenchmarkSnake_Throughput_SelfContention(b *testing.B) {
 	for _, parallelism := range []int{2, 4, 8} {
 		b.Run(fmt.Sprintf("SameID_P%d", parallelism), func(b *testing.B) {
-			s := NewSnake(defaultSnakeConfig())
+			s := NewSnake[struct{}](defaultSnakeConfig())
 			ctx := context.Background()
 
 			b.SetParallelism(parallelism / runtime.GOMAXPROCS(0))
@@ -335,7 +335,7 @@ func BenchmarkSnake_NHolder_Throughput(b *testing.B) {
 		b.Run(fmt.Sprintf("Cap%d", capacity), func(b *testing.B) {
 			cfg := defaultSnakeConfig()
 			cfg.Capacity = func() int { return capacity }
-			s := NewSnake(cfg)
+			s := NewSnake[struct{}](cfg)
 			ctx := context.Background()
 
 			b.SetParallelism(capacity * 2 / runtime.GOMAXPROCS(0))
@@ -360,7 +360,7 @@ func BenchmarkSnake_NHolder_Uncontended(b *testing.B) {
 		b.Run(fmt.Sprintf("Cap%d", capacity), func(b *testing.B) {
 			cfg := defaultSnakeConfig()
 			cfg.Capacity = func() int { return capacity }
-			s := NewSnake(cfg)
+			s := NewSnake[struct{}](cfg)
 			ctx := context.Background()
 
 			b.ResetTimer()
@@ -382,7 +382,7 @@ func BenchmarkSnake_NHolder_Saturated(b *testing.B) {
 		b.Run(fmt.Sprintf("Cap%d", capacity), func(b *testing.B) {
 			cfg := defaultSnakeConfig()
 			cfg.Capacity = func() int { return capacity }
-			s := NewSnake(cfg)
+			s := NewSnake[struct{}](cfg)
 			ctx := context.Background()
 
 			b.SetParallelism(capacity * 4 / runtime.GOMAXPROCS(0))
@@ -407,7 +407,7 @@ func BenchmarkSnake_NHolder_WithValve(b *testing.B) {
 		b.Run(fmt.Sprintf("Cap%d", capacity), func(b *testing.B) {
 			cfg := defaultSnakeConfig()
 			cfg.Capacity = func() int { return capacity }
-			s := NewSnake(cfg)
+			s := NewSnake[struct{}](cfg)
 			ctx := context.Background()
 
 			ids := make([]string, 4)
@@ -440,7 +440,7 @@ func BenchmarkSnake_NHolder_Allocs(b *testing.B) {
 		b.Run(fmt.Sprintf("Cap%d", capacity), func(b *testing.B) {
 			cfg := defaultSnakeConfig()
 			cfg.Capacity = func() int { return capacity }
-			s := NewSnake(cfg)
+			s := NewSnake[struct{}](cfg)
 			ctx := context.Background()
 
 			b.ReportAllocs()
@@ -533,7 +533,7 @@ func BenchmarkSnake_HighContention(b *testing.B) {
 			b.Run(fmt.Sprintf("C%d", level), func(b *testing.B) {
 				cfg := defaultSnakeConfig()
 				cfg.Capacity = hugeCapacity
-				s := NewSnake(cfg)
+				s := NewSnake[struct{}](cfg)
 				runPooledContention(b, level, func() {
 					u, err := s.Acquire(ctx, "", 0)
 					if err != nil {
@@ -550,7 +550,7 @@ func BenchmarkSnake_HighContention(b *testing.B) {
 			b.Run(fmt.Sprintf("C%d", level), func(b *testing.B) {
 				cfg := defaultSnakeConfig()
 				cfg.Capacity = hugeCapacity
-				s := NewSnake(cfg)
+				s := NewSnake[struct{}](cfg)
 				runPooledContention(b, level, func() {
 					u, err := s.Acquire(ctx, "shared-valve", 0)
 					if err != nil {
@@ -568,7 +568,7 @@ func BenchmarkSnake_HighContention(b *testing.B) {
 				// Default config: Capacity == nil => capacity 1. Contenders
 				// beyond the single holder block on signalChan or are shed by
 				// CoDel; either way the mutex is the serialization point.
-				s := NewSnake(defaultSnakeConfig())
+				s := NewSnake[struct{}](defaultSnakeConfig())
 				runPooledContention(b, level, func() {
 					u, err := s.Acquire(ctx, "", 0)
 					if err != nil {

--- a/go/vt/vttablet/tabletserver/loadshed/snake_nholder_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_nholder_test.go
@@ -35,9 +35,9 @@ func TestSnake_NHolder_ConcurrentGrants(t *testing.T) {
 		t.Run(fmt.Sprintf("Cap%d", cap), func(t *testing.T) {
 			cfg := defaultSnakeConfig()
 			cfg.Capacity = func() int { return cap }
-			s := NewSnake(cfg)
+			s := NewSnake[struct{}](cfg)
 
-			unlocks := make([]*SafeUnlock, cap)
+			unlocks := make([]*testSafeUnlock, cap)
 			for i := range cap {
 				u, err := s.Acquire(t.Context(), "", 0)
 				require.NoError(t, err, "acquire %d should succeed (capacity=%d)", i, cap)
@@ -59,9 +59,9 @@ func TestSnake_NHolder_ConcurrentGrants(t *testing.T) {
 func TestSnake_NHolder_BlocksAtCapacity(t *testing.T) {
 	cfg := defaultSnakeConfig()
 	cfg.Capacity = func() int { return 3 }
-	s := NewSnake(cfg)
+	s := NewSnake[struct{}](cfg)
 
-	unlocks := make([]*SafeUnlock, 3)
+	unlocks := make([]*testSafeUnlock, 3)
 	for i := range 3 {
 		u, err := s.Acquire(t.Context(), "", 0)
 		require.NoError(t, err)
@@ -101,7 +101,7 @@ func TestSnake_NHolder_ParallelThroughput(t *testing.T) {
 
 	cfg := defaultSnakeConfig()
 	cfg.Capacity = func() int { return capacity }
-	s := NewSnake(cfg)
+	s := NewSnake[struct{}](cfg)
 
 	var maxConcurrent atomic.Int64
 	var ops atomic.Int64
@@ -143,7 +143,7 @@ func TestSnake_NHolder_DynamicCapacityIncrease(t *testing.T) {
 
 	cfg := defaultSnakeConfig()
 	cfg.Capacity = func() int { return int(cap.Load()) }
-	s := NewSnake(cfg)
+	s := NewSnake[struct{}](cfg)
 
 	u1, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
@@ -181,9 +181,9 @@ func TestSnake_NHolder_DynamicCapacityDecrease(t *testing.T) {
 
 	cfg := defaultSnakeConfig()
 	cfg.Capacity = func() int { return int(cap.Load()) }
-	s := NewSnake(cfg)
+	s := NewSnake[struct{}](cfg)
 
-	unlocks := make([]*SafeUnlock, 4)
+	unlocks := make([]*testSafeUnlock, 4)
 	for i := range 4 {
 		u, err := s.Acquire(t.Context(), "", 0)
 		require.NoError(t, err)
@@ -227,7 +227,7 @@ func TestSnake_NHolder_DynamicCapacityDecrease(t *testing.T) {
 func TestSnake_NHolder_ValveSerialization(t *testing.T) {
 	cfg := defaultSnakeConfig()
 	cfg.Capacity = func() int { return 3 }
-	s := NewSnake(cfg)
+	s := NewSnake[struct{}](cfg)
 
 	u1, err := s.Acquire(t.Context(), "valve-a", 0)
 	require.NoError(t, err)
@@ -275,7 +275,7 @@ func TestSnake_NHolder_NGrantedAccuracy(t *testing.T) {
 	const capacity = 5
 	cfg := defaultSnakeConfig()
 	cfg.Capacity = func() int { return capacity }
-	s := NewSnake(cfg)
+	s := NewSnake[struct{}](cfg)
 
 	var wg sync.WaitGroup
 	var violations atomic.Int64
@@ -305,7 +305,7 @@ func TestSnake_NHolder_NGrantedAccuracy(t *testing.T) {
 func TestSnake_NHolder_ContextCancelFreesSlot(t *testing.T) {
 	cfg := defaultSnakeConfig()
 	cfg.Capacity = func() int { return 2 }
-	s := NewSnake(cfg)
+	s := NewSnake[struct{}](cfg)
 
 	ctx1, cancel1 := context.WithCancel(t.Context())
 	u1, err := s.Acquire(ctx1, "", 0)
@@ -346,9 +346,9 @@ func TestSnake_NHolder_ReleaseCallbacks(t *testing.T) {
 	cfg.ReleaseCBs = []func(error){
 		func(_ error) { count.Add(1) },
 	}
-	s := NewSnake(cfg)
+	s := NewSnake[struct{}](cfg)
 
-	unlocks := make([]*SafeUnlock, 3)
+	unlocks := make([]*testSafeUnlock, 3)
 	for i := range 3 {
 		u, err := s.Acquire(t.Context(), "", 0)
 		require.NoError(t, err)
@@ -370,9 +370,9 @@ func TestSnake_NHolder_ValveInvariant_AllGranted(t *testing.T) {
 
 	cfg := defaultSnakeConfig()
 	cfg.Capacity = func() int { return capacity }
-	s := NewSnake(cfg)
+	s := NewSnake[struct{}](cfg)
 
-	unlocks := make([]*SafeUnlock, M)
+	unlocks := make([]*testSafeUnlock, M)
 	for i := range M {
 		ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
 		u, err := s.Acquire(ctx, "foo", 0)
@@ -396,9 +396,9 @@ func TestSnake_NHolder_ValveInvariant_CapacityExhausted(t *testing.T) {
 
 	cfg := defaultSnakeConfig()
 	cfg.Capacity = func() int { return capacity }
-	s := NewSnake(cfg)
+	s := NewSnake[struct{}](cfg)
 
-	unlocks := make([]*SafeUnlock, capacity)
+	unlocks := make([]*testSafeUnlock, capacity)
 	for i := range capacity {
 		ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
 		u, err := s.Acquire(ctx, "foo", 0)
@@ -409,7 +409,7 @@ func TestSnake_NHolder_ValveInvariant_CapacityExhausted(t *testing.T) {
 	assert.Equal(t, capacity, s.nGranted())
 
 	blocked := make(chan struct{})
-	granted := make(chan *SafeUnlock, 1)
+	granted := make(chan *testSafeUnlock, 1)
 	go func() {
 		close(blocked)
 		u, err := s.Acquire(context.Background(), "foo", 0)
@@ -446,10 +446,10 @@ func TestSnake_NHolder_ValveInvariant_CapacityExhausted(t *testing.T) {
 func TestSnake_NHolder_MemoryCleanup(t *testing.T) {
 	cfg := defaultSnakeConfig()
 	cfg.Capacity = func() int { return 5 }
-	s := NewSnake(cfg)
+	s := NewSnake[struct{}](cfg)
 
 	for range 500 {
-		unlocks := make([]*SafeUnlock, 5)
+		unlocks := make([]*testSafeUnlock, 5)
 		for i := range 5 {
 			u, err := s.Acquire(t.Context(), fmt.Sprintf("id-%d", i), 0)
 			require.NoError(t, err)

--- a/go/vt/vttablet/tabletserver/loadshed/snake_overload_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_overload_test.go
@@ -35,7 +35,7 @@ func TestSnake_Overload_RecoveryToHealthy(t *testing.T) {
 	cfg.CoDel.IntervalNs = func() int64 { return 5_000_000 }   // 5ms
 	cfg.CoDel.TargetNs = func() int64 { return 500_000 }       // 0.5ms
 	cfg.CoDel.MinDropDelayNs = func() int64 { return 100_000 } // 0.1ms
-	s := NewSnake(cfg)
+	s := NewSnake[struct{}](cfg)
 
 	// Phase 1: overload — hold lock for a long time with waiters
 	unlock, err := s.Acquire(t.Context(), "", 0)
@@ -74,7 +74,7 @@ func TestSnake_Overload_RecoveryToHealthy(t *testing.T) {
 // --- Holder not counted in queue length ---
 
 func TestSnake_Overload_HolderNotCountedInQueueLen(t *testing.T) {
-	s := NewSnake(defaultSnakeConfig())
+	s := NewSnake[struct{}](defaultSnakeConfig())
 
 	unlock, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
@@ -93,7 +93,7 @@ func TestSnake_Overload_HolderNotCountedInQueueLen(t *testing.T) {
 }
 
 func TestSnake_Overload_WaiterCountedNotHolder(t *testing.T) {
-	s := NewSnake(defaultSnakeConfig())
+	s := NewSnake[struct{}](defaultSnakeConfig())
 
 	unlock, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
@@ -120,7 +120,7 @@ func TestSnake_Overload_WaiterCountedNotHolder(t *testing.T) {
 // --- Mass cancel at Snake layer ---
 
 func TestSnake_Overload_MassCancel(t *testing.T) {
-	s := NewSnake(defaultSnakeConfig())
+	s := NewSnake[struct{}](defaultSnakeConfig())
 
 	unlock, err := s.Acquire(t.Context(), "mass-cancel", 0)
 	require.NoError(t, err)
@@ -216,7 +216,7 @@ func TestSnake_Overload_DropOnlyDroppable(t *testing.T) {
 		cfg.CoDel.TargetNs = func() int64 { return 1 }
 		cfg.CoDel.MinDropDelayNs = func() int64 { return 1_000 }
 		cfg.LoadsheddingAllowed = func() bool { return true }
-		s := NewSnake(cfg)
+		s := NewSnake[struct{}](cfg)
 
 		unlock, err := s.Acquire(t.Context(), "", 0)
 		require.NoError(t, err)
@@ -249,7 +249,7 @@ func TestSnake_Overload_DropOnlyDroppable(t *testing.T) {
 		cfg.CoDel.TargetNs = func() int64 { return 1 }
 		cfg.CoDel.MinDropDelayNs = func() int64 { return 1_000 }
 		cfg.LoadsheddingAllowed = func() bool { return false }
-		s := NewSnake(cfg)
+		s := NewSnake[struct{}](cfg)
 
 		unlock, err := s.Acquire(t.Context(), "", 0)
 		require.NoError(t, err)
@@ -334,7 +334,7 @@ func TestSnake_Overload_SelfContention_CrossIDDrops(t *testing.T) {
 	cfg.CoDel.IntervalNs = func() int64 { return 5_000_000 }   // 5ms
 	cfg.CoDel.TargetNs = func() int64 { return 500_000 }       // 0.5ms
 	cfg.CoDel.MinDropDelayNs = func() int64 { return 100_000 } // 0.1ms
-	s := NewSnake(cfg)
+	s := NewSnake[struct{}](cfg)
 
 	// Hold the lock
 	unlock, err := s.Acquire(t.Context(), "holder", 0)
@@ -391,7 +391,7 @@ func TestSnake_Overload_SelfContention_CrossIDDrops(t *testing.T) {
 // --- Memory steady-state: clean baseline after many cycles ---
 
 func TestSnake_Memory_CleanBaseline(t *testing.T) {
-	s := NewSnake(defaultSnakeConfig())
+	s := NewSnake[struct{}](defaultSnakeConfig())
 
 	// Run many acquire/release cycles
 	for range 1000 {
@@ -415,7 +415,7 @@ func TestSnake_Memory_CleanBaseline(t *testing.T) {
 // --- Memory: many distinct valve IDs map cleanup ---
 
 func TestSnake_Memory_ManyDistinctValveIDs_Cleanup(t *testing.T) {
-	s := NewSnake(defaultSnakeConfig())
+	s := NewSnake[struct{}](defaultSnakeConfig())
 
 	// Use many distinct valve IDs
 	for i := range 500 {
@@ -439,7 +439,7 @@ func TestSnake_Memory_CoDelStateTransition(t *testing.T) {
 	cfg.CoDel.IntervalNs = func() int64 { return 5_000_000 }   // 5ms
 	cfg.CoDel.TargetNs = func() int64 { return 500_000 }       // 0.5ms
 	cfg.CoDel.MinDropDelayNs = func() int64 { return 100_000 } // 0.1ms
-	s := NewSnake(cfg)
+	s := NewSnake[struct{}](cfg)
 
 	// Initially healthy
 	assert.True(t, s.IsHealthy())
@@ -485,7 +485,7 @@ func TestSnake_Overload_GrantStall_ShedsDuringStall(t *testing.T) {
 	cfg.CoDel.IntervalNs = func() int64 { return 1_000 }
 	cfg.CoDel.TargetNs = func() int64 { return 1 }
 	cfg.CoDel.MinDropDelayNs = func() int64 { return 1_000 }
-	s := NewSnake(cfg)
+	s := NewSnake[struct{}](cfg)
 
 	// Acquire the only slot (capacity defaults to 1). Once granted, this
 	// holder becomes undroppable and never releases — a stuck in-flight query
@@ -536,7 +536,7 @@ func TestSnake_Overload_GrantStall_ShedsDuringStall(t *testing.T) {
 // --- Double-signal panic invariant ---
 
 func TestSnake_NoPanicOnConcurrentCancel(t *testing.T) {
-	s := NewSnake(defaultSnakeConfig())
+	s := NewSnake[struct{}](defaultSnakeConfig())
 
 	unlock, err := s.Acquire(t.Context(), "no-panic", 0)
 	require.NoError(t, err)

--- a/go/vt/vttablet/tabletserver/loadshed/snake_race_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_race_test.go
@@ -56,7 +56,7 @@ func TestSnake_CancelVsGrant_Race(t *testing.T) {
 		wg.Add(1)
 
 		var acquireErr error
-		var unlockB *SafeUnlock
+		var unlockB *testSafeUnlock
 
 		go func() {
 			defer wg.Done()

--- a/go/vt/vttablet/tabletserver/loadshed/snake_stats.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_stats.go
@@ -75,7 +75,7 @@ func durationNanos(ds ...time.Duration) []int64 {
 // label: both the oltp-read and dml snakes register through the same tablet
 // Exporter, whose single label dimension is already the tablet name, so a
 // shared labeled metric would collide on that one key.
-func PublishStats(exporter statsExporter, prefix string, s *Snake) {
+func PublishStats[T any](exporter statsExporter, prefix string, s *Snake[T]) {
 	exporter.NewCounterFunc(prefix+"ShedCount", "Cumulative requests shed by the Snake load shedder", func() int64 {
 		return s.ShedCount()
 	})

--- a/go/vt/vttablet/tabletserver/loadshed/snake_stats_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_stats_test.go
@@ -116,7 +116,7 @@ func TestPublishStats_ShedCountTracksDrops(t *testing.T) {
 	assert.Equal(t, int64(0), shedGauge(), "no sheds before any contention")
 
 	// Hold every slot, then pile on contending acquires so CoDel drops some.
-	var unlocks []*SafeUnlock
+	var unlocks []*testSafeUnlock
 	for range 4 {
 		u, err := s.Acquire(t.Context(), "", 0)
 		require.NoError(t, err)
@@ -347,7 +347,7 @@ func TestPublishStats_DroppableAndIntervalHistogramsRecordUnderLoad(t *testing.T
 
 	// Occupy every slot, then contend so droppable entries queue and the drop
 	// timer fires (recording interval and drop-count observations).
-	var unlocks []*SafeUnlock
+	var unlocks []*testSafeUnlock
 	for range 4 {
 		u, err := s.Acquire(t.Context(), "", 0)
 		require.NoError(t, err)
@@ -420,7 +420,7 @@ func TestPublishStats_DroppingNanosAdvancesDuringEpisode(t *testing.T) {
 	assert.Equal(t, int64(0), droppingNanos(), "no dropping time before contention")
 
 	// Drive a dropping episode: hold every slot and pile on contenders.
-	var unlocks []*SafeUnlock
+	var unlocks []*testSafeUnlock
 	for range 4 {
 		u, err := s.Acquire(t.Context(), "", 0)
 		require.NoError(t, err)

--- a/go/vt/vttablet/tabletserver/loadshed/snake_stress_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_stress_test.go
@@ -33,7 +33,7 @@ import (
 // --- High contention ---
 
 func TestSnake_Stress_HighContention(t *testing.T) {
-	s := NewSnake(defaultSnakeConfig())
+	s := NewSnake[struct{}](defaultSnakeConfig())
 
 	var completed atomic.Int64
 	var held atomic.Int32
@@ -65,7 +65,7 @@ func TestSnake_Stress_HighContention(t *testing.T) {
 // --- Context cancellation under load ---
 
 func TestSnake_Stress_ContextCancellation(t *testing.T) {
-	s := NewSnake(defaultSnakeConfig())
+	s := NewSnake[struct{}](defaultSnakeConfig())
 
 	var wg sync.WaitGroup
 	var acquired, cancelled atomic.Int64
@@ -102,14 +102,14 @@ func TestSnake_Stress_MixedPriorities(t *testing.T) {
 	droppableCfg.CoDel.TargetNs = func() int64 { return 1_000_000 }     // 1ms
 	droppableCfg.CoDel.MinDropDelayNs = func() int64 { return 100_000 } // 0.1ms
 	droppableCfg.LoadsheddingAllowed = func() bool { return true }
-	droppableSnake := NewSnake(droppableCfg)
+	droppableSnake := NewSnake[struct{}](droppableCfg)
 
 	undroppableCfg := defaultSnakeConfig()
 	undroppableCfg.CoDel.IntervalNs = func() int64 { return 10_000_000 }
 	undroppableCfg.CoDel.TargetNs = func() int64 { return 1_000_000 }
 	undroppableCfg.CoDel.MinDropDelayNs = func() int64 { return 100_000 }
 	undroppableCfg.LoadsheddingAllowed = func() bool { return false }
-	undroppableSnake := NewSnake(undroppableCfg)
+	undroppableSnake := NewSnake[struct{}](undroppableCfg)
 
 	unlock, err := droppableSnake.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
@@ -166,7 +166,7 @@ func TestSnake_Stress_MixedPriorities(t *testing.T) {
 // --- Self-contention ---
 
 func TestSnake_Stress_SelfContention_MutualExclusion(t *testing.T) {
-	s := NewSnake(defaultSnakeConfig())
+	s := NewSnake[struct{}](defaultSnakeConfig())
 
 	var wg sync.WaitGroup
 	var globalHeld atomic.Int32
@@ -224,7 +224,7 @@ func TestSnake_Stress_SelfContention_MutualExclusion(t *testing.T) {
 }
 
 func TestSnake_Stress_SelfContention_ValveSerializationOrder(t *testing.T) {
-	s := NewSnake(defaultSnakeConfig())
+	s := NewSnake[struct{}](defaultSnakeConfig())
 
 	unlock, err := s.Acquire(t.Context(), "order-test", 0)
 	require.NoError(t, err)
@@ -268,7 +268,7 @@ func TestSnake_Stress_SelfContention_DropPromotionChain(t *testing.T) {
 	cfg.CoDel.IntervalNs = func() int64 { return 1_000 }     // 1us
 	cfg.CoDel.TargetNs = func() int64 { return 1 }           // 1ns
 	cfg.CoDel.MinDropDelayNs = func() int64 { return 1_000 } // 1us
-	s := NewSnake(cfg)
+	s := NewSnake[struct{}](cfg)
 
 	unlock, err := s.Acquire(t.Context(), "holder", 0)
 	require.NoError(t, err)
@@ -326,7 +326,7 @@ func TestSnake_Stress_SelfContention_DropPromotionChain(t *testing.T) {
 }
 
 func TestSnake_Stress_SelfContention_CancelInValve(t *testing.T) {
-	s := NewSnake(defaultSnakeConfig())
+	s := NewSnake[struct{}](defaultSnakeConfig())
 
 	unlock, err := s.Acquire(t.Context(), "cancel-test", 0)
 	require.NoError(t, err)
@@ -388,7 +388,7 @@ func TestSnake_Stress_SelfContention_MixedCancelDropGrant(t *testing.T) {
 	cfg.CoDel.IntervalNs = func() int64 { return 5_000_000 }   // 5ms
 	cfg.CoDel.TargetNs = func() int64 { return 500_000 }       // 0.5ms
 	cfg.CoDel.MinDropDelayNs = func() int64 { return 100_000 } // 0.1ms
-	s := NewSnake(cfg)
+	s := NewSnake[struct{}](cfg)
 
 	const numIDs = 5
 	const perID = 8
@@ -432,7 +432,7 @@ func TestSnake_Stress_SelfContention_MixedCancelDropGrant(t *testing.T) {
 }
 
 func TestSnake_Stress_SelfContention_HighConcurrency_Sustained(t *testing.T) {
-	s := NewSnake(defaultSnakeConfig())
+	s := NewSnake[struct{}](defaultSnakeConfig())
 
 	const numIDs = 5
 	const goroutinesPerID = 4
@@ -480,7 +480,7 @@ func TestSnake_Stress_SelfContention_HighConcurrency_Sustained(t *testing.T) {
 // --- Rapid acquire/release ---
 
 func TestSnake_Stress_RapidAcquireRelease(t *testing.T) {
-	s := NewSnake(defaultSnakeConfig())
+	s := NewSnake[struct{}](defaultSnakeConfig())
 
 	var wg sync.WaitGroup
 	for range 10 {
@@ -504,7 +504,7 @@ func TestSnake_Stress_RapidAcquireRelease(t *testing.T) {
 // --- Cancel and grant race under load ---
 
 func TestSnake_Stress_CancelAndGrant_Race(t *testing.T) {
-	s := NewSnake(defaultSnakeConfig())
+	s := NewSnake[struct{}](defaultSnakeConfig())
 
 	var wg sync.WaitGroup
 	for range 100 {
@@ -536,7 +536,7 @@ func TestSnake_Stress_DropTimerAndCancel_Race(t *testing.T) {
 	cfg.CoDel.IntervalNs = func() int64 { return 1_000 }     // 1us
 	cfg.CoDel.TargetNs = func() int64 { return 1 }           // 1ns
 	cfg.CoDel.MinDropDelayNs = func() int64 { return 1_000 } // 1us
-	s := NewSnake(cfg)
+	s := NewSnake[struct{}](cfg)
 
 	unlock, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
@@ -570,7 +570,7 @@ func TestSnake_Stress_SelfContention_WithDrops(t *testing.T) {
 	cfg.CoDel.IntervalNs = func() int64 { return 10_000_000 }  // 10ms
 	cfg.CoDel.TargetNs = func() int64 { return 1_000_000 }     // 1ms
 	cfg.CoDel.MinDropDelayNs = func() int64 { return 100_000 } // 0.1ms
-	s := NewSnake(cfg)
+	s := NewSnake[struct{}](cfg)
 
 	var wg sync.WaitGroup
 
@@ -597,7 +597,7 @@ func TestSnake_Stress_SelfContention_WithDrops(t *testing.T) {
 func TestSnake_Stress_GoroutineLeakDetector(t *testing.T) {
 	baseline := runtime.NumGoroutine()
 
-	s := NewSnake(defaultSnakeConfig())
+	s := NewSnake[struct{}](defaultSnakeConfig())
 
 	var wg sync.WaitGroup
 	for range 50 {
@@ -626,7 +626,7 @@ func TestSnake_Stress_GoroutineLeakDetector(t *testing.T) {
 // --- No starvation ---
 
 func TestSnake_Stress_NoStarvation(t *testing.T) {
-	s := NewSnake(defaultSnakeConfig())
+	s := NewSnake[struct{}](defaultSnakeConfig())
 
 	var wg sync.WaitGroup
 	acquiredFlags := make([]atomic.Bool, 100)
@@ -663,7 +663,7 @@ func TestSnake_Stress_NoStarvation(t *testing.T) {
 // --- Promotion during cancel ---
 
 func TestSnake_Stress_PromotionDuringCancel(t *testing.T) {
-	s := NewSnake(defaultSnakeConfig())
+	s := NewSnake[struct{}](defaultSnakeConfig())
 
 	unlock, err := s.Acquire(t.Context(), "id1", 0)
 	require.NoError(t, err)

--- a/go/vt/vttablet/tabletserver/loadshed/snake_syncshed_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_syncshed_test.go
@@ -39,7 +39,7 @@ func TestSnake_SyncShedOnRelease(t *testing.T) {
 	cfg.CoDel.MinDropDelayNs = func() int64 { return 1 }
 	cfg.Capacity = func() int { return 1 }
 
-	s := NewSnake(cfg)
+	s := NewSnake[struct{}](cfg)
 	s.clockFunc = now.Load
 	s.q.codelq.nowNs = now.Load // queue uses defaultClock otherwise — keep clocks consistent
 
@@ -53,7 +53,7 @@ func TestSnake_SyncShedOnRelease(t *testing.T) {
 	// The backlog must exceed keepDroppableFloor so the drop pass actually sheds
 	// (it refuses to shed at or below the floor).
 	const backlog = keepDroppableFloor + 4
-	waiters := make([]*Request, backlog)
+	waiters := make([]*testRequest, backlog)
 	s.mu.Lock()
 	for i := range backlog {
 		waiters[i] = s.q.lockedEnqueue("", 1)

--- a/go/vt/vttablet/tabletserver/loadshed/snake_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/snake_test.go
@@ -42,17 +42,17 @@ func defaultSnakeConfig() SnakeConfig {
 	}
 }
 
-func newTestSnake(cfg SnakeConfig) *Snake {
-	return NewSnake(cfg)
+func newTestSnake(cfg SnakeConfig) *testSnake {
+	return NewSnake[struct{}](cfg)
 }
 
-func (s *Snake) nGranted() int {
+func (s *Snake[T]) nGranted() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return len(s.holders)
 }
 
-func (s *Snake) isIdle() bool {
+func (s *Snake[T]) isIdle() bool {
 	return s.nGranted() == 0
 }
 
@@ -357,7 +357,7 @@ func TestSnake_DroppedRequest(t *testing.T) {
 	cfg.Capacity = func() int { return 4 }
 	s := newTestSnake(cfg)
 
-	var unlocks []*SafeUnlock
+	var unlocks []*testSafeUnlock
 	for range 4 {
 		u, err := s.Acquire(t.Context(), "", 0)
 		require.NoError(t, err)
@@ -454,7 +454,7 @@ func TestSnake_SafeUnlock_StaleNonce(t *testing.T) {
 	unlock1, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
 
-	acquired := make(chan *SafeUnlock, 1)
+	acquired := make(chan *testSafeUnlock, 1)
 	go func() {
 		u, err := s.Acquire(t.Context(), "", 0)
 		if err == nil {
@@ -465,7 +465,7 @@ func TestSnake_SafeUnlock_StaleNonce(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 	unlock1.Release()
 
-	var unlock2 *SafeUnlock
+	var unlock2 *testSafeUnlock
 	select {
 	case unlock2 = <-acquired:
 	case <-time.After(1 * time.Second):
@@ -756,7 +756,7 @@ func TestSnake_AcquireError_Custom(t *testing.T) {
 	cfg.Capacity = func() int { return 4 }
 	s := newTestSnake(cfg)
 
-	var unlocks []*SafeUnlock
+	var unlocks []*testSafeUnlock
 	for range 4 {
 		u, err := s.Acquire(t.Context(), "", 0)
 		require.NoError(t, err)
@@ -834,7 +834,7 @@ func TestSnake_SelfContention_WithExceptions(t *testing.T) {
 // --- NewSnake (default clock) ---
 
 func TestNewSnake_DefaultClock(t *testing.T) {
-	s := NewSnake(defaultSnakeConfig())
+	s := NewSnake[struct{}](defaultSnakeConfig())
 
 	unlock, err := s.Acquire(t.Context(), "", 0)
 	require.NoError(t, err)
@@ -868,12 +868,12 @@ func TestSnake_Priority_DisabledPreservesCallerPriority(t *testing.T) {
 
 func TestSnake_DisablePreventsQueuedRequestFromBeingShed(t *testing.T) {
 	type result struct {
-		unlock *SafeUnlock
+		unlock *testSafeUnlock
 		err    error
 	}
 	const waiters = 10
 
-	runDueBatch := func(s *Snake) {
+	runDueBatch := func(s *testSnake) {
 		s.mu.Lock()
 		s.lockedStopDropTimer()
 		s.q.codelq.dropping = true
@@ -886,7 +886,7 @@ func TestSnake_DisablePreventsQueuedRequestFromBeingShed(t *testing.T) {
 		}
 	}
 
-	newLoadedSnake := func(t *testing.T) (*Snake, *SafeUnlock, *atomic.Bool, context.CancelFunc, <-chan result) {
+	newLoadedSnake := func(t *testing.T) (*testSnake, *testSafeUnlock, *atomic.Bool, context.CancelFunc, <-chan result) {
 		t.Helper()
 		allowed := &atomic.Bool{}
 		allowed.Store(true)

--- a/go/vt/vttablet/tabletserver/loadshed/valved_codelq.go
+++ b/go/vt/vttablet/tabletserver/loadshed/valved_codelq.go
@@ -80,13 +80,13 @@ type (
 	//
 	// All methods are prefixed locked* and assume the caller holds the parent
 	// mutex.
-	ValvedCoDelQueue struct {
-		codelq *CoDelQueue
+	ValvedCoDelQueue[T any] struct {
+		codelq *CoDelQueue[T]
 
 		// valves is the per-valve-ID queue. Requests here are waiting for the
 		// active request to complete before entering the CoDel queue. There may
 		// be entries with the same valve ID in the CoDel queue.
-		valves map[string][]*Request
+		valves map[string][]*Request[T]
 
 		// outstandingCounts tracks the total number of outstanding requests per
 		// valve ID (in CoDel queue + in valve).
@@ -96,7 +96,7 @@ type (
 		// representative in the CoDel queue for each valve ID. Maintains the
 		// invariant that each nonempty valve always has exactly one droppable
 		// entry in the CoDel queue.
-		droppablePerValve map[string]*Request
+		droppablePerValve map[string]*Request[T]
 
 		// pendingSignals collects requests that lockedDrop marked (signaledValue
 		// set) but whose channel send is deferred until the queue mutex is
@@ -104,15 +104,15 @@ type (
 		// arrivals from serializing behind a large batch drop. The caller takes
 		// this slice before unlocking and sends each afterward (see
 		// lockedTakePendingSignals).
-		pendingSignals []*Request
+		pendingSignals []*Request[T]
 	}
 )
 
-func newValvedCoDelQueue(cfg CoDelConfig, nowNs func() int64, scheduleDropTimer func(delayNs int64), stopDropTimer func()) *ValvedCoDelQueue {
-	q := &ValvedCoDelQueue{
-		valves:            make(map[string][]*Request),
+func newValvedCoDelQueue[T any](cfg CoDelConfig, nowNs func() int64, scheduleDropTimer func(delayNs int64), stopDropTimer func()) *ValvedCoDelQueue[T] {
+	q := &ValvedCoDelQueue[T]{
+		valves:            make(map[string][]*Request[T]),
 		outstandingCounts: make(map[string]int),
-		droppablePerValve: make(map[string]*Request),
+		droppablePerValve: make(map[string]*Request[T]),
 	}
 	q.codelq = newCoDelQueue(cfg, nowNs, scheduleDropTimer, stopDropTimer, q.onPeekCleanup)
 	return q
@@ -121,33 +121,33 @@ func newValvedCoDelQueue(cfg CoDelConfig, nowNs func() int64, scheduleDropTimer 
 // onPeekCleanup is called by the CoDel queue when lockedPeek defensively
 // removes a done-with-error request from the list head. Decrements the
 // outstanding count for the request's valve ID.
-func (q *ValvedCoDelQueue) onPeekCleanup(req *Request) {
+func (q *ValvedCoDelQueue[T]) onPeekCleanup(req *Request[T]) {
 	q.decrementOutstanding(req.valveID)
 }
 
-func (q *ValvedCoDelQueue) lockedCurrentInterval() int64 {
+func (q *ValvedCoDelQueue[T]) lockedCurrentInterval() int64 {
 	return q.codelq.lockedCurrentInterval()
 }
 
-func (q *ValvedCoDelQueue) lockedDroppableLen() int {
+func (q *ValvedCoDelQueue[T]) lockedDroppableLen() int {
 	return q.codelq.droppableLen
 }
 
-func (q *ValvedCoDelQueue) lockedCount() int {
+func (q *ValvedCoDelQueue[T]) lockedCount() int {
 	return q.codelq.count
 }
 
 // lockedLen returns the number of requests in the CoDel queue.
-func (q *ValvedCoDelQueue) lockedLen() int {
+func (q *ValvedCoDelQueue[T]) lockedLen() int {
 	return q.codelq.lockedLen()
 }
 
-func (q *ValvedCoDelQueue) lockedValveDepth(valveID string) int {
+func (q *ValvedCoDelQueue[T]) lockedValveDepth(valveID string) int {
 	return len(q.valves[valveID])
 }
 
 // lockedIsHealthy reports whether the CoDel queue is healthy.
-func (q *ValvedCoDelQueue) lockedIsHealthy() bool {
+func (q *ValvedCoDelQueue[T]) lockedIsHealthy() bool {
 	return q.codelq.lockedIsHealthy()
 }
 
@@ -157,17 +157,17 @@ func (q *ValvedCoDelQueue) lockedIsHealthy() bool {
 // could arm on. When false, lockedDequeue is a guaranteed no-op, so the release
 // path can skip the call — and its clock read — entirely on the healthy fast
 // path.
-func (q *ValvedCoDelQueue) lockedNeedsAdvance() bool {
+func (q *ValvedCoDelQueue[T]) lockedNeedsAdvance() bool {
 	return q.codelq.dropping || q.codelq.dropNextNs != 0 || q.codelq.droppableLen > 0
 }
 
 // lockedPeek returns the head of the CoDel queue without removing it.
-func (q *ValvedCoDelQueue) lockedPeek() *Request {
+func (q *ValvedCoDelQueue[T]) lockedPeek() *Request[T] {
 	return q.codelq.lockedPeek()
 }
 
-func (q *ValvedCoDelQueue) lockedEnqueue(valveID string, priority float64) *Request {
-	req := newRequest(priority)
+func (q *ValvedCoDelQueue[T]) lockedEnqueue(valveID string, priority float64) *Request[T] {
+	req := newRequest[T](priority)
 	req.valveID = valveID
 
 	if valveID != "" {
@@ -184,7 +184,7 @@ func (q *ValvedCoDelQueue) lockedEnqueue(valveID string, priority float64) *Requ
 
 // lockedRelease updates valve accounting for a granted request and promotes a
 // pending request when needed.
-func (q *ValvedCoDelQueue) lockedRelease(req *Request) {
+func (q *ValvedCoDelQueue[T]) lockedRelease(req *Request[T]) {
 	q.decrementOutstanding(req.valveID)
 	if req.valveID != "" {
 		// Promote if no droppable entry exists. This handles the case where
@@ -197,7 +197,7 @@ func (q *ValvedCoDelQueue) lockedRelease(req *Request) {
 	}
 }
 
-func (q *ValvedCoDelQueue) lockedDrop(req *Request) {
+func (q *ValvedCoDelQueue[T]) lockedDrop(req *Request[T]) {
 	q.codelq.lockedRemove(req)
 	// Mark the rejection under the lock (so under-lock readers see signaledValue
 	// immediately) but defer the channel send: it goreadys the parked Acquire
@@ -216,7 +216,7 @@ func (q *ValvedCoDelQueue) lockedDrop(req *Request) {
 // the buffer is set to nil (not truncated in place) so a concurrent drop pass
 // that re-appends under the lock cannot corrupt the slice the caller is draining
 // after unlocking.
-func (q *ValvedCoDelQueue) lockedTakePendingSignals() []*Request {
+func (q *ValvedCoDelQueue[T]) lockedTakePendingSignals() []*Request[T] {
 	pending := q.pendingSignals
 	q.pendingSignals = nil
 	return pending
@@ -226,7 +226,7 @@ func (q *ValvedCoDelQueue) lockedTakePendingSignals() []*Request {
 // and promotes the next from the valve. If it's pending in the valve, it
 // signals it in place and lets clearDone handle removal during the next
 // promotion — this avoids an O(N) scan of the valve.
-func (q *ValvedCoDelQueue) lockedCancel(req *Request) {
+func (q *ValvedCoDelQueue[T]) lockedCancel(req *Request[T]) {
 	if req.codelqElem != nil {
 		q.codelq.lockedRemove(req)
 		q.lockedPromoteOnEvict(req)
@@ -253,7 +253,7 @@ const keepDroppableFloor = 4
 // lockedDropFn builds the drop callback shared by the timer and the synchronous
 // advance path: drop the lowest-priority droppable request and promote its
 // valve successor.
-func (q *ValvedCoDelQueue) lockedDropFn() func() bool {
+func (q *ValvedCoDelQueue[T]) lockedDropFn() func() bool {
 	return func() bool {
 		return q.lockedDropOne()
 	}
@@ -263,11 +263,11 @@ func (q *ValvedCoDelQueue) lockedDropFn() func() bool {
 // lowest-priority request and triggering valve promotion. It is driven both by
 // the backstop timer and synchronously from the release/dequeue path, so
 // shedding tracks target as slots free rather than waiting for the timer.
-func (q *ValvedCoDelQueue) lockedRunTimer() {
+func (q *ValvedCoDelQueue[T]) lockedRunTimer() {
 	q.lockedRunTimerIf(func() bool { return true })
 }
 
-func (q *ValvedCoDelQueue) lockedRunTimerIf(loadsheddingAllowed func() bool) {
+func (q *ValvedCoDelQueue[T]) lockedRunTimerIf(loadsheddingAllowed func() bool) {
 	enabled := loadsheddingAllowed()
 	if enabled {
 		q.codelq.lockedRunTimer(q.lockedDropFn())
@@ -279,7 +279,7 @@ func (q *ValvedCoDelQueue) lockedRunTimerIf(loadsheddingAllowed func() bool) {
 	}, maxDrops)
 }
 
-func (q *ValvedCoDelQueue) lockedDropOne() bool {
+func (q *ValvedCoDelQueue[T]) lockedDropOne() bool {
 	if q.codelq.droppableLen <= keepDroppableFloor {
 		return false
 	}
@@ -287,11 +287,11 @@ func (q *ValvedCoDelQueue) lockedDropOne() bool {
 	if elem == nil {
 		return false
 	}
-	q.lockedDrop(elem.Value.(*Request))
+	q.lockedDrop(elem.Value.(*Request[T]))
 	return true
 }
 
-func (q *ValvedCoDelQueue) lockedOnGrant(r *Request) {
+func (q *ValvedCoDelQueue[T]) lockedOnGrant(r *Request[T]) {
 	q.codelq.lockedOnGrant(r)
 	if r.valveID != "" {
 		delete(q.droppablePerValve, r.valveID)
@@ -299,13 +299,13 @@ func (q *ValvedCoDelQueue) lockedOnGrant(r *Request) {
 	}
 }
 
-func (q *ValvedCoDelQueue) lockedFirstWaiting() *Request {
+func (q *ValvedCoDelQueue[T]) lockedFirstWaiting() *Request[T] {
 	return q.codelq.lockedFirstWaiting()
 }
 
 // --- private helpers ---
 
-func (q *ValvedCoDelQueue) lockedEnqueueToCoDel(req *Request, valveID string) {
+func (q *ValvedCoDelQueue[T]) lockedEnqueueToCoDel(req *Request[T], valveID string) {
 	if valveID != "" {
 		q.droppablePerValve[valveID] = req
 	}
@@ -314,7 +314,7 @@ func (q *ValvedCoDelQueue) lockedEnqueueToCoDel(req *Request, valveID string) {
 
 // lockedPromoteOnEvict handles involuntary removal of the active request
 // (drop or cancel). Decrements outstanding, then promotes.
-func (q *ValvedCoDelQueue) lockedPromoteOnEvict(req *Request) {
+func (q *ValvedCoDelQueue[T]) lockedPromoteOnEvict(req *Request[T]) {
 	valveID := req.valveID
 	if valveID == "" {
 		return
@@ -324,7 +324,7 @@ func (q *ValvedCoDelQueue) lockedPromoteOnEvict(req *Request) {
 	q.lockedPromote(valveID)
 }
 
-func (q *ValvedCoDelQueue) lockedPromote(valveID string) {
+func (q *ValvedCoDelQueue[T]) lockedPromote(valveID string) {
 	if valveID == "" {
 		return
 	}
@@ -351,7 +351,7 @@ func (q *ValvedCoDelQueue) lockedPromote(valveID string) {
 // clearDone removes done (cancelled) requests from the head of the valve.
 // Their outstanding counts are decremented since the CoDel queue never learned
 // about them.
-func (q *ValvedCoDelQueue) clearDone(valveID string) {
+func (q *ValvedCoDelQueue[T]) clearDone(valveID string) {
 	pending, ok := q.valves[valveID]
 	if !ok {
 		return
@@ -370,7 +370,7 @@ func (q *ValvedCoDelQueue) clearDone(valveID string) {
 	}
 }
 
-func (q *ValvedCoDelQueue) decrementOutstanding(valveID string) {
+func (q *ValvedCoDelQueue[T]) decrementOutstanding(valveID string) {
 	if valveID == "" {
 		return
 	}

--- a/go/vt/vttablet/tabletserver/loadshed/valved_codelq_test.go
+++ b/go/vt/vttablet/tabletserver/loadshed/valved_codelq_test.go
@@ -23,9 +23,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newValvedQueue(clock *testClock) (*ValvedCoDelQueue, *testDropTimerRecorder) {
+func newValvedQueue(clock *testClock) (*testValvedCoDelQueue, *testDropTimerRecorder) {
 	rec := &testDropTimerRecorder{}
-	q := newValvedCoDelQueue(defaultTestConfig(), clock.nowFunc, rec.schedule, rec.stop)
+	q := newValvedCoDelQueue[struct{}](defaultTestConfig(), clock.nowFunc, rec.schedule, rec.stop)
 	return q, rec
 }
 
@@ -33,7 +33,7 @@ func newValvedQueue(clock *testClock) (*ValvedCoDelQueue, *testDropTimerRecorder
 // ValvedCoDelQueue: gets the first waiting request, marks it not droppable
 // (which triggers eager valve promotion), signals it, and completes it
 // (removing from queue).
-func testValvedDequeue(sq *ValvedCoDelQueue) *Request {
+func testValvedDequeue(sq *testValvedCoDelQueue) *testRequest {
 	req := sq.lockedFirstWaiting()
 	if req == nil {
 		return nil
@@ -355,7 +355,7 @@ func TestValved_MassCancel_OverloadScenario(t *testing.T) {
 	sq.lockedEnqueue("id1", 0) // r0: active in CoDel
 
 	// Simulate overload: 50 requests arrive for same valve ID
-	requests := make([]*Request, 50)
+	requests := make([]*testRequest, 50)
 	for i := range 50 {
 		requests[i] = sq.lockedEnqueue("id1", 0)
 	}

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -200,7 +200,7 @@ type QueryEngine struct {
 	redactUIQuery bool
 
 	// snake is the CoDel-based load-shedding gate for the OLTP read pool.
-	snake *loadshed.Snake
+	snake *loadshed.Snake[struct{}]
 }
 
 // NewQueryEngine creates a new QueryEngine.
@@ -245,7 +245,7 @@ func NewQueryEngine(env tabletenv.Env, se *schema.Engine) *QueryEngine {
 	}
 	qe.txSerializer = txserializer.New(env)
 
-	qe.snake = loadshed.NewSnake(loadshed.SnakeConfig{
+	qe.snake = loadshed.NewSnake[struct{}](loadshed.SnakeConfig{
 		Name: "oltp-read",
 		CoDel: loadshed.CoDelConfig{
 			TargetNs: func() int64 { return config.LoadshedOltpRead.TargetValue().Nanoseconds() },

--- a/go/vt/vttablet/tabletserver/snake_capacity_test.go
+++ b/go/vt/vttablet/tabletserver/snake_capacity_test.go
@@ -30,9 +30,9 @@ import (
 
 // acquireN acquires count slots from the snake, failing the test if any acquire
 // is shed or blocked. The returned unlocks must be released by the caller.
-func acquireN(t *testing.T, s *loadshed.Snake, count int) []*loadshed.SafeUnlock {
+func acquireN(t *testing.T, s *loadshed.Snake[struct{}], count int) []*loadshed.SafeUnlock[struct{}] {
 	t.Helper()
-	unlocks := make([]*loadshed.SafeUnlock, count)
+	unlocks := make([]*loadshed.SafeUnlock[struct{}], count)
 	for i := range count {
 		u, err := s.Acquire(t.Context(), "", 0)
 		require.NoErrorf(t, err, "acquire %d of %d should be granted", i+1, count)
@@ -43,8 +43,8 @@ func acquireN(t *testing.T, s *loadshed.Snake, count int) []*loadshed.SafeUnlock
 
 // acquireBlocks reports whether a single acquire blocks (rather than being
 // granted) within a short window. A granted slot is released immediately.
-func acquireBlocks(s *loadshed.Snake) bool {
-	granted := make(chan *loadshed.SafeUnlock, 1)
+func acquireBlocks(s *loadshed.Snake[struct{}]) bool {
+	granted := make(chan *loadshed.SafeUnlock[struct{}], 1)
 	go func() {
 		u, err := s.Acquire(context.Background(), "", 0)
 		if err == nil {

--- a/go/vt/vttablet/tabletserver/tx_engine.go
+++ b/go/vt/vttablet/tabletserver/tx_engine.go
@@ -115,7 +115,7 @@ func NewTxEngine(env tabletenv.Env, dxNotifier func()) *TxEngine {
 	}
 	limiter := txlimiter.New(env)
 	te.txPool = NewTxPool(env, limiter)
-	te.txPool.snake = loadshed.NewSnake(loadshed.SnakeConfig{
+	te.txPool.snake = loadshed.NewSnake[struct{}](loadshed.SnakeConfig{
 		Name: "dml",
 		CoDel: loadshed.CoDelConfig{
 			TargetNs: func() int64 { return config.LoadshedTx.TargetValue().Nanoseconds() },

--- a/go/vt/vttablet/tabletserver/tx_pool.go
+++ b/go/vt/vttablet/tabletserver/tx_pool.go
@@ -70,7 +70,7 @@ type (
 		scp     *StatefulConnectionPool
 		ticks   *timer.Timer
 		limiter txlimiter.TxLimiter
-		snake   *loadshed.Snake
+		snake   *loadshed.Snake[struct{}]
 
 		logMu   sync.Mutex
 		lastLog time.Time

--- a/go/vt/vttablet/tabletserver/tx_pool_snake_test.go
+++ b/go/vt/vttablet/tabletserver/tx_pool_snake_test.go
@@ -48,7 +48,7 @@ func setupWithSnake(t *testing.T, capacity int) (*fakesqldb.DB, *TxPool, func())
 
 	limiter := &fakeLimiter{}
 	txPool := NewTxPool(env, limiter)
-	txPool.snake = loadshed.NewSnake(loadshed.SnakeConfig{
+	txPool.snake = loadshed.NewSnake[struct{}](loadshed.SnakeConfig{
 		Name: "dml-test",
 		CoDel: loadshed.CoDelConfig{
 			TargetNs:       func() int64 { return (5 * time.Millisecond).Nanoseconds() },


### PR DESCRIPTION
### Background / Why?
The loadshed queue currently relies on untyped request values, which forces queue internals to use `any` as the queue integration becomes reusable by typed callers. This PR carries the element type through `Snake`, `Request`, CoDel queues, and the priority index so the queue boundary remains type-safe.

### Testing
Existing unit tests updated.

AI assisted with development. Every line of code was either written by or carefully reviewed by me :)
